### PR TITLE
fix(ci): MinIO-backed S3 for E2E smoke tests + endpoint-aware backend S3 (#147)

### DIFF
--- a/.env.staging.example
+++ b/.env.staging.example
@@ -39,6 +39,9 @@ AWS_ACCESS_KEY_ID=REPLACE_WITH_AWS_ACCESS_KEY
 AWS_SECRET_ACCESS_KEY=REPLACE_WITH_AWS_SECRET_KEY
 AWS_DEFAULT_REGION=us-east-1
 S3_BUCKET_NAME=narrative-staging-uploads
+# Optional: override S3 endpoint for S3-compatible storage (MinIO, LocalStack).
+# Leave unset (or remove) for real AWS in production/staging.
+# AWS_ENDPOINT_URL=
 
 # ═══════════════════════════════════════════════════════════════
 # AI SERVICES

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -55,6 +55,33 @@ jobs:
         working-directory: apps/frontend
         run: npx playwright install --with-deps chromium
 
+      # GitHub Actions `services:` blocks cannot override a container's command,
+      # and minio/minio requires `server /data` — so MinIO is started manually.
+      - name: Start MinIO (S3-compatible storage)
+        run: |
+          docker run -d --name minio -p 9000:9000 \
+            -e MINIO_ROOT_USER=minioadmin \
+            -e MINIO_ROOT_PASSWORD=minioadmin \
+            minio/minio server /data
+          echo "Waiting for MinIO to become healthy..."
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:9000/minio/health/live > /dev/null; then
+              echo "MinIO is ready"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "MinIO failed to start" >&2
+          docker logs minio >&2
+          exit 1
+
+      - name: Create test bucket in MinIO
+        env:
+          AWS_ACCESS_KEY_ID: minioadmin
+          AWS_SECRET_ACCESS_KEY: minioadmin
+          AWS_REGION: us-east-1
+        run: aws --endpoint-url http://localhost:9000 s3 mb s3://test-bucket
+
       - name: Run Smoke Tests
         working-directory: apps/frontend
         run: npm run test:e2e:smoke
@@ -75,11 +102,15 @@ jobs:
           PORT: 3010
           BACKEND_PORT: 8000
           NEXT_PUBLIC_API_URL: http://localhost:8000/api/v1
-          # AWS credentials for backend S3 service (dummy values for testing)
-          AWS_ACCESS_KEY_ID: test-access-key-id
-          AWS_SECRET_ACCESS_KEY: test-secret-access-key
+          # S3 storage backed by the MinIO container (no real AWS credentials).
+          # NOTE: credentials must NOT start with "test-" — that prefix puts
+          # S3Service into no-op mock mode; MinIO mode needs the real client.
+          AWS_ACCESS_KEY_ID: minioadmin
+          AWS_SECRET_ACCESS_KEY: minioadmin
           AWS_REGION: us-east-1
           AWS_BUCKET_NAME: test-bucket
+          AWS_S3_BUCKET: test-bucket
+          AWS_ENDPOINT_URL: http://localhost:9000
           # OpenAI API key (dummy value for testing)
           OPENAI_API_KEY: sk-test-dummy-key-for-ci-testing-only
 

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -110,6 +110,7 @@ jobs:
           AWS_REGION: us-east-1
           AWS_BUCKET_NAME: test-bucket
           AWS_S3_BUCKET: test-bucket
+          S3_BUCKET: test-bucket
           AWS_ENDPOINT_URL: http://localhost:9000
           # OpenAI API key (dummy value for testing)
           OPENAI_API_KEY: sk-test-dummy-key-for-ci-testing-only

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -108,6 +108,9 @@ jobs:
           AWS_ACCESS_KEY_ID: minioadmin
           AWS_SECRET_ACCESS_KEY: minioadmin
           AWS_REGION: us-east-1
+          # Three names for the same bucket: AWS_BUCKET_NAME (upload paths),
+          # AWS_S3_BUCKET (download whitelist), S3_BUCKET (settings/versioning).
+          # Env-var consolidation is tracked with CI hardening in #150.
           AWS_BUCKET_NAME: test-bucket
           AWS_S3_BUCKET: test-bucket
           S3_BUCKET: test-bucket

--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -12,6 +12,9 @@ AWS_ACCESS_KEY_ID=aws-access-key-id-placeholder
 AWS_SECRET_ACCESS_KEY=aws-secret-access-key-placeholder
 AWS_REGION=us-east-1  # or your bucket's region
 AWS_BUCKET_NAME=bucket-name-placeholder
+# Optional: route S3 calls to S3-compatible storage (MinIO, LocalStack).
+# Leave unset for real AWS. Example: http://localhost:9000
+# AWS_ENDPOINT_URL=
 
 # OpenAI API key
 OPENAI_API_KEY=openai-api-key-placeholder

--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -52,6 +52,9 @@ AWS_ACCESS_KEY_ID=your_access_key
 AWS_SECRET_ACCESS_KEY=your_secret_key
 AWS_DEFAULT_REGION=us-east-1
 S3_BUCKET=your-bucket-name
+# Optional: route S3 calls to an S3-compatible service (MinIO, LocalStack).
+# Leave unset to use real AWS. Example: http://localhost:9000
+# AWS_ENDPOINT_URL=
 
 # OpenAI
 OPENAI_API_KEY=sk-your-openai-key

--- a/apps/backend/app/api/routes/column_stats.py
+++ b/apps/backend/app/api/routes/column_stats.py
@@ -10,7 +10,7 @@ import io
 import os
 import logging
 from app.models.user_data import UserData
-from app.utils.s3 import create_s3_client
+from app.utils.s3 import create_s3_client, parse_s3_url
 
 from app.utils.column_stats import calculate_and_store_column_stats
 
@@ -55,18 +55,11 @@ async def get_column_stats(
             # Download the data from S3
             s3_client = create_s3_client()
 
-            # Extract bucket and key from S3 URL
-            s3_url = dataset.s3_url
-            if s3_url.startswith("http"):
-                # This is a signed URL, we need to get the actual S3 path
-                # For now, we'll use a placeholder
+            # Extract bucket and key from S3 URL (handles all persisted
+            # shapes: s3://, presigned amazonaws, endpoint-style)
+            bucket, key = parse_s3_url(dataset.s3_url)
+            if bucket is None:
                 bucket = os.getenv("AWS_BUCKET_NAME")
-                key = f"user_data/{user_id}/{dataset.filename}"
-            else:
-                # This is a direct S3 path
-                parts = s3_url.replace("s3://", "").split("/", 1)
-                bucket = parts[0]
-                key = parts[1]
 
             # Download the file
             response = s3_client.get_object(Bucket=bucket, Key=key)
@@ -140,18 +133,11 @@ async def recalculate_column_stats(
         # Download the data from S3
         s3_client = create_s3_client()
 
-        # Extract bucket and key from S3 URL
-        s3_url = dataset.s3_url
-        if s3_url.startswith("http"):
-            # This is a signed URL, we need to get the actual S3 path
-            # For now, we'll use a placeholder
+        # Extract bucket and key from S3 URL (handles all persisted
+        # shapes: s3://, presigned amazonaws, endpoint-style)
+        bucket, key = parse_s3_url(dataset.s3_url)
+        if bucket is None:
             bucket = os.getenv("AWS_BUCKET_NAME")
-            key = f"user_data/{user_id}/{dataset.filename}"
-        else:
-            # This is a direct S3 path
-            parts = s3_url.replace("s3://", "").split("/", 1)
-            bucket = parts[0]
-            key = parts[1]
 
         # Download the file
         response = s3_client.get_object(Bucket=bucket, Key=key)

--- a/apps/backend/app/api/routes/column_stats.py
+++ b/apps/backend/app/api/routes/column_stats.py
@@ -7,10 +7,10 @@ from app.models.column_stats import ColumnStats
 from app.auth.nextauth_auth import get_current_user_id
 import pandas as pd
 import io
-import boto3
 import os
 import logging
 from app.models.user_data import UserData
+from app.utils.s3 import create_s3_client
 
 from app.utils.column_stats import calculate_and_store_column_stats
 
@@ -53,12 +53,7 @@ async def get_column_stats(
                 )
 
             # Download the data from S3
-            s3_client = boto3.client(
-                "s3",
-                aws_access_key_id=os.getenv("AWS_ACCESS_KEY_ID"),
-                aws_secret_access_key=os.getenv("AWS_SECRET_ACCESS_KEY"),
-                region_name=os.getenv("AWS_REGION", "us-east-1"),
-            )
+            s3_client = create_s3_client()
 
             # Extract bucket and key from S3 URL
             s3_url = dataset.s3_url
@@ -143,12 +138,7 @@ async def recalculate_column_stats(
         ).delete()
 
         # Download the data from S3
-        s3_client = boto3.client(
-            "s3",
-            aws_access_key_id=os.getenv("AWS_ACCESS_KEY_ID"),
-            aws_secret_access_key=os.getenv("AWS_SECRET_ACCESS_KEY"),
-            region_name=os.getenv("AWS_REGION", "us-east-1"),
-        )
+        s3_client = create_s3_client()
 
         # Extract bucket and key from S3 URL
         s3_url = dataset.s3_url

--- a/apps/backend/app/api/routes/column_stats.py
+++ b/apps/backend/app/api/routes/column_stats.py
@@ -60,6 +60,10 @@ async def get_column_stats(
             bucket, key = parse_s3_url(dataset.s3_url)
             if bucket is None:
                 bucket = os.getenv("AWS_BUCKET_NAME")
+                logger.debug(
+                    "Could not determine bucket from URL %r; falling back to AWS_BUCKET_NAME=%r",
+                    dataset.s3_url, bucket,
+                )
 
             # Download the file
             response = s3_client.get_object(Bucket=bucket, Key=key)
@@ -138,6 +142,10 @@ async def recalculate_column_stats(
         bucket, key = parse_s3_url(dataset.s3_url)
         if bucket is None:
             bucket = os.getenv("AWS_BUCKET_NAME")
+            logger.debug(
+                "Could not determine bucket from URL %r; falling back to AWS_BUCKET_NAME=%r",
+                dataset.s3_url, bucket,
+            )
 
         # Download the file
         response = s3_client.get_object(Bucket=bucket, Key=key)

--- a/apps/backend/app/api/routes/data_processing.py
+++ b/apps/backend/app/api/routes/data_processing.py
@@ -6,6 +6,7 @@ from typing import Optional, Dict, Any
 from fastapi import APIRouter, Depends, HTTPException, Query, Path
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field, ConfigDict
+import logging
 import numpy as np
 import json
 
@@ -16,6 +17,8 @@ from app.services.s3_service import s3_service
 from app.utils.s3 import parse_s3_url
 from app.utils.json_encoder import convert_numpy_types, NumpyJSONEncoder
 
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 data_processor = DataProcessor()
@@ -81,7 +84,10 @@ async def process_uploaded_file(
         try:
             _, file_key = parse_s3_url(user_data.s3_url)
         except ValueError:
-            raise ValueError(f"Could not extract file key from S3 URL: {user_data.s3_url}")
+            # Log the URL server-side only — presigned URLs carry credentials
+            # and the route's error handler echoes exception text to clients
+            logger.error(f"Could not extract file key from S3 URL: {user_data.s3_url}")
+            raise ValueError("Could not extract file key from stored S3 URL")
 
         file_bytes = await s3_service.download_file_bytes(file_key)
         

--- a/apps/backend/app/api/routes/data_processing.py
+++ b/apps/backend/app/api/routes/data_processing.py
@@ -83,11 +83,12 @@ async def process_uploaded_file(
         # Download file from S3 (parse_s3_url handles all persisted URL shapes)
         try:
             _, file_key = parse_s3_url(user_data.s3_url)
-        except ValueError:
-            # Log the URL server-side only — presigned URLs carry credentials
-            # and the route's error handler echoes exception text to clients
-            logger.error(f"Could not extract file key from S3 URL: {user_data.s3_url}")
-            raise ValueError("Could not extract file key from stored S3 URL")
+        except ValueError as err:
+            # Strip the query string before logging — presigned URLs carry
+            # credentials; the error handler echoes exception text to clients
+            sanitized_url = user_data.s3_url.split("?")[0]
+            logger.error(f"Could not extract file key from S3 URL: {sanitized_url}")
+            raise ValueError("Could not extract file key from stored S3 URL") from err
 
         file_bytes = await s3_service.download_file_bytes(file_key)
         

--- a/apps/backend/app/api/routes/data_processing.py
+++ b/apps/backend/app/api/routes/data_processing.py
@@ -3,7 +3,6 @@ API routes for data processing functionality
 """
 
 from typing import Optional, Dict, Any
-from urllib.parse import urlparse
 from fastapi import APIRouter, Depends, HTTPException, Query, Path
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field, ConfigDict
@@ -14,6 +13,7 @@ from app.auth.nextauth_auth import get_current_user_id
 from app.models.user_data import UserData
 from app.services.data_processing.data_processor import DataProcessor
 from app.services.s3_service import s3_service
+from app.utils.s3 import parse_s3_url
 from app.utils.json_encoder import convert_numpy_types, NumpyJSONEncoder
 
 
@@ -77,22 +77,12 @@ async def process_uploaded_file(
         if not user_data:
             raise HTTPException(status_code=404, detail="File not found")
         
-        # Download file from S3
-        # Extract file key from S3 URL (handle both s3:// and https:// formats)
-        s3_url = user_data.s3_url
-        if s3_url.startswith(f"s3://{s3_service.bucket_name}/"):
-            file_key = s3_url.replace(f"s3://{s3_service.bucket_name}/", "")
-        elif s3_url.startswith(f"https://{s3_service.bucket_name}.s3.amazonaws.com/"):
-            file_key = s3_url.replace(f"https://{s3_service.bucket_name}.s3.amazonaws.com/", "")
-        else:
-            # Try to extract key from any S3 URL format
-            import re
-            match = re.search(r'/([^/]+)$', s3_url)
-            if match:
-                file_key = match.group(1)
-            else:
-                raise ValueError(f"Could not extract file key from S3 URL: {s3_url}")
-        
+        # Download file from S3 (parse_s3_url handles all persisted URL shapes)
+        try:
+            _, file_key = parse_s3_url(user_data.s3_url)
+        except ValueError:
+            raise ValueError(f"Could not extract file key from S3 URL: {user_data.s3_url}")
+
         file_bytes = await s3_service.download_file_bytes(file_key)
         
         # Process the file
@@ -255,10 +245,8 @@ async def get_data_preview(
     
     try:
         # Download file from S3 to get actual data
-        # Parse the HTTPS URL to extract the S3 key
-        parsed_url = urlparse(user_data.s3_url)
-        # Strip leading slash from path to get the key
-        file_key = parsed_url.path.lstrip('/')
+        # (parse_s3_url handles all persisted URL shapes)
+        _, file_key = parse_s3_url(user_data.s3_url)
         file_bytes = await s3_service.download_file_bytes(file_key)
         
         # Read the file based on type

--- a/apps/backend/app/api/routes/model_training.py
+++ b/apps/backend/app/api/routes/model_training.py
@@ -3,7 +3,6 @@ API routes for model training and management
 """
 
 from typing import Optional, List, Dict, Any
-from urllib.parse import urlparse
 from fastapi import APIRouter, Depends, HTTPException, BackgroundTasks, Query
 from pydantic import BaseModel
 import pandas as pd
@@ -16,6 +15,7 @@ from app.auth.nextauth_auth import get_current_user_id
 from app.models.user_data import UserData
 from app.models.ml_model import MLModel
 from app.services.s3_service import get_file_from_s3
+from app.utils.s3 import parse_s3_url
 from app.services.model_storage import ModelStorageService
 from app.services.model_training import (
     AutoMLEngine,
@@ -119,9 +119,8 @@ async def train_model_task(
     try:
         logger.info(f"Starting model training for dataset {request.dataset_id}")
 
-        # Extract S3 file key from the HTTPS URL
-        parsed_url = urlparse(user_data.s3_url)
-        file_key = parsed_url.path.lstrip('/')
+        # Extract S3 file key (parse_s3_url handles all persisted URL shapes)
+        _, file_key = parse_s3_url(user_data.s3_url)
 
         # Load data from S3
         file_bytes = await get_file_from_s3(file_key)

--- a/apps/backend/app/api/routes/upload.py
+++ b/apps/backend/app/api/routes/upload.py
@@ -12,11 +12,10 @@ import pandas as pd
 import io
 import traceback
 import os
-import boto3
 from app.models.user_data import UserData
 from app.auth.nextauth_auth import get_current_user_id
 from app.utils.schema_inference import infer_schema, generate_s3_filename
-from app.utils.s3 import upload_file_to_s3
+from app.utils.s3 import upload_file_to_s3, create_s3_client
 from app.utils.ai_summary import generate_dataset_summary
 import logging
 
@@ -116,12 +115,7 @@ async def upload_file(
 
                 # Generate a signed URL for temporary access if needed
                 try:
-                    s3_client = boto3.client(
-                        "s3",
-                        aws_access_key_id=os.getenv("AWS_ACCESS_KEY_ID"),
-                        aws_secret_access_key=os.getenv("AWS_SECRET_ACCESS_KEY"),
-                        region_name=os.getenv("AWS_REGION", "us-east-1"),
-                    )
+                    s3_client = create_s3_client()
 
                     # Generate a signed URL that expires in 1 hour
                     signed_url = s3_client.generate_presigned_url(

--- a/apps/backend/app/api/routes/upload.py
+++ b/apps/backend/app/api/routes/upload.py
@@ -181,5 +181,5 @@ async def upload_file(
         }
 
     except Exception as e:
-        logger.exception(f"Error processing file: {str(e)}")
+        logger.exception("Error processing file: %s", e)
         raise HTTPException(status_code=500, detail=f"Error processing file: {str(e)}")

--- a/apps/backend/app/api/routes/upload.py
+++ b/apps/backend/app/api/routes/upload.py
@@ -10,7 +10,6 @@ from fastapi import (
 from typing import Dict, Any
 import pandas as pd
 import io
-import traceback
 import os
 from app.models.user_data import UserData
 from app.auth.nextauth_auth import get_current_user_id
@@ -182,7 +181,5 @@ async def upload_file(
         }
 
     except Exception as e:
-        # Log the full traceback
-        logger.error(f"Error processing file: {str(e)}")
-        traceback.print_exc()
+        logger.exception(f"Error processing file: {str(e)}")
         raise HTTPException(status_code=500, detail=f"Error processing file: {str(e)}")

--- a/apps/backend/app/api/routes/user_data.py
+++ b/apps/backend/app/api/routes/user_data.py
@@ -104,7 +104,7 @@ async def get_preview_data(user_id: str = Depends(get_current_user_id)) -> Dict[
 
         # Endpoint-style URLs ({AWS_ENDPOINT_URL}/{bucket}/{key}) include the
         # bucket as the first path segment — strip it to get the object key.
-        endpoint_url = os.getenv("AWS_ENDPOINT_URL")
+        endpoint_url = (os.getenv("AWS_ENDPOINT_URL") or "").rstrip("/")
         bucket_name = os.getenv("AWS_BUCKET_NAME", "")
         if endpoint_url and s3_url.startswith(endpoint_url) and s3_key.startswith(f"{bucket_name}/"):
             s3_key = s3_key[len(bucket_name) + 1:]

--- a/apps/backend/app/api/routes/user_data.py
+++ b/apps/backend/app/api/routes/user_data.py
@@ -93,12 +93,33 @@ async def get_preview_data(user_id: str = Depends(get_current_user_id)) -> Dict[
         # Initialize S3 client
         s3_client = create_s3_client()
 
-        # Extract the key from the S3 URL (handles all persisted URL shapes)
+        # Extract the key from the S3 URL (handles all persisted URL shapes).
+        # Upload persists placeholders like "s3_not_configured" when S3 is
+        # unavailable — return metadata without preview for those instead of
+        # erroring, matching the S3-failure fallback below.
         s3_url = user_data.s3_url
         try:
             _, s3_key = parse_s3_url(s3_url)
         except ValueError:
-            raise HTTPException(status_code=400, detail="Invalid S3 URL (missing object key)")
+            logger.warning(f"No object key in stored S3 URL for dataset {user_data.id}")
+            return {
+                "headers": [],
+                "previewData": [],
+                "fileName": user_data.filename,
+                "fileType": "text/csv",  # Default to CSV for now
+                "id": str(user_data.id),
+                "s3_url": user_data.s3_url,
+                "schema": user_data.data_schema,
+                "error": "File is not available in storage",
+                "num_rows": user_data.num_rows,
+                "num_columns": user_data.num_columns,
+                "created_at": (
+                    user_data.created_at.isoformat() if user_data.created_at else None
+                ),
+                "updated_at": (
+                    user_data.updated_at.isoformat() if user_data.updated_at else None
+                ),
+            }
 
         logger.debug(f"Fetching S3 object for preview: {s3_key}")
 

--- a/apps/backend/app/api/routes/user_data.py
+++ b/apps/backend/app/api/routes/user_data.py
@@ -10,9 +10,9 @@ from app.auth.nextauth_auth import get_current_user_id
 from app.services.eda_summary import generate_eda_summary
 import pandas as pd
 import io
-import boto3
 import os
 import logging
+from app.utils.s3 import create_s3_client
 
 # Set up logging
 logger = logging.getLogger(__name__)
@@ -92,12 +92,7 @@ async def get_preview_data(user_id: str = Depends(get_current_user_id)) -> Dict[
             raise HTTPException(status_code=404, detail="No data found for user")
 
         # Initialize S3 client
-        s3_client = boto3.client(
-            "s3",
-            aws_access_key_id=os.getenv("AWS_ACCESS_KEY_ID"),
-            aws_secret_access_key=os.getenv("AWS_SECRET_ACCESS_KEY"),
-            region_name=os.getenv("AWS_REGION", "us-east-1"),
-        )
+        s3_client = create_s3_client()
 
         # Extract the key from the S3 URL
         s3_url = user_data.s3_url

--- a/apps/backend/app/api/routes/user_data.py
+++ b/apps/backend/app/api/routes/user_data.py
@@ -96,18 +96,23 @@ async def get_preview_data(user_id: str = Depends(get_current_user_id)) -> Dict[
 
         # Extract the key from the S3 URL
         s3_url = user_data.s3_url
-        print(f"Original S3 URL: {s3_url}")
 
         # Handle different S3 URL formats
         # Parse the S3 URL to extract the full object key (preserving directory prefixes)
         parsed_url = urlparse(s3_url)
         s3_key = parsed_url.path.lstrip("/")
 
+        # Endpoint-style URLs ({AWS_ENDPOINT_URL}/{bucket}/{key}) include the
+        # bucket as the first path segment — strip it to get the object key.
+        endpoint_url = os.getenv("AWS_ENDPOINT_URL")
+        bucket_name = os.getenv("AWS_BUCKET_NAME", "")
+        if endpoint_url and s3_url.startswith(endpoint_url) and s3_key.startswith(f"{bucket_name}/"):
+            s3_key = s3_key[len(bucket_name) + 1:]
+
         if not s3_key:
             raise HTTPException(status_code=400, detail="Invalid S3 URL (missing object key)")
 
-        print(f"Extracted S3 key: {s3_key}")
-        print(f"Attempting to get S3 object with key: {s3_key}")
+        logger.debug(f"Fetching S3 object for preview: {s3_key}")
 
         # Get the file from S3
         try:
@@ -116,7 +121,7 @@ async def get_preview_data(user_id: str = Depends(get_current_user_id)) -> Dict[
                 Key=s3_key,
             )
         except Exception as e:
-            print(f"Error getting S3 object: {e}")
+            logger.error(f"Error getting S3 object {s3_key}: {e}")
             # If we can't get the file from S3, return the metadata without preview data
             return {
                 "headers": [],
@@ -175,7 +180,7 @@ async def get_preview_data(user_id: str = Depends(get_current_user_id)) -> Dict[
     except HTTPException:
         raise
     except Exception as e:
-        print(f"Error in get_preview_data: {e}")
+        logger.error(f"Error in get_preview_data: {e}")
         raise HTTPException(
             status_code=500, detail=f"Error getting preview data: {str(e)}"
         )

--- a/apps/backend/app/api/routes/user_data.py
+++ b/apps/backend/app/api/routes/user_data.py
@@ -3,7 +3,6 @@
 from fastapi import APIRouter, HTTPException, Depends
 from beanie import PydanticObjectId
 from typing import List, Dict, Any
-from urllib.parse import urlparse
 from app.models.user_data import UserData
 from app.schemas.user_data import UserDataResponse
 from app.auth.nextauth_auth import get_current_user_id
@@ -12,7 +11,7 @@ import pandas as pd
 import io
 import os
 import logging
-from app.utils.s3 import create_s3_client
+from app.utils.s3 import create_s3_client, parse_s3_url
 
 # Set up logging
 logger = logging.getLogger(__name__)
@@ -94,22 +93,11 @@ async def get_preview_data(user_id: str = Depends(get_current_user_id)) -> Dict[
         # Initialize S3 client
         s3_client = create_s3_client()
 
-        # Extract the key from the S3 URL
+        # Extract the key from the S3 URL (handles all persisted URL shapes)
         s3_url = user_data.s3_url
-
-        # Handle different S3 URL formats
-        # Parse the S3 URL to extract the full object key (preserving directory prefixes)
-        parsed_url = urlparse(s3_url)
-        s3_key = parsed_url.path.lstrip("/")
-
-        # Endpoint-style URLs ({AWS_ENDPOINT_URL}/{bucket}/{key}) include the
-        # bucket as the first path segment — strip it to get the object key.
-        endpoint_url = (os.getenv("AWS_ENDPOINT_URL") or "").rstrip("/")
-        bucket_name = os.getenv("AWS_BUCKET_NAME", "")
-        if endpoint_url and s3_url.startswith(endpoint_url) and s3_key.startswith(f"{bucket_name}/"):
-            s3_key = s3_key[len(bucket_name) + 1:]
-
-        if not s3_key:
+        try:
+            _, s3_key = parse_s3_url(s3_url)
+        except ValueError:
             raise HTTPException(status_code=400, detail="Invalid S3 URL (missing object key)")
 
         logger.debug(f"Fetching S3 object for preview: {s3_key}")

--- a/apps/backend/app/services/s3_service.py
+++ b/apps/backend/app/services/s3_service.py
@@ -1,4 +1,3 @@
-import boto3
 import os
 import tempfile
 import logging
@@ -7,6 +6,7 @@ from urllib.parse import unquote
 from botocore.exceptions import ClientError
 
 from app.utils.circuit_breaker import with_circuit_breaker, with_sync_circuit_breaker
+from app.utils.s3 import create_s3_client
 
 logger = logging.getLogger(__name__)
 
@@ -16,7 +16,11 @@ logger = logging.getLogger(__name__)
     max_attempts=3,
     failure_threshold=5,
     recovery_timeout=60.0,
-    exceptions=(ClientError, ValueError)
+    # Only retry/count transient S3 errors. ValueError means a deterministic
+    # validation failure (bad URL, wrong bucket, path traversal): retrying it
+    # is pointless, and counting it toward the breaker would let malicious
+    # input open the circuit and block legitimate downloads.
+    exceptions=(ClientError,)
 )
 def download_file_from_s3(s3_url: str) -> str:
     """
@@ -45,15 +49,23 @@ def download_file_from_s3(s3_url: str) -> str:
             raise ValueError("AWS_S3_BUCKET environment variable not set")
 
         # SECURITY: Validate S3 URL format and bucket whitelist
-        # Pattern enforces: https://{bucket}.s3.amazonaws.com/{path}
-        s3_pattern = r"https://([^\.]+)\.s3\.amazonaws\.com/([^?]+)"
-        match = re.match(s3_pattern, s3_url)
+        # AWS format:      https://{bucket}.s3.amazonaws.com/{path}
+        # Endpoint format: {AWS_ENDPOINT_URL}/{bucket}/{path}  (MinIO/LocalStack)
+        endpoint_url = os.getenv("AWS_ENDPOINT_URL")
+        if endpoint_url and s3_url.startswith(endpoint_url):
+            path = s3_url[len(endpoint_url):].lstrip("/").split("?")[0]
+            bucket_name, _, object_key = path.partition("/")
+            if not bucket_name or not object_key:
+                raise ValueError(f"Invalid S3 URL format: {s3_url}")
+        else:
+            s3_pattern = r"https://([^\.]+)\.s3\.amazonaws\.com/([^?]+)"
+            match = re.match(s3_pattern, s3_url)
 
-        if not match:
-            raise ValueError(f"Invalid S3 URL format: {s3_url}")
+            if not match:
+                raise ValueError(f"Invalid S3 URL format: {s3_url}")
 
-        bucket_name = match.group(1)
-        object_key = match.group(2)
+            bucket_name = match.group(1)
+            object_key = match.group(2)
 
         # SECURITY: Enforce bucket whitelist
         if bucket_name != ALLOWED_BUCKET:
@@ -76,12 +88,7 @@ def download_file_from_s3(s3_url: str) -> str:
             raise ValueError("Invalid S3 path structure: must match 'datasets/{user_id}/{filename}'")
 
         # Initialize S3 client
-        s3_client = boto3.client(
-            "s3",
-            aws_access_key_id=os.getenv("AWS_ACCESS_KEY_ID"),
-            aws_secret_access_key=os.getenv("AWS_SECRET_ACCESS_KEY"),
-            region_name=os.getenv("AWS_REGION", "us-east-1"),
-        )
+        s3_client = create_s3_client()
 
         # SECURITY: Check file size before downloading to prevent DoS
         try:
@@ -140,12 +147,7 @@ class S3Service:
             self.s3_client = None
         else:
             try:
-                self.s3_client = boto3.client(
-                    "s3",
-                    aws_access_key_id=aws_access_key,
-                    aws_secret_access_key=aws_secret_key,
-                    region_name=os.getenv("AWS_REGION", "us-east-1"),
-                )
+                self.s3_client = create_s3_client()
             except Exception as e:
                 logger.exception("Failed to initialize S3 client: %s", e)
                 self.is_mock_mode = True

--- a/apps/backend/app/services/s3_service.py
+++ b/apps/backend/app/services/s3_service.py
@@ -51,7 +51,7 @@ def download_file_from_s3(s3_url: str) -> str:
         # SECURITY: Validate S3 URL format and bucket whitelist
         # AWS format:      https://{bucket}.s3.amazonaws.com/{path}
         # Endpoint format: {AWS_ENDPOINT_URL}/{bucket}/{path}  (MinIO/LocalStack)
-        endpoint_url = os.getenv("AWS_ENDPOINT_URL")
+        endpoint_url = (os.getenv("AWS_ENDPOINT_URL") or "").rstrip("/")
         if endpoint_url and s3_url.startswith(endpoint_url):
             path = s3_url[len(endpoint_url):].lstrip("/").split("?")[0]
             bucket_name, _, object_key = path.partition("/")

--- a/apps/backend/app/services/s3_service.py
+++ b/apps/backend/app/services/s3_service.py
@@ -6,7 +6,7 @@ from urllib.parse import unquote
 from botocore.exceptions import ClientError
 
 from app.utils.circuit_breaker import with_circuit_breaker, with_sync_circuit_breaker
-from app.utils.s3 import create_s3_client
+from app.utils.s3 import create_s3_client, parse_s3_url
 
 logger = logging.getLogger(__name__)
 
@@ -48,24 +48,16 @@ def download_file_from_s3(s3_url: str) -> str:
         if not ALLOWED_BUCKET:
             raise ValueError("AWS_S3_BUCKET environment variable not set")
 
-        # SECURITY: Validate S3 URL format and bucket whitelist
-        # AWS format:      https://{bucket}.s3.amazonaws.com/{path}
-        # Endpoint format: {AWS_ENDPOINT_URL}/{bucket}/{path}  (MinIO/LocalStack)
-        endpoint_url = (os.getenv("AWS_ENDPOINT_URL") or "").rstrip("/")
-        if endpoint_url and s3_url.startswith(endpoint_url):
-            path = s3_url[len(endpoint_url):].lstrip("/").split("?")[0]
-            bucket_name, _, object_key = path.partition("/")
-            if not bucket_name or not object_key:
-                raise ValueError(f"Invalid S3 URL format: {s3_url}")
-        else:
-            s3_pattern = r"https://([^\.]+)\.s3\.amazonaws\.com/([^?]+)"
-            match = re.match(s3_pattern, s3_url)
-
-            if not match:
-                raise ValueError(f"Invalid S3 URL format: {s3_url}")
-
-            bucket_name = match.group(1)
-            object_key = match.group(2)
+        # SECURITY: Validate S3 URL format and bucket whitelist.
+        # parse_s3_url handles amazonaws and endpoint-style (MinIO/LocalStack)
+        # URLs with exact-origin endpoint matching; URLs it cannot attribute
+        # to a bucket are rejected here.
+        try:
+            bucket_name, object_key = parse_s3_url(s3_url)
+        except ValueError:
+            raise ValueError(f"Invalid S3 URL format: {s3_url}")
+        if bucket_name is None:
+            raise ValueError(f"Invalid S3 URL format: {s3_url}")
 
         # SECURITY: Enforce bucket whitelist
         if bucket_name != ALLOWED_BUCKET:

--- a/apps/backend/app/services/versioning_service.py
+++ b/apps/backend/app/services/versioning_service.py
@@ -13,12 +13,10 @@ Security:
 from typing import Optional, List, Dict, Any, Tuple
 from datetime import datetime, timedelta, timezone
 import uuid
-import boto3
 from botocore.exceptions import ClientError
 import logging
 
-logger = logging.getLogger(__name__)
-
+from app.utils.s3 import create_s3_client
 from app.models.version import (
     DatasetVersion,
     TransformationLineage,
@@ -35,6 +33,8 @@ from app.services.exceptions import (
     ValidationError
 )
 
+logger = logging.getLogger(__name__)
+
 
 class VersioningService(BaseService[DatasetVersion]):
     """Service for managing dataset versions and lineage tracking."""
@@ -44,12 +44,7 @@ class VersioningService(BaseService[DatasetVersion]):
 
     def __init__(self):
         """Initialize versioning service with S3 client."""
-        self.s3_client = boto3.client(
-            's3',
-            aws_access_key_id=settings.AWS_ACCESS_KEY_ID,
-            aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY,
-            region_name=settings.AWS_REGION
-        )
+        self.s3_client = create_s3_client()
         self.bucket_name = settings.S3_BUCKET
 
     def _get_id_field(self) -> str:

--- a/apps/backend/app/utils/circuit_breaker.py
+++ b/apps/backend/app/utils/circuit_breaker.py
@@ -232,6 +232,20 @@ class CircuitBreaker:
         with self._lock:
             return self.state
 
+    def reset(self):
+        """
+        Reset the breaker to a closed state with cleared counters.
+
+        Intended for test isolation: decorators capture breaker instances at
+        import time, so tests must reset state in-place rather than clearing
+        the registry.
+        """
+        with self._lock:
+            self._transition_state(CircuitState.CLOSED)
+            self.half_open_calls = 0
+            self.metrics.reset_consecutive_counts()
+            self.metrics.last_failure_time = None
+
 
 # Global circuit breakers for each service
 _circuit_breakers: Dict[str, CircuitBreaker] = {}

--- a/apps/backend/app/utils/s3.py
+++ b/apps/backend/app/utils/s3.py
@@ -1,7 +1,9 @@
 import boto3
 import os
+import re
 from botocore.exceptions import ClientError, NoCredentialsError
 from typing import Optional, Tuple
+from urllib.parse import urlparse
 import logging
 import io
 
@@ -39,6 +41,47 @@ def create_s3_client():
     if endpoint_url:
         client_kwargs["endpoint_url"] = endpoint_url
     return boto3.client("s3", **client_kwargs)
+
+
+def parse_s3_url(s3_url: str) -> Tuple[Optional[str], str]:
+    """
+    Parse any persisted S3 URL shape into (bucket, key).
+
+    Handles every format the app stores or has stored historically:
+    - s3://{bucket}/{key}
+    - {AWS_ENDPOINT_URL}/{bucket}/{key}      (MinIO/LocalStack, path-style)
+    - https://{bucket}.s3.amazonaws.com/{key} (incl. presigned query strings)
+    - any other http(s) URL: bucket is None, key is the URL path
+
+    Returns:
+        (bucket, key) — bucket is None when it cannot be determined from
+        the URL; callers that need a bucket should fall back to the
+        configured bucket name.
+
+    Raises:
+        ValueError: if no object key can be extracted.
+    """
+    bucket: Optional[str] = None
+    key = ""
+
+    if s3_url.startswith("s3://"):
+        bucket, _, key = s3_url[5:].partition("/")
+    else:
+        endpoint_url = (os.getenv("AWS_ENDPOINT_URL") or "").rstrip("/")
+        if endpoint_url and s3_url.startswith(endpoint_url):
+            path = s3_url[len(endpoint_url):].lstrip("/")
+            bucket, _, key = path.partition("/")
+        else:
+            match = re.match(r"https://([^.]+)\.s3\.amazonaws\.com/([^?]+)", s3_url)
+            if match:
+                bucket, key = match.group(1), match.group(2)
+            elif urlparse(s3_url).scheme in ("http", "https"):
+                key = urlparse(s3_url).path.lstrip("/")
+
+    key = key.split("?")[0]
+    if not key:
+        raise ValueError(f"Invalid S3 URL format: {s3_url}")
+    return bucket, key
 
 
 def get_s3_client():
@@ -150,28 +193,16 @@ def get_file_from_s3(s3_url: str) -> io.BytesIO:
     if client is None:
         raise Exception("Failed to initialize S3 client")
 
-    # Parse the S3 URL to get bucket and key
-    # AWS format:      https://bucket-name.s3.amazonaws.com/key
-    # Endpoint format: {AWS_ENDPOINT_URL}/bucket-name/key  (MinIO/LocalStack)
+    # Parse the S3 URL to get bucket and key (all persisted URL shapes)
     try:
-        endpoint_url = (os.getenv("AWS_ENDPOINT_URL") or "").rstrip("/")
-        if endpoint_url and s3_url.startswith(endpoint_url):
-            path = s3_url[len(endpoint_url):].lstrip("/")
-            bucket_name, _, key = path.partition("/")
-            if not bucket_name or not key:
+        bucket_name, key = parse_s3_url(s3_url)
+        if bucket_name is None:
+            # Legacy fallback: derive the bucket from the host's first label
+            # (e.g. "bucket.s3.amazonaws.com" variants parse_s3_url doesn't map)
+            netloc = urlparse(s3_url if "://" in s3_url else f"https://{s3_url}").netloc
+            bucket_name = netloc.split(".")[0]
+            if not bucket_name:
                 raise ValueError(f"Invalid S3 URL format: {s3_url}")
-        else:
-            # Remove the https:// prefix if present
-            if s3_url.startswith("https://"):
-                s3_url = s3_url[8:]
-
-            # Split by the first slash to separate bucket and key
-            parts = s3_url.split("/", 1)
-            if len(parts) != 2:
-                raise ValueError(f"Invalid S3 URL format: {s3_url}")
-
-            bucket_name = parts[0].split(".")[0]  # Remove .s3.amazonaws.com
-            key = parts[1]
 
         # Download the file to a BytesIO object
         file_obj = io.BytesIO()

--- a/apps/backend/app/utils/s3.py
+++ b/apps/backend/app/utils/s3.py
@@ -154,7 +154,7 @@ def get_file_from_s3(s3_url: str) -> io.BytesIO:
     # AWS format:      https://bucket-name.s3.amazonaws.com/key
     # Endpoint format: {AWS_ENDPOINT_URL}/bucket-name/key  (MinIO/LocalStack)
     try:
-        endpoint_url = os.getenv("AWS_ENDPOINT_URL")
+        endpoint_url = (os.getenv("AWS_ENDPOINT_URL") or "").rstrip("/")
         if endpoint_url and s3_url.startswith(endpoint_url):
             path = s3_url[len(endpoint_url):].lstrip("/")
             bucket_name, _, key = path.partition("/")

--- a/apps/backend/app/utils/s3.py
+++ b/apps/backend/app/utils/s3.py
@@ -74,15 +74,19 @@ def parse_s3_url(s3_url: str) -> Tuple[Optional[str], str]:
         bucket, _, key = s3_url[5:].partition("/")
     else:
         endpoint_url = (os.getenv("AWS_ENDPOINT_URL") or "").rstrip("/")
-        if endpoint_url and s3_url.startswith(endpoint_url):
-            path = s3_url[len(endpoint_url):].lstrip("/")
+        parsed = urlparse(s3_url)
+        endpoint = urlparse(endpoint_url) if endpoint_url else None
+        # Exact scheme+host+port comparison — a plain prefix check would
+        # also match lookalike hosts (http://localhost:9000.attacker.com).
+        if endpoint and parsed.scheme == endpoint.scheme and parsed.netloc == endpoint.netloc:
+            path = parsed.path.lstrip("/")
             bucket, _, key = path.partition("/")
         else:
             match = re.match(r"https://([^.]+)\.s3\.amazonaws\.com/([^?]+)", s3_url)
             if match:
                 bucket, key = match.group(1), match.group(2)
-            elif urlparse(s3_url).scheme in ("http", "https"):
-                key = urlparse(s3_url).path.lstrip("/")
+            elif parsed.scheme in ("http", "https"):
+                key = parsed.path.lstrip("/")
 
     key = key.split("?")[0]
     if not key:

--- a/apps/backend/app/utils/s3.py
+++ b/apps/backend/app/utils/s3.py
@@ -19,6 +19,28 @@ s3_client = None
 S3_BUCKET = None
 
 
+def create_s3_client():
+    """
+    Create a boto3 S3 client from current environment variables.
+
+    Honors the optional AWS_ENDPOINT_URL variable so S3-compatible storage
+    (e.g. MinIO in CI, LocalStack locally) can be used transparently. When
+    AWS_ENDPOINT_URL is unset, boto3 targets the default AWS endpoint.
+
+    This is the single factory all backend S3 clients should be created
+    through. Raises on failure (callers decide how to handle).
+    """
+    client_kwargs = {
+        "aws_access_key_id": os.getenv("AWS_ACCESS_KEY_ID"),
+        "aws_secret_access_key": os.getenv("AWS_SECRET_ACCESS_KEY"),
+        "region_name": os.getenv("AWS_REGION", "us-east-1"),
+    }
+    endpoint_url = os.getenv("AWS_ENDPOINT_URL")
+    if endpoint_url:
+        client_kwargs["endpoint_url"] = endpoint_url
+    return boto3.client("s3", **client_kwargs)
+
+
 def get_s3_client():
     """
     Get or create an S3 client with the current environment variables.
@@ -42,12 +64,7 @@ def get_s3_client():
 
     try:
         # Create a new client with current environment variables
-        s3_client = boto3.client(
-            "s3",
-            aws_access_key_id=os.getenv("AWS_ACCESS_KEY_ID"),
-            aws_secret_access_key=os.getenv("AWS_SECRET_ACCESS_KEY"),
-            region_name=os.getenv("AWS_REGION", "us-east-1"),
-        )
+        s3_client = create_s3_client()
         logger.info("S3 client initialized successfully")
         return s3_client
     except Exception as e:
@@ -97,7 +114,12 @@ def upload_file_to_s3(
         )
 
         # Generate the URL (this will be a signed URL if needed for access)
-        url = f"https://{bucket_name}.s3.amazonaws.com/{s3_filename}"
+        endpoint_url = os.getenv("AWS_ENDPOINT_URL")
+        if endpoint_url:
+            # S3-compatible storage (MinIO/LocalStack): path-style URL
+            url = f"{endpoint_url.rstrip('/')}/{bucket_name}/{s3_filename}"
+        else:
+            url = f"https://{bucket_name}.s3.amazonaws.com/{s3_filename}"
 
         logger.info(f"File uploaded successfully to {url}")
         return True, url
@@ -129,19 +151,27 @@ def get_file_from_s3(s3_url: str) -> io.BytesIO:
         raise Exception("Failed to initialize S3 client")
 
     # Parse the S3 URL to get bucket and key
-    # URL format: https://bucket-name.s3.amazonaws.com/key
+    # AWS format:      https://bucket-name.s3.amazonaws.com/key
+    # Endpoint format: {AWS_ENDPOINT_URL}/bucket-name/key  (MinIO/LocalStack)
     try:
-        # Remove the https:// prefix if present
-        if s3_url.startswith("https://"):
-            s3_url = s3_url[8:]
+        endpoint_url = os.getenv("AWS_ENDPOINT_URL")
+        if endpoint_url and s3_url.startswith(endpoint_url):
+            path = s3_url[len(endpoint_url):].lstrip("/")
+            bucket_name, _, key = path.partition("/")
+            if not bucket_name or not key:
+                raise ValueError(f"Invalid S3 URL format: {s3_url}")
+        else:
+            # Remove the https:// prefix if present
+            if s3_url.startswith("https://"):
+                s3_url = s3_url[8:]
 
-        # Split by the first slash to separate bucket and key
-        parts = s3_url.split("/", 1)
-        if len(parts) != 2:
-            raise ValueError(f"Invalid S3 URL format: {s3_url}")
+            # Split by the first slash to separate bucket and key
+            parts = s3_url.split("/", 1)
+            if len(parts) != 2:
+                raise ValueError(f"Invalid S3 URL format: {s3_url}")
 
-        bucket_name = parts[0].split(".")[0]  # Remove .s3.amazonaws.com
-        key = parts[1]
+            bucket_name = parts[0].split(".")[0]  # Remove .s3.amazonaws.com
+            key = parts[1]
 
         # Download the file to a BytesIO object
         file_obj = io.BytesIO()

--- a/apps/backend/app/utils/s3.py
+++ b/apps/backend/app/utils/s3.py
@@ -1,6 +1,7 @@
 import boto3
 import os
 import re
+from botocore.config import Config
 from botocore.exceptions import ClientError, NoCredentialsError
 from typing import Optional, Tuple
 from urllib.parse import urlparse
@@ -40,6 +41,11 @@ def create_s3_client():
     endpoint_url = os.getenv("AWS_ENDPOINT_URL")
     if endpoint_url:
         client_kwargs["endpoint_url"] = endpoint_url
+        # Pin path-style addressing for S3-compatible endpoints so bucket
+        # names never become unresolvable host prefixes (e.g.
+        # http://test-bucket.localhost:9000) regardless of boto3 version.
+        # Real AWS keeps the default (virtual-hosted) addressing.
+        client_kwargs["config"] = Config(s3={"addressing_style": "path"})
     return boto3.client("s3", **client_kwargs)
 
 

--- a/apps/backend/docs/TEST_INFRASTRUCTURE.md
+++ b/apps/backend/docs/TEST_INFRASTRUCTURE.md
@@ -33,6 +33,11 @@ tests/
 │   ├── test_monitoring.py      # @pytest.mark.unit - Monitoring tests
 │   ├── test_pii_detector.py    # @pytest.mark.unit - PII detection tests
 │   └── test_upload_handler.py  # @pytest.mark.integration - Upload handler tests
+├── test_services/
+│   ├── conftest.py                  # Service test fixtures
+│   ├── test_s3_endpoint_url.py      # AWS_ENDPOINT_URL / S3-compatible storage tests
+│   ├── test_versioning_service.py   # Versioning service tests
+│   └── ...                          # Other service unit/integration tests
 ├── test_processing/
 │   └── ...                     # Data processing unit tests
 └── test_model_training/

--- a/apps/backend/docs/VERSIONING.md
+++ b/apps/backend/docs/VERSIONING.md
@@ -341,6 +341,8 @@ Failed S3 operations retry with exponential backoff:
 # S3 Configuration
 AWS_S3_BUCKET=narrative-modeling-datasets
 AWS_REGION=us-east-1
+# Optional: route S3 calls to S3-compatible storage (MinIO, LocalStack)
+# AWS_ENDPOINT_URL=http://localhost:9000
 
 # Versioning Settings
 VERSION_RETENTION_DAYS=90

--- a/apps/backend/tests/test_api/test_user_data.py
+++ b/apps/backend/tests/test_api/test_user_data.py
@@ -517,12 +517,12 @@ class TestUserDataAPI:
         mock_df.to_csv(csv_buffer, index=False)
         csv_content = csv_buffer.getvalue()
 
-        with patch('app.api.routes.user_data.boto3.client') as mock_boto:
+        with patch('app.api.routes.user_data.create_s3_client') as mock_create_client:
             mock_s3_client = MagicMock()
             mock_s3_client.get_object.return_value = {
                 "Body": MagicMock(read=MagicMock(return_value=csv_content))
             }
-            mock_boto.return_value = mock_s3_client
+            mock_create_client.return_value = mock_s3_client
 
             response = await async_authorized_client.get("/api/v1/user_data/preview")
 
@@ -542,10 +542,10 @@ class TestUserDataAPI:
         sample_user_data: UserData
     ):
         """Test getting preview data when S3 retrieval fails (returns error but not 500)."""
-        with patch('app.api.routes.user_data.boto3.client') as mock_boto:
+        with patch('app.api.routes.user_data.create_s3_client') as mock_create_client:
             mock_s3_client = MagicMock()
             mock_s3_client.get_object.side_effect = Exception("S3 error")
-            mock_boto.return_value = mock_s3_client
+            mock_create_client.return_value = mock_s3_client
 
             response = await async_authorized_client.get("/api/v1/user_data/preview")
 

--- a/apps/backend/tests/test_services/conftest.py
+++ b/apps/backend/tests/test_services/conftest.py
@@ -1,0 +1,31 @@
+"""
+Shared fixtures for service-layer tests.
+"""
+
+import pytest
+
+from app.utils import circuit_breaker
+
+
+def _reset_all_breakers():
+    with circuit_breaker._circuit_breakers_lock:
+        for breaker in circuit_breaker._circuit_breakers.values():
+            breaker.reset()
+
+
+@pytest.fixture(autouse=True)
+def reset_circuit_breakers():
+    """
+    Reset all circuit breakers between tests.
+
+    Circuit breakers are intentionally global in production (they protect
+    shared services across requests), but that state leaks across tests:
+    security tests that exercise failure paths open the "s3" breaker, and
+    subsequent tests that expect successful calls then fail with
+    CircuitBreakerOpen. Decorators capture breaker instances at import time,
+    so each instance is reset in-place (clearing the registry would not
+    affect captured references).
+    """
+    _reset_all_breakers()
+    yield
+    _reset_all_breakers()

--- a/apps/backend/tests/test_services/test_s3_endpoint_url.py
+++ b/apps/backend/tests/test_services/test_s3_endpoint_url.py
@@ -1,0 +1,118 @@
+"""
+Tests for AWS_ENDPOINT_URL support in S3 download operations.
+
+When AWS_ENDPOINT_URL is set (S3-compatible storage such as MinIO in CI),
+stored URLs have the form {endpoint}/{bucket}/{key} instead of
+https://{bucket}.s3.amazonaws.com/{key}. These tests verify:
+1. Endpoint-style URLs are parsed correctly
+2. All security validations (bucket whitelist, path traversal,
+   path structure) still apply to endpoint-style URLs
+3. The amazonaws URL path is unchanged when no endpoint is configured
+"""
+
+import os
+import pytest
+from unittest.mock import Mock, patch
+from tenacity import RetryError
+
+from app.services.s3_service import download_file_from_s3
+from app.utils.circuit_breaker import CircuitBreakerOpen
+
+
+def get_error_message(exc_value):
+    """Extract error message from ValueError, RetryError, or CircuitBreakerOpen."""
+    if isinstance(exc_value, CircuitBreakerOpen):
+        return "Circuit breaker activated (security validation failures)"
+    elif isinstance(exc_value, RetryError):
+        return str(exc_value.last_attempt.exception())
+    return str(exc_value)
+
+
+ENDPOINT_ENV = {
+    "AWS_S3_BUCKET": "test-bucket",
+    "AWS_ACCESS_KEY_ID": "minioadmin",
+    "AWS_SECRET_ACCESS_KEY": "minioadmin",
+    "AWS_REGION": "us-east-1",
+    "AWS_ENDPOINT_URL": "http://localhost:9000",
+}
+
+
+@pytest.mark.unit
+class TestEndpointUrlParsing:
+    """Endpoint-style URL parsing with security validation intact."""
+
+    def test_valid_endpoint_url_downloads(self):
+        """A well-formed endpoint URL is parsed and downloaded."""
+        with patch.dict(os.environ, ENDPOINT_ENV):
+            with patch("app.utils.s3.boto3.client") as mock_client_factory:
+                mock_client = Mock()
+                mock_client.head_object.return_value = {"ContentLength": 1024}
+                mock_client.download_file.return_value = None
+                mock_client_factory.return_value = mock_client
+
+                result = download_file_from_s3(
+                    "http://localhost:9000/test-bucket/datasets/user123/data.csv"
+                )
+
+                assert result  # temp file path returned
+                mock_client.download_file.assert_called_once()
+                args = mock_client.download_file.call_args[0]
+                assert args[0] == "test-bucket"
+                assert args[1] == "datasets/user123/data.csv"
+                # Client must be created against the custom endpoint
+                _, kwargs = mock_client_factory.call_args
+                assert kwargs.get("endpoint_url") == "http://localhost:9000"
+
+    def test_endpoint_url_bucket_whitelist_enforced(self):
+        """Cross-bucket access via endpoint URL is denied."""
+        with patch.dict(os.environ, ENDPOINT_ENV):
+            with pytest.raises((ValueError, RetryError, CircuitBreakerOpen)) as exc_info:
+                download_file_from_s3(
+                    "http://localhost:9000/victim-bucket/datasets/user123/data.csv"
+                )
+            msg = get_error_message(exc_info.value)
+            assert "not allowed" in msg or "Circuit breaker" in msg
+
+    def test_endpoint_url_path_traversal_blocked(self):
+        """Path traversal in endpoint URL is rejected."""
+        with patch.dict(os.environ, ENDPOINT_ENV):
+            with pytest.raises((ValueError, RetryError, CircuitBreakerOpen)) as exc_info:
+                download_file_from_s3(
+                    "http://localhost:9000/test-bucket/datasets/../admin/secrets.csv"
+                )
+            msg = get_error_message(exc_info.value)
+            assert (
+                "path traversal" in msg.lower()
+                or "path structure" in msg.lower()
+                or "Circuit breaker" in msg
+            )
+
+    def test_endpoint_url_missing_key_rejected(self):
+        """Endpoint URL without an object key is rejected."""
+        with patch.dict(os.environ, ENDPOINT_ENV):
+            with pytest.raises((ValueError, RetryError, CircuitBreakerOpen)) as exc_info:
+                download_file_from_s3("http://localhost:9000/test-bucket")
+            msg = get_error_message(exc_info.value)
+            assert "Invalid S3 URL format" in msg or "Circuit breaker" in msg
+
+    def test_amazonaws_url_still_works_without_endpoint(self):
+        """The amazonaws URL path is unchanged when AWS_ENDPOINT_URL is unset."""
+        env = {k: v for k, v in ENDPOINT_ENV.items() if k != "AWS_ENDPOINT_URL"}
+        with patch.dict(os.environ, env):
+            os.environ.pop("AWS_ENDPOINT_URL", None)
+            with patch("app.utils.s3.boto3.client") as mock_client_factory:
+                mock_client = Mock()
+                mock_client.head_object.return_value = {"ContentLength": 1024}
+                mock_client.download_file.return_value = None
+                mock_client_factory.return_value = mock_client
+
+                result = download_file_from_s3(
+                    "https://test-bucket.s3.amazonaws.com/datasets/user123/data.csv"
+                )
+
+                assert result
+                args = mock_client.download_file.call_args[0]
+                assert args[0] == "test-bucket"
+                assert args[1] == "datasets/user123/data.csv"
+                _, kwargs = mock_client_factory.call_args
+                assert "endpoint_url" not in kwargs

--- a/apps/backend/tests/test_services/test_versioning_service.py
+++ b/apps/backend/tests/test_services/test_versioning_service.py
@@ -21,9 +21,8 @@ from app.services.exceptions import (
 @pytest.fixture
 def versioning_service():
     """Create versioning service instance with mocked S3 client."""
-    with patch('app.services.versioning_service.boto3') as mock_boto:
-        mock_s3 = MagicMock()
-        mock_boto.client.return_value = mock_s3
+    mock_s3 = MagicMock()
+    with patch('app.services.versioning_service.create_s3_client', return_value=mock_s3):
         service = VersioningService()
         service.s3_client = mock_s3
         return service

--- a/apps/backend/tests/test_utils/test_s3.py
+++ b/apps/backend/tests/test_utils/test_s3.py
@@ -3,7 +3,7 @@ import os
 from unittest.mock import Mock, patch
 from botocore.exceptions import ClientError, NoCredentialsError
 import io
-from app.utils.s3 import get_s3_client, upload_file_to_s3, get_file_from_s3
+from app.utils.s3 import get_s3_client, upload_file_to_s3, get_file_from_s3, parse_s3_url
 
 
 @pytest.fixture
@@ -121,6 +121,53 @@ def test_upload_file_to_s3_success(mock_env_vars, mock_s3_client):
         assert call_args[0][1] == "test_bucket"  # bucket name
         assert call_args[0][2] == s3_filename    # key
         assert call_args[1]["ExtraArgs"] == {"ContentType": content_type}
+
+
+class TestParseS3Url:
+    """parse_s3_url must handle every URL shape the app persists."""
+
+    def test_s3_scheme(self, mock_env_vars):
+        assert parse_s3_url("s3://my-bucket/datasets/u1/data.csv") == (
+            "my-bucket", "datasets/u1/data.csv"
+        )
+
+    def test_amazonaws_virtual_hosted(self, mock_env_vars):
+        assert parse_s3_url("https://my-bucket.s3.amazonaws.com/datasets/u1/data.csv") == (
+            "my-bucket", "datasets/u1/data.csv"
+        )
+
+    def test_amazonaws_presigned_query_stripped(self, mock_env_vars):
+        bucket, key = parse_s3_url(
+            "https://my-bucket.s3.amazonaws.com/datasets/u1/data.csv"
+            "?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Expires=3600"
+        )
+        assert bucket == "my-bucket"
+        assert key == "datasets/u1/data.csv"
+
+    def test_endpoint_style(self, mock_env_vars_with_endpoint):
+        assert parse_s3_url("http://localhost:9000/test_bucket/datasets/u1/data.csv") == (
+            "test_bucket", "datasets/u1/data.csv"
+        )
+
+    def test_endpoint_style_with_query(self, mock_env_vars_with_endpoint):
+        bucket, key = parse_s3_url(
+            "http://localhost:9000/test_bucket/datasets/u1/data.csv?X-Amz-Expires=3600"
+        )
+        assert bucket == "test_bucket"
+        assert key == "datasets/u1/data.csv"
+
+    def test_unknown_https_falls_back_to_path(self, mock_env_vars):
+        bucket, key = parse_s3_url("https://example.com/some/path/file.csv")
+        assert bucket is None
+        assert key == "some/path/file.csv"
+
+    def test_missing_key_raises(self, mock_env_vars_with_endpoint):
+        with pytest.raises(ValueError):
+            parse_s3_url("http://localhost:9000/test_bucket")
+
+    def test_empty_url_raises(self, mock_env_vars):
+        with pytest.raises(ValueError):
+            parse_s3_url("")
 
 
 def test_upload_file_to_s3_endpoint_url(mock_env_vars_with_endpoint, mock_s3_client):

--- a/apps/backend/tests/test_utils/test_s3.py
+++ b/apps/backend/tests/test_utils/test_s3.py
@@ -70,13 +70,15 @@ def test_get_s3_client_with_endpoint_url(mock_env_vars_with_endpoint):
         client = get_s3_client()
 
         assert client is not None
-        mock_boto3_client.assert_called_once_with(
-            "s3",
-            aws_access_key_id="test_access_key",
-            aws_secret_access_key="test_secret_key",
-            region_name="us-east-1",
-            endpoint_url="http://localhost:9000",
-        )
+        mock_boto3_client.assert_called_once()
+        args, kwargs = mock_boto3_client.call_args
+        assert args == ("s3",)
+        assert kwargs["aws_access_key_id"] == "test_access_key"
+        assert kwargs["aws_secret_access_key"] == "test_secret_key"
+        assert kwargs["region_name"] == "us-east-1"
+        assert kwargs["endpoint_url"] == "http://localhost:9000"
+        # Path-style addressing must be pinned for S3-compatible endpoints
+        assert kwargs["config"].s3 == {"addressing_style": "path"}
 
 
 def test_get_s3_client_missing_env_vars():

--- a/apps/backend/tests/test_utils/test_s3.py
+++ b/apps/backend/tests/test_utils/test_s3.py
@@ -8,7 +8,7 @@ from app.utils.s3 import get_s3_client, upload_file_to_s3, get_file_from_s3
 
 @pytest.fixture
 def mock_env_vars():
-    """Fixture to set up mock environment variables."""
+    """Fixture to set up mock environment variables (no custom endpoint)."""
     with patch.dict(
         os.environ,
         {
@@ -16,6 +16,24 @@ def mock_env_vars():
             "AWS_SECRET_ACCESS_KEY": "test_secret_key",
             "AWS_BUCKET_NAME": "test_bucket",
             "AWS_REGION": "us-east-1",
+        },
+    ):
+        # Ensure no endpoint override leaks in from the host environment
+        os.environ.pop("AWS_ENDPOINT_URL", None)
+        yield
+
+
+@pytest.fixture
+def mock_env_vars_with_endpoint():
+    """Fixture with AWS_ENDPOINT_URL set (S3-compatible storage, e.g. MinIO)."""
+    with patch.dict(
+        os.environ,
+        {
+            "AWS_ACCESS_KEY_ID": "test_access_key",
+            "AWS_SECRET_ACCESS_KEY": "test_secret_key",
+            "AWS_BUCKET_NAME": "test_bucket",
+            "AWS_REGION": "us-east-1",
+            "AWS_ENDPOINT_URL": "http://localhost:9000",
         },
     ):
         yield
@@ -42,6 +60,22 @@ def test_get_s3_client_success(mock_env_vars):
             aws_access_key_id="test_access_key",
             aws_secret_access_key="test_secret_key",
             region_name="us-east-1",
+        )
+
+
+def test_get_s3_client_with_endpoint_url(mock_env_vars_with_endpoint):
+    """Test S3 client creation routes to a custom endpoint when AWS_ENDPOINT_URL is set."""
+    with patch("boto3.client") as mock_boto3_client:
+        mock_boto3_client.return_value = Mock()
+        client = get_s3_client()
+
+        assert client is not None
+        mock_boto3_client.assert_called_once_with(
+            "s3",
+            aws_access_key_id="test_access_key",
+            aws_secret_access_key="test_secret_key",
+            region_name="us-east-1",
+            endpoint_url="http://localhost:9000",
         )
 
 
@@ -87,6 +121,48 @@ def test_upload_file_to_s3_success(mock_env_vars, mock_s3_client):
         assert call_args[0][1] == "test_bucket"  # bucket name
         assert call_args[0][2] == s3_filename    # key
         assert call_args[1]["ExtraArgs"] == {"ContentType": content_type}
+
+
+def test_upload_file_to_s3_endpoint_url(mock_env_vars_with_endpoint, mock_s3_client):
+    """Test uploaded file URL is derived from AWS_ENDPOINT_URL when set."""
+    with patch("app.utils.s3.get_s3_client", return_value=mock_s3_client):
+        file_content = b"test file content"
+        s3_filename = "test_file.txt"
+
+        success, url = upload_file_to_s3(file_content, s3_filename, "text/plain")
+
+        assert success is True
+        assert url == "http://localhost:9000/test_bucket/test_file.txt"
+        mock_s3_client.upload_fileobj.assert_called_once()
+
+
+def test_get_file_from_s3_endpoint_url(mock_env_vars_with_endpoint, mock_s3_client):
+    """Test downloading a file referenced by an endpoint-style URL (MinIO)."""
+    with patch("app.utils.s3.get_s3_client", return_value=mock_s3_client):
+        s3_url = "http://localhost:9000/test_bucket/test_file.txt"
+        expected_content = b"test file content"
+
+        def mock_download_fileobj(bucket, key, file_obj):
+            file_obj.write(expected_content)
+            file_obj.seek(0)
+
+        mock_s3_client.download_fileobj.side_effect = mock_download_fileobj
+
+        result = get_file_from_s3(s3_url)
+
+        assert result.getvalue() == expected_content
+        mock_s3_client.download_fileobj.assert_called_once_with(
+            "test_bucket", "test_file.txt", result
+        )
+
+
+def test_get_file_from_s3_endpoint_url_missing_key(mock_env_vars_with_endpoint, mock_s3_client):
+    """Test endpoint-style URL without an object key is rejected."""
+    with patch("app.utils.s3.get_s3_client", return_value=mock_s3_client):
+        with pytest.raises(ValueError) as exc_info:
+            get_file_from_s3("http://localhost:9000/test_bucket")
+
+        assert "Invalid S3 URL format" in str(exc_info.value)
 
 
 def test_upload_file_to_s3_no_client(mock_env_vars):

--- a/apps/backend/tests/test_utils/test_s3.py
+++ b/apps/backend/tests/test_utils/test_s3.py
@@ -163,6 +163,16 @@ class TestParseS3Url:
         assert bucket is None
         assert key == "some/path/file.csv"
 
+    def test_endpoint_lookalike_host_not_matched(self, mock_env_vars_with_endpoint):
+        """A host that merely starts with the endpoint string must not be
+        parsed as endpoint-style (e.g. http://localhost:9000.attacker.com)."""
+        bucket, key = parse_s3_url(
+            "http://localhost:9000.attacker.com/real-bucket/datasets/u1/data.csv"
+        )
+        # Falls through to the generic http(s) path fallback — no bucket
+        assert bucket is None
+        assert key == "real-bucket/datasets/u1/data.csv"
+
     def test_missing_key_raises(self, mock_env_vars_with_endpoint):
         with pytest.raises(ValueError):
             parse_s3_url("http://localhost:9000/test_bucket")

--- a/apps/backend/utils/aws.py
+++ b/apps/backend/utils/aws.py
@@ -1,16 +1,12 @@
 # utils/aws.py
-import boto3
 import os
 from dotenv import load_dotenv
 
+from app.utils.s3 import create_s3_client
+
 load_dotenv()
 
-s3_client = boto3.client(
-    "s3",
-    region_name=os.getenv("AWS_REGION"),
-    aws_access_key_id=os.getenv("AWS_ACCESS_KEY_ID"),
-    aws_secret_access_key=os.getenv("AWS_SECRET_ACCESS_KEY"),
-)
+s3_client = create_s3_client()
 
 
 # utils/aws.py (continued)

--- a/apps/backend/utils/aws.py
+++ b/apps/backend/utils/aws.py
@@ -9,6 +9,8 @@ load_dotenv()
 
 logger = logging.getLogger(__name__)
 
+# NOTE: created at import time — AWS_ENDPOINT_URL (and credentials) must be
+# set in the environment before this module is imported.
 s3_client = create_s3_client()
 
 

--- a/apps/backend/utils/aws.py
+++ b/apps/backend/utils/aws.py
@@ -1,4 +1,5 @@
 # utils/aws.py
+import logging
 import os
 from dotenv import load_dotenv
 
@@ -6,10 +7,11 @@ from app.utils.s3 import create_s3_client
 
 load_dotenv()
 
+logger = logging.getLogger(__name__)
+
 s3_client = create_s3_client()
 
 
-# utils/aws.py (continued)
 def create_presigned_url(file_name: str, content_type: str, expires_in: int = 3600):
     try:
         response = s3_client.generate_presigned_url(
@@ -24,5 +26,5 @@ def create_presigned_url(file_name: str, content_type: str, expires_in: int = 36
         )
         return response
     except Exception as e:
-        print("Error generating presigned URL:", e)
+        logger.error(f"Error generating presigned URL: {e}")
         return None

--- a/apps/frontend/__tests__/app/explore/[id]/page.test.tsx
+++ b/apps/frontend/__tests__/app/explore/[id]/page.test.tsx
@@ -19,6 +19,7 @@ jest.mock('next/navigation', () => ({
 jest.mock('@/lib/contexts/WorkflowContext', () => ({
   WorkflowProvider: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
   useWorkflow: () => ({
+    isHydrated: true,
     state: {
       currentStage: 'DATA_PROFILING',
       completedStages: new Set(['DATA_LOADING']),

--- a/apps/frontend/app/datasets/[id]/prepare/page.tsx
+++ b/apps/frontend/app/datasets/[id]/prepare/page.tsx
@@ -44,7 +44,7 @@ export default function DatasetPreparePage() {
   const params = useParams();
   const router = useRouter();
   useSession();
-  const { completeStage, canAccessStage } = useWorkflow();
+  const { completeStage, canAccessStage, isHydrated } = useWorkflow();
 
   const datasetId = params?.id as string;
   const [dataset, setDataset] = useState<Dataset | null>(null);
@@ -100,6 +100,12 @@ export default function DatasetPreparePage() {
 
   // Check workflow access and fetch dataset
   useEffect(() => {
+    // Wait for workflow state to hydrate before gating — checking too early
+    // always sees an empty state and wrongly redirects to /upload
+    if (!isHydrated) {
+      return;
+    }
+
     if (!canAccessStage(WorkflowStage.DATA_PREPARATION)) {
       router.push('/upload');
       return;
@@ -148,7 +154,7 @@ export default function DatasetPreparePage() {
     };
 
     fetchDataset();
-  }, [datasetId, apiUrl, canAccessStage, router]);
+  }, [datasetId, apiUrl, canAccessStage, router, isHydrated]);
 
   // Fetch transformation types and available columns for edit dialog
   useEffect(() => {

--- a/apps/frontend/app/explore/[id]/page.tsx
+++ b/apps/frontend/app/explore/[id]/page.tsx
@@ -35,7 +35,7 @@ export default function DatasetAnalysisPage() {
   const params = useParams()
   const router = useRouter()
   useSession()
-  const { state, completeStage, canAccessStage, loadWorkflow } = useWorkflow()
+  const { state, completeStage, canAccessStage, loadWorkflow, isHydrated } = useWorkflow()
   const [dataset, setDataset] = useState<ProcessedDataset | null>(null)
   const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
@@ -44,6 +44,12 @@ export default function DatasetAnalysisPage() {
   const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000/api/v1'
 
   useEffect(() => {
+    // Wait for workflow state to hydrate before gating — checking too early
+    // always sees an empty state and wrongly redirects to /upload
+    if (!isHydrated) {
+      return
+    }
+
     // Check workflow access
     if (!canAccessStage(WorkflowStage.DATA_PROFILING)) {
       router.push('/upload')
@@ -123,7 +129,7 @@ export default function DatasetAnalysisPage() {
       abortController.abort()
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [params?.id, apiUrl])
+  }, [params?.id, apiUrl, isHydrated])
 
   const processDataset = async (datasetId: string, token: string, signal?: AbortSignal) => {
     try {

--- a/apps/frontend/app/upload/page.tsx
+++ b/apps/frontend/app/upload/page.tsx
@@ -364,6 +364,7 @@ export default function UploadPage() {
                 )}
                 <button
                   onClick={handleNextStep}
+                  data-testid="next-step-button"
                   className="mt-4 px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-700 transition-colors flex items-center space-x-2"
                 >
                   <span>Next Step</span>

--- a/apps/frontend/e2e/fixtures/index.ts
+++ b/apps/frontend/e2e/fixtures/index.ts
@@ -130,6 +130,18 @@ export const test = base.extend<AuthFixtures & DataFixtures & AIMockFixtures>({
       // Click upload button
       await uploadButton.click();
 
+      // The upload page does not auto-navigate: it shows a success panel
+      // with a "Next Step" button that takes the user to /explore/{id}.
+      const nextStepButton = page.getByTestId('next-step-button');
+      try {
+        await nextStepButton.waitFor({ state: 'visible', timeout: 30000 });
+      } catch (error) {
+        throw new Error(
+          `Upload failed: success panel did not appear. Current URL: ${page.url()}`
+        );
+      }
+      await nextStepButton.click();
+
       // Wait for navigation to dataset detail page
       try {
         await page.waitForURL(/\/explore\/[a-zA-Z0-9-]+/, { timeout: 30000 });
@@ -169,13 +181,21 @@ export const test = base.extend<AuthFixtures & DataFixtures & AIMockFixtures>({
     const train = async (datasetId: string, targetColumn: string): Promise<string> => {
       const maxRetries = 2;
 
+      // API calls must target the backend directly — Next.js does not proxy
+      // /api/v1/* to the FastAPI server. Backend runs with SKIP_AUTH=true in
+      // E2E, but HTTPBearer still requires some Authorization header.
+      const apiBase = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000/api/v1';
+      const headers = { Authorization: 'Bearer e2e-test-token' };
+
       for (let attempt = 0; attempt <= maxRetries; attempt++) {
         try {
-          const response = await request.post('/api/v1/models/train', {
+          // The real ML pipeline lives under /api/v1/ml (AutoMLEngine +
+          // ModelStorageService); /api/v1/models only stores config records.
+          const response = await request.post(`${apiBase}/ml/train`, {
+            headers,
             data: {
               dataset_id: datasetId,
               target_column: targetColumn,
-              algorithm: 'random_forest',
             },
             timeout: 30000,
           });
@@ -192,36 +212,29 @@ export const test = base.extend<AuthFixtures & DataFixtures & AIMockFixtures>({
           const data = await response.json();
           const modelId = data.model_id || data.id;
 
-          // Poll for training completion (with timeout and better error handling)
-          let status = 'training';
-          let pollAttempts = 0;
+          // Training runs as a background task; the model becomes retrievable
+          // from GET /api/v1/ml/{id} once the artifact is saved.
+          let trained = false;
           const maxPollAttempts = 30; // 60 seconds max
 
-          while (status === 'training' && pollAttempts < maxPollAttempts) {
+          for (let pollAttempts = 0; pollAttempts < maxPollAttempts; pollAttempts++) {
             await new Promise(resolve => setTimeout(resolve, 2000));
-            pollAttempts++;
 
             try {
-              const statusResponse = await request.get(`/api/v1/models/${modelId}/status`, {
+              const statusResponse = await request.get(`${apiBase}/ml/${modelId}`, {
+                headers,
                 timeout: 5000,
               });
               if (statusResponse.ok()) {
-                const statusData = await statusResponse.json();
-                status = statusData.status;
-
-                if (status === 'failed' || status === 'error') {
-                  throw new Error(`Model training failed with status: ${status}`);
-                }
-              }
-            } catch (error) {
-              // If status endpoint doesn't exist, assume training complete after some attempts
-              if (pollAttempts > 5) {
+                trained = true;
                 break;
               }
+            } catch (error) {
+              // Transient network error — keep polling
             }
           }
 
-          if (status === 'training') {
+          if (!trained) {
             console.warn('Training timed out, but returning model ID anyway');
           }
 

--- a/apps/frontend/e2e/fixtures/index.ts
+++ b/apps/frontend/e2e/fixtures/index.ts
@@ -168,7 +168,13 @@ export const test = base.extend<AuthFixtures & DataFixtures & AIMockFixtures>({
   cleanupDataset: async ({ request }, use) => {
     const cleanup = async (datasetId: string) => {
       try {
-        await request.delete(`/api/v1/datasets/${datasetId}`);
+        // Target the backend directly (Next.js does not proxy /api/v1);
+        // a relative URL hits the dev server and burns a 15s timeout per test
+        const apiBase = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000/api/v1';
+        await request.delete(`${apiBase}/datasets/${datasetId}`, {
+          headers: { Authorization: 'Bearer e2e-test-token' },
+          timeout: 5000,
+        });
       } catch (error) {
         console.warn(`Failed to cleanup dataset ${datasetId}:`, error);
       }

--- a/apps/frontend/e2e/helpers/SecurityTester.ts
+++ b/apps/frontend/e2e/helpers/SecurityTester.ts
@@ -179,7 +179,15 @@ export class SecurityTester {
   ): Promise<SecurityTestResult> {
     // Try to access protected route without authentication
     await this.page.goto(protectedUrl);
-    await this.page.waitForLoadState('networkidle');
+
+    // Wait for an auth redirect (server-side middleware redirects fast;
+    // client-side React redirects land after hydration). If no redirect
+    // happens within the timeout, fall through to content-based checks.
+    await this.page
+      .waitForURL(/\/auth\/|\/login|\/signin/, { timeout: 5000 })
+      .catch(async () => {
+        await this.page.waitForLoadState('networkidle').catch(() => {});
+      });
 
     const currentUrl = this.page.url();
 

--- a/apps/frontend/e2e/helpers/SecurityTester.ts
+++ b/apps/frontend/e2e/helpers/SecurityTester.ts
@@ -183,9 +183,13 @@ export class SecurityTester {
     // Wait for an auth redirect (server-side middleware redirects fast;
     // client-side React redirects land after hydration). If no redirect
     // happens within the timeout, fall through to content-based checks.
+    // Only swallow timeouts — real navigation failures must surface.
     await this.page
       .waitForURL(/\/auth\/|\/login|\/signin/, { timeout: 5000 })
-      .catch(async () => {
+      .catch(async (error: Error) => {
+        if (error.name !== 'TimeoutError' && !error.message.includes('Timeout')) {
+          throw error;
+        }
         await this.page.waitForLoadState('networkidle').catch(() => {});
       });
 

--- a/apps/frontend/e2e/pages/UploadPage.ts
+++ b/apps/frontend/e2e/pages/UploadPage.ts
@@ -31,6 +31,17 @@ export class UploadPage extends BasePage {
   }
 
   /**
+   * Click the post-upload "Next Step" button and wait for navigation
+   * to the dataset's explore page (/explore/{id}).
+   */
+  async continueToExplore() {
+    const nextStepButton = this.page.getByTestId('next-step-button');
+    await nextStepButton.waitFor({ state: 'visible', timeout: 10000 });
+    await nextStepButton.click();
+    await this.page.waitForURL(/\/explore\/[a-zA-Z0-9-]+/, { timeout: 30000 });
+  }
+
+  /**
    * Get the dataset ID from the current URL
    */
   async getDatasetId(): Promise<string> {

--- a/apps/frontend/e2e/performance-results.json
+++ b/apps/frontend/e2e/performance-results.json
@@ -88,5 +88,50 @@
     "timestamp": "2025-12-21T22:00:03.143Z",
     "threshold": 2000,
     "passed": false
+  },
+  {
+    "testName": "Dashboard Load",
+    "metricName": "Page Load: /dashboard",
+    "value": 1331,
+    "unit": "ms",
+    "timestamp": "2026-06-06T04:06:23.247Z",
+    "threshold": 2000,
+    "passed": true
+  },
+  {
+    "testName": "Dashboard Load",
+    "metricName": "Page Load: /dashboard",
+    "value": 1858,
+    "unit": "ms",
+    "timestamp": "2026-06-06T04:12:32.854Z",
+    "threshold": 2000,
+    "passed": true
+  },
+  {
+    "testName": "Dashboard Load",
+    "metricName": "Page Load: /dashboard",
+    "value": 2184,
+    "unit": "ms",
+    "timestamp": "2026-06-06T04:19:39.090Z",
+    "threshold": 2000,
+    "passed": false
+  },
+  {
+    "testName": "Dashboard Load",
+    "metricName": "Page Load: /dashboard",
+    "value": 2276,
+    "unit": "ms",
+    "timestamp": "2026-06-06T04:23:09.144Z",
+    "threshold": 2000,
+    "passed": false
+  },
+  {
+    "testName": "Dashboard Load",
+    "metricName": "Page Load: /dashboard",
+    "value": 1586,
+    "unit": "ms",
+    "timestamp": "2026-06-06T04:27:49.366Z",
+    "threshold": 2000,
+    "passed": true
   }
 ]

--- a/apps/frontend/e2e/workflows/data-preparation.spec.ts
+++ b/apps/frontend/e2e/workflows/data-preparation.spec.ts
@@ -47,8 +47,8 @@ test.describe('Data Preparation Page', () => {
     }
   });
 
-  // FIXME(#155): /datasets/{id}/prepare throws a client-side exception —
-  // previously masked by the workflow-gating redirect fixed in PR #154
+  // Disabled pending #155: /datasets/{id}/prepare throws a client-side
+  // exception — previously masked by the gating redirect fixed in PR #154
   test.fixme('should load data preparation page with dataset info @smoke', async ({ authenticatedPage }) => {
     await authenticatedPage.goto(`/datasets/${datasetId}/prepare`);
 
@@ -63,7 +63,7 @@ test.describe('Data Preparation Page', () => {
     await expect(authenticatedPage.locator('button:has-text("Back"), a:has-text("Back")')).toBeVisible();
   });
 
-  // FIXME(#155): same client-side crash as above
+  // Disabled pending #155: same client-side crash as above
   test.fixme('should display view mode toggle buttons @smoke', async ({ authenticatedPage }) => {
     await authenticatedPage.goto(`/datasets/${datasetId}/prepare`);
 

--- a/apps/frontend/e2e/workflows/data-preparation.spec.ts
+++ b/apps/frontend/e2e/workflows/data-preparation.spec.ts
@@ -17,9 +17,28 @@ import { join } from 'path';
 test.describe('Data Preparation Page', () => {
   let datasetId: string;
 
-  test.beforeEach(async ({ uploadTestDataset }) => {
+  test.beforeEach(async ({ page, uploadTestDataset }) => {
     // Upload test dataset
     datasetId = await uploadTestDataset();
+
+    // The prepare page is stage-gated behind DATA_PROFILING; these tests
+    // target the preparation UI directly, so seed the workflow state a real
+    // user would have after completing the profiling stage.
+    // addInitScript (not evaluate): the still-open explore page persists its
+    // own in-memory state on changes and would clobber a one-time seed; the
+    // init script re-seeds before app code runs on every navigation.
+    await page.addInitScript((id) => {
+      localStorage.setItem(
+        'workflowState',
+        JSON.stringify({
+          currentStage: 'data_preparation',
+          completedStages: ['data_loading', 'data_profiling'],
+          stageData: {},
+          datasetId: id,
+          lastUpdated: new Date().toISOString(),
+        })
+      );
+    }, datasetId);
   });
 
   test.afterEach(async ({ cleanupDataset }) => {

--- a/apps/frontend/e2e/workflows/data-preparation.spec.ts
+++ b/apps/frontend/e2e/workflows/data-preparation.spec.ts
@@ -47,7 +47,9 @@ test.describe('Data Preparation Page', () => {
     }
   });
 
-  test('should load data preparation page with dataset info @smoke', async ({ authenticatedPage }) => {
+  // FIXME(#155): /datasets/{id}/prepare throws a client-side exception —
+  // previously masked by the workflow-gating redirect fixed in PR #154
+  test.fixme('should load data preparation page with dataset info @smoke', async ({ authenticatedPage }) => {
     await authenticatedPage.goto(`/datasets/${datasetId}/prepare`);
 
     // Verify page title
@@ -61,7 +63,8 @@ test.describe('Data Preparation Page', () => {
     await expect(authenticatedPage.locator('button:has-text("Back"), a:has-text("Back")')).toBeVisible();
   });
 
-  test('should display view mode toggle buttons @smoke', async ({ authenticatedPage }) => {
+  // FIXME(#155): same client-side crash as above
+  test.fixme('should display view mode toggle buttons @smoke', async ({ authenticatedPage }) => {
     await authenticatedPage.goto(`/datasets/${datasetId}/prepare`);
 
     // Verify both view mode buttons exist

--- a/apps/frontend/e2e/workflows/data-versioning.spec.ts
+++ b/apps/frontend/e2e/workflows/data-versioning.spec.ts
@@ -34,6 +34,8 @@ test.describe('Data Versioning Workflow', () => {
   });
 
   test('should create dataset version @smoke', async ({ authenticatedPage }) => {
+    // Full UI journey is slow on 2-core CI runners (flaky at default timeout)
+    test.slow();
     const versioningPage = new VersioningPage(authenticatedPage);
 
     // Navigate to versions page (goes to /explore/{id} since /datasets/{id}/versions doesn't exist)

--- a/apps/frontend/e2e/workflows/dataset-metadata.spec.ts
+++ b/apps/frontend/e2e/workflows/dataset-metadata.spec.ts
@@ -34,6 +34,9 @@ test.describe('Dataset Metadata Workflow', () => {
   });
 
   test('should upload CSV and create DatasetMetadata @smoke', async ({ authenticatedPage, uploadTestDataset }) => {
+    // Full UI upload journey (upload -> next-step -> explore -> metadata)
+    // exceeds the default timeout on 2-core CI runners
+    test.slow();
     const uploadPage = new UploadPage(authenticatedPage);
     const datasetPage = new DatasetPage(authenticatedPage);
 

--- a/apps/frontend/e2e/workflows/performance.spec.ts
+++ b/apps/frontend/e2e/workflows/performance.spec.ts
@@ -28,7 +28,9 @@ test.afterEach(() => {
 });
 
 test.describe('Performance - Page Load', () => {
-  test('should load dashboard page within 2s @smoke', async ({ authenticatedPage }) => {
+  // FIXME(#157): threshold flakes across identical runs; re-enable once
+  // perf thresholds are calibrated for CI runners
+  test.fixme('should load dashboard page within 2s @smoke', async ({ authenticatedPage }) => {
     const metric = await perfMonitor.measurePageLoad(
       authenticatedPage,
       'Dashboard Load',
@@ -172,7 +174,9 @@ test.describe('Performance - API Response Times', () => {
     expect(metric.value).toBeLessThanOrEqual(30000);
   });
 
-  test('should make single prediction within 100ms @smoke', async ({
+  // FIXME(#156): POST /api/v1/ml/train 404s on valid dataset ids, so no real
+  // model exists to predict against; also #157 for the 100ms threshold
+  test.fixme('should make single prediction within 100ms @smoke', async ({
     request,
     uploadTestDataset,
     trainModel,

--- a/apps/frontend/e2e/workflows/performance.spec.ts
+++ b/apps/frontend/e2e/workflows/performance.spec.ts
@@ -28,8 +28,8 @@ test.afterEach(() => {
 });
 
 test.describe('Performance - Page Load', () => {
-  // FIXME(#157): threshold flakes across identical runs; re-enable once
-  // perf thresholds are calibrated for CI runners
+  // Disabled pending #157: threshold flakes across identical runs;
+  // re-enable once perf thresholds are calibrated for CI runners
   test.fixme('should load dashboard page within 2s @smoke', async ({ authenticatedPage }) => {
     const metric = await perfMonitor.measurePageLoad(
       authenticatedPage,
@@ -174,8 +174,8 @@ test.describe('Performance - API Response Times', () => {
     expect(metric.value).toBeLessThanOrEqual(30000);
   });
 
-  // FIXME(#156): POST /api/v1/ml/train 404s on valid dataset ids, so no real
-  // model exists to predict against; also #157 for the 100ms threshold
+  // Disabled pending #156: POST /api/v1/ml/train 404s on valid dataset ids,
+  // so no real model exists to predict against; also #157 for the threshold
   test.fixme('should make single prediction within 100ms @smoke', async ({
     request,
     uploadTestDataset,

--- a/apps/frontend/e2e/workflows/performance.spec.ts
+++ b/apps/frontend/e2e/workflows/performance.spec.ts
@@ -180,12 +180,19 @@ test.describe('Performance - API Response Times', () => {
     const datasetId = await uploadTestDataset();
     const modelId = await trainModel(datasetId, 'purchased');
 
+    // Direct backend call (Next.js does not proxy /api/v1); SKIP_AUTH backend
+    // still requires an Authorization header for HTTPBearer.
+    const apiBase = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000/api/v1';
+
     const metric = await perfMonitor.measureApiCall(
       'Single Prediction API',
       async () => {
-        const response = await request.post(`/api/v1/models/${modelId}/predict`, {
+        // Real prediction endpoint lives under /api/v1/ml and takes a list
+        // of records (PredictRequest.data)
+        const response = await request.post(`${apiBase}/ml/${modelId}/predict`, {
+          headers: { Authorization: 'Bearer e2e-test-token' },
           data: {
-            features: { age: 30, income: 60000 },
+            data: [{ age: 30, income: 60000 }],
           },
         });
         expect(response.ok()).toBeTruthy();

--- a/apps/frontend/e2e/workflows/predict.spec.ts
+++ b/apps/frontend/e2e/workflows/predict.spec.ts
@@ -94,6 +94,8 @@ test.describe('Single Prediction Workflow', () => {
   });
 
   test('should make single prediction with valid feature values @smoke', async ({ authenticatedPage }) => {
+    // Full prediction UI journey is slow on 2-core CI runners
+    test.slow();
     const predictPage = new PredictPage(authenticatedPage);
 
     await predictPage.goto('/predict');

--- a/apps/frontend/e2e/workflows/transform.spec.ts
+++ b/apps/frontend/e2e/workflows/transform.spec.ts
@@ -51,6 +51,8 @@ test.describe('Data Transformation Workflow', () => {
   });
 
   test('should apply one-hot encoding transformation @smoke', async ({ authenticatedPage }) => {
+    // Full upload + transformation UI journey is slow on 2-core CI runners
+    test.slow();
     const transformPage = new TransformPage(authenticatedPage);
 
     await transformPage.goto(`/datasets/${datasetId}/prepare`);
@@ -98,6 +100,8 @@ test.describe('Data Transformation Workflow', () => {
   });
 
   test('should apply standard scaling transformation @smoke', async ({ authenticatedPage }) => {
+    // Full upload + transformation UI journey is slow on 2-core CI runners
+    test.slow();
     const transformPage = new TransformPage(authenticatedPage);
 
     await transformPage.goto(`/datasets/${datasetId}/prepare`);

--- a/apps/frontend/e2e/workflows/transformation-config.spec.ts
+++ b/apps/frontend/e2e/workflows/transformation-config.spec.ts
@@ -39,6 +39,8 @@ test.describe('Transformation Config Workflow', () => {
   });
 
   test('should apply one-hot encoding transformation @smoke', async ({ authenticatedPage }) => {
+    // Full upload + transformation UI journey is slow on 2-core CI runners
+    test.slow();
     const transformPage = new TransformPage(authenticatedPage);
 
     await transformPage.goto(`/datasets/${datasetId}/prepare`);

--- a/apps/frontend/e2e/workflows/upload.spec.ts
+++ b/apps/frontend/e2e/workflows/upload.spec.ts
@@ -92,7 +92,8 @@ test.describe('Dataset Upload Workflow', () => {
     // Verify success message is displayed
     await expect(authenticatedPage.locator('text=/File uploaded successfully/i')).toBeVisible();
 
-    // Get dataset ID from URL or page
+    // Navigate to the explore page via the Next Step button, then read the ID
+    await uploadPage.continueToExplore();
     const datasetId = await uploadPage.getDatasetId();
 
     // Verify metadata in database via API (graceful - API may not exist)
@@ -186,10 +187,12 @@ test.describe('Dataset Upload Workflow', () => {
     await uploadButton.waitFor({ state: 'visible', timeout: 5000 });
     await uploadButton.click();
 
-    // Verify progress indicator appears (button text changes during upload)
+    // Verify progress indicator appears (button text changes during upload).
+    // Target the button itself — a bare text locator also matches the static
+    // page copy ("Start by uploading...") and trips strict mode.
     await expect(
-      authenticatedPage.locator('text=/Scanning|Uploading|Processing/i')
-    ).toBeVisible({ timeout: 5000 });
+      authenticatedPage.getByTestId('upload-button')
+    ).toHaveText(/Scanning|Uploading|Processing/i, { timeout: 5000 });
 
     // Wait for completion
     await uploadPage.waitForUploadComplete();

--- a/apps/frontend/lib/contexts/WorkflowContext.tsx
+++ b/apps/frontend/lib/contexts/WorkflowContext.tsx
@@ -25,6 +25,10 @@ export function WorkflowProvider({
     ...initialState,
     datasetId: initialDatasetId
   });
+  // Pages must not run stage-gating redirects until state is restored:
+  // consumer effects fire before this provider's hydration effect, so an
+  // early canAccessStage() check always sees an empty completedStages set.
+  const [isHydrated, setIsHydrated] = useState(false);
   const router = useRouter();
   const pathname = usePathname();
 
@@ -41,7 +45,7 @@ export function WorkflowProvider({
           // Check if the saved state is recent (within 24 hours)
           const stateAge = parsed.lastUpdated ? Date.now() - new Date(parsed.lastUpdated).getTime() : Infinity;
           const oneDayMs = 24 * 60 * 60 * 1000;
-          
+
           if (stateAge < oneDayMs) {
             setState({
               ...parsed,
@@ -58,6 +62,7 @@ export function WorkflowProvider({
         }
       }
     }
+    setIsHydrated(true);
   }, [initialDatasetId]);
 
   // Save workflow state to localStorage when it changes
@@ -248,6 +253,7 @@ export function WorkflowProvider({
 
   const value: WorkflowContextType = {
     state,
+    isHydrated,
     canAccessStage,
     completeStage,
     setCurrentStage,

--- a/apps/frontend/lib/types/workflow.ts
+++ b/apps/frontend/lib/types/workflow.ts
@@ -33,6 +33,12 @@ export interface WorkflowState {
 
 export interface WorkflowContextType {
   state: WorkflowState;
+  /**
+   * True once workflow state has been restored from storage. Stage-gating
+   * redirects must wait for this — checking canAccessStage before hydration
+   * always sees an empty state and wrongly kicks the user back to /upload.
+   */
+  isHydrated: boolean;
   canAccessStage: (stage: WorkflowStage) => boolean;
   completeStage: (stage: WorkflowStage, data?: any) => void;
   setCurrentStage: (stage: WorkflowStage) => void;

--- a/apps/frontend/playwright.config.ts
+++ b/apps/frontend/playwright.config.ts
@@ -17,8 +17,11 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */
   retries: process.env.CI ? 2 : 0,
-  /* Use 4 workers on CI for better performance (GitHub Actions has 2 cores, 4 workers is optimal) */
-  workers: process.env.CI ? 4 : undefined,
+  /* 2 workers on CI: GitHub runners have 2 cores and each test drives the
+     full stack (Next dev server + FastAPI + MinIO + MongoDB). 4 workers
+     caused cascading navigation/upload timeouts once uploads actually
+     started exercising real storage. */
+  workers: process.env.CI ? 2 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: 'html',
 

--- a/apps/frontend/test-e2e.sh
+++ b/apps/frontend/test-e2e.sh
@@ -175,21 +175,23 @@ export BASE_URL=http://localhost:${TEST_PORT}
 export PORT=${TEST_PORT}
 export NEXTAUTH_URL=http://localhost:${TEST_PORT}
 
-# Run Playwright with all arguments passed to this script
-npx playwright test "$@"
-
-# Capture exit code
-EXIT_CODE=$?
+# Run Playwright with all arguments passed to this script.
+# Capture the exit code without letting `set -e` abort the script —
+# cleanup below must always run, and the exit code must propagate.
+EXIT_CODE=0
+npx playwright test "$@" || EXIT_CODE=$?
 
 # Cleanup: Kill both servers
 echo ""
 echo -e "${YELLOW}=== Cleaning up ===${NC}"
+# `|| true` keeps `set -e` from turning an already-exited process
+# (kill returns non-zero) into a spurious script failure on green runs
 if [ ! -z "$FRONTEND_PID" ]; then
-  kill $FRONTEND_PID 2>/dev/null
+  kill $FRONTEND_PID 2>/dev/null || true
   echo "Stopped frontend server (PID: $FRONTEND_PID)"
 fi
 if [ ! -z "$BACKEND_PID" ]; then
-  kill $BACKEND_PID 2>/dev/null
+  kill $BACKEND_PID 2>/dev/null || true
   echo "Stopped backend server (PID: $BACKEND_PID)"
 fi
 

--- a/apps/frontend/test-e2e.sh
+++ b/apps/frontend/test-e2e.sh
@@ -91,9 +91,13 @@ export SKIP_AUTH=true
 export AWS_S3_BUCKET_NAME=${AWS_S3_BUCKET_NAME:-test-bucket}
 export AWS_BUCKET_NAME=${AWS_BUCKET_NAME:-test-bucket}
 export AWS_S3_BUCKET=${AWS_S3_BUCKET:-test-bucket}
+export S3_BUCKET=${S3_BUCKET:-test-bucket}
 export AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-test-access-key-id}
 export AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-test-secret-access-key}
 export AWS_REGION=${AWS_REGION:-us-east-1}
+if [ -n "${AWS_ENDPOINT_URL:-}" ]; then
+  export AWS_ENDPOINT_URL
+fi
 
 # OpenAI API configuration (test/mock value for E2E)
 export OPENAI_API_KEY=${OPENAI_API_KEY:-sk-test-dummy-key-for-e2e-testing}

--- a/apps/frontend/test-e2e.sh
+++ b/apps/frontend/test-e2e.sh
@@ -86,8 +86,11 @@ export NEXTAUTH_SECRET=${NEXTAUTH_SECRET:-test-secret-for-e2e-only-not-for-produ
 export SKIP_AUTH=true
 
 # AWS S3 configuration (test/mock values for E2E)
+# When AWS_ENDPOINT_URL is set (e.g. http://localhost:9000 for MinIO in CI),
+# the backend routes all S3 calls to that endpoint instead of real AWS.
 export AWS_S3_BUCKET_NAME=${AWS_S3_BUCKET_NAME:-test-bucket}
 export AWS_BUCKET_NAME=${AWS_BUCKET_NAME:-test-bucket}
+export AWS_S3_BUCKET=${AWS_S3_BUCKET:-test-bucket}
 export AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-test-access-key-id}
 export AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-test-secret-access-key}
 export AWS_REGION=${AWS_REGION:-us-east-1}

--- a/apps/frontend/test-e2e.sh
+++ b/apps/frontend/test-e2e.sh
@@ -92,12 +92,17 @@ export AWS_S3_BUCKET_NAME=${AWS_S3_BUCKET_NAME:-test-bucket}
 export AWS_BUCKET_NAME=${AWS_BUCKET_NAME:-test-bucket}
 export AWS_S3_BUCKET=${AWS_S3_BUCKET:-test-bucket}
 export S3_BUCKET=${S3_BUCKET:-test-bucket}
-export AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-test-access-key-id}
-export AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-test-secret-access-key}
-export AWS_REGION=${AWS_REGION:-us-east-1}
 if [ -n "${AWS_ENDPOINT_URL:-}" ]; then
+  # Real S3-compatible storage (MinIO/LocalStack): credentials must NOT start
+  # with "test-" or S3Service enters no-op mock mode instead of using MinIO.
   export AWS_ENDPOINT_URL
+  export AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-minioadmin}
+  export AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-minioadmin}
+else
+  export AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-test-access-key-id}
+  export AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-test-secret-access-key}
 fi
+export AWS_REGION=${AWS_REGION:-us-east-1}
 
 # OpenAI API configuration (test/mock value for E2E)
 export OPENAI_API_KEY=${OPENAI_API_KEY:-sk-test-dummy-key-for-e2e-testing}


### PR DESCRIPTION
## Summary
Implements #147 ([P1.1]): E2E smoke tests run against a real S3-compatible store (MinIO) in CI instead of failing on dummy AWS credentials.

- **Backend**: single `create_s3_client()` factory honoring optional `AWS_ENDPOINT_URL` (MinIO/LocalStack), adopted at all 9 boto3 client sites; path-style addressing pinned for custom endpoints
- **Backend**: new `parse_s3_url()` handles every persisted URL shape (`s3://`, amazonaws + presigned query strings, endpoint-style, exact-origin endpoint matching) — adopted by all S3-URL consumers; all security validations preserved with new tests
- **Frontend (app)**: workflow-state hydration fix — `WorkflowContext.isHydrated` gate stops every hard navigation/refresh of `/explore/{id}` and `/datasets/{id}/prepare` from spuriously redirecting to `/upload` (real UX bug); upload "Next Step" button gets a testid
- **CI**: `smoke-tests.yml` starts MinIO via `docker run` (GH Actions `services:` can't override a container command), creates `test-bucket` with the preinstalled AWS CLI, and switches env to `minioadmin` + `AWS_ENDPOINT_URL`
- **E2E**: fixture flow aligned with the app (post-upload "Next Step" click); `trainModel`/perf tests target the real backend origin + `/api/v1/ml` endpoints; SecurityTester waits for redirect URL; `test-e2e.sh` exit-code/cleanup bugs fixed
- **Test infra (pre-existing fixes)**: circuit-breaker state leak across tests (8 failures on `main`) fixed via `CircuitBreaker.reset()` + autouse fixture; deterministic `ValueError`s no longer retried/counted (malicious input could open the breaker and DoS legitimate downloads)

## Demo Evidence (local full-stack: MinIO + MongoDB + backend + frontend)
| Criterion | Outcome evidence | Status |
|---|---|---|
| No real AWS credentials | 116 objects written to MinIO `test-bucket` by E2E uploads; backend logs `POST /upload/secure -> 200` with `http://localhost:9000/test-bucket/{uuid}.csv`; presigned URL round-trip HTTP 200; only `minioadmin` creds in env | VERIFIED |
| Auth redirect test | `production-readiness` auth spec passed every run (server-side `middleware.ts` redirect) | VERIFIED |
| All 27 smoke tests | **23 passed, 4 `test.fixme` (suite exit 0)** — vs 7/27 on `main`. The 4 are pre-existing non-S3 bugs unmasked by this PR, tracked in #155/#156/#157 (approved scope decision) | VERIFIED with tracked exceptions |

## Test Plan
- [x] TDD unit tests: endpoint wiring, URL construction, `parse_s3_url` (9 shapes incl. lookalike-host rejection), endpoint-URL security validation
- [x] Backend unit suites green (exit 0); frontend Jest 840/840
- [x] Diff coverage 95% on changed lines (>=85% gate)
- [x] Lint clean on all changed files
- [x] Internal review (advisory): Major S3_BUCKET finding fixed
- [x] Cross-family review: codex x2 rounds — all P1s fixed (URL-shape consumers via `parse_s3_url`; path-style pinned; column_stats placeholder removed); one claim empirically rebutted against live MinIO
- [x] CodeRabbit findings (4) verified & fixed: URL leak in error detail, placeholder-URL 400 regression, parameterized logging, timeout-only catch
- [x] Mutation sanity: 4 mutations, each failed its covering test

## Known Limitations / Intentionally Deferred
- **4 smoke tests `test.fixme`** with tracked issues: #155 (`/datasets/{id}/prepare` client-side crash — pre-existing, previously masked by the gating bug), #156 (`/api/v1/ml/train` 404 on valid dataset ids + fixture mock-id fallback), #157 (perf threshold flakiness)
- Workflow-gating hydration fix applied to the two pages exercised by smoke tests; other gated pages (`/model`, `/predict`, ...) share the latent pattern — follow-up alongside #87/#88 (P2.4/P3.4)
- `main.py` loads `.env` with `override=True` (local `.env` beats exported env vars) — surfaced during local verification, out of scope
- `tests/test_api/test_user_data.py` lifespan-fixture errors are pre-existing on `main` (verified in a clean worktree)
- Triple bucket env-var naming (`AWS_BUCKET_NAME`/`AWS_S3_BUCKET`/`S3_BUCKET`) documented in workflow; consolidation tracked with #150

## Implementation Notes
Deviations from the Traycer plan on the issue: GH Actions `services:` blocks don't support `command:` (MinIO via `docker run` step); `mc` replaced by preinstalled AWS CLI; scope extended from 2 files to all 9 boto3 sites; auth smoke test was already fixed by #148 (SecurityTester change is hardening).

Closes #147


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional S3-compatible endpoint support (AWS_ENDPOINT_URL) and centralized S3 client/URL parsing.

* **Bug Fixes**
  * Avoided premature redirects by waiting for workflow hydration; improved S3 URL parsing/error handling and safer logging for upload/preview flows.

* **Tests**
  * Added and updated unit/integration/e2e tests for endpoint-style S3, circuit-breaker isolation, and e2e flows.

* **Documentation**
  * Updated env examples and backend docs to document optional S3 endpoint configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->