### PR TITLE
Harden upload preview parser

### DIFF
--- a/apps/frontend/__tests__/app/api/upload/route.test.ts
+++ b/apps/frontend/__tests__/app/api/upload/route.test.ts
@@ -37,7 +37,35 @@ function makeRequest(blob?: Blob, filename?: string): Request {
   return new Request('http://localhost/api/upload', { method: 'POST', body: formData })
 }
 
+function makeRequestWithFile(file: {
+  name: string
+  size: number
+  arrayBuffer: jest.Mock<Promise<ArrayBuffer>, []>
+}): Request {
+  return {
+    formData: async () => new Map([['file', file]]),
+  } as unknown as Request
+}
+
 describe('POST /api/upload', () => {
+  describe('file size guard', () => {
+    it('returns 413 before reading an oversized preview file into memory', async () => {
+      const file = {
+        name: 'oversized.csv',
+        size: 100 * 1024 * 1024 + 1,
+        arrayBuffer: jest.fn<Promise<ArrayBuffer>, []>().mockResolvedValue(new ArrayBuffer(0)),
+      }
+
+      const res = await POST(makeRequestWithFile(file))
+
+      expect(res.status).toBe(413)
+      expect(await res.json()).toEqual({
+        error: 'File exceeds the 100MB preview limit. Use chunked upload for larger files.',
+      })
+      expect(file.arrayBuffer).not.toHaveBeenCalled()
+    })
+  })
+
   describe('.xlsx parsing', () => {
     it('parses headers and preview rows from an .xlsx file', async () => {
       const blob = await xlsxBlob([
@@ -71,6 +99,48 @@ describe('POST /api/upload', () => {
       expect(body.previewData).toHaveLength(10)
       expect(body.previewData[0]).toEqual(['v0'])
       expect(body.previewData[9]).toEqual(['v9'])
+    })
+
+    it('collects preview rows with bounded indexed reads instead of walking the whole sheet', async () => {
+      const file = {
+        name: 'many-rows.xlsx',
+        size: 1024,
+        arrayBuffer: jest.fn<Promise<ArrayBuffer>, []>().mockResolvedValue(new ArrayBuffer(8)),
+      }
+      const worksheet = {
+        rowCount: 50000,
+        columnCount: 1,
+        dimensions: { left: 1, right: 1 },
+        getRow: jest.fn((rowNumber: number) => ({
+          values: [undefined, rowNumber === 1 ? 'col' : `v${rowNumber - 2}`],
+        })),
+        eachRow: jest.fn(() => {
+          throw new Error('eachRow should not be used for bounded previews')
+        }),
+      }
+      const workbook = {
+        xlsx: { load: jest.fn().mockResolvedValue(undefined) },
+        worksheets: [worksheet],
+      }
+      const workbookSpy = jest
+        .spyOn(ExcelJS, 'Workbook')
+        .mockImplementation(() => workbook as unknown as ExcelJS.Workbook)
+
+      try {
+        const res = await POST(makeRequestWithFile(file))
+        expect(res.status).toBe(200)
+
+        const body = await res.json()
+        expect(body.headers).toEqual(['col'])
+        expect(body.previewData).toHaveLength(10)
+        expect(body.previewData[0]).toEqual(['v0'])
+        expect(body.previewData[9]).toEqual(['v9'])
+        expect(worksheet.eachRow).not.toHaveBeenCalled()
+        expect(worksheet.getRow).toHaveBeenCalledTimes(11)
+        expect(Math.max(...worksheet.getRow.mock.calls.map(([rowNumber]) => rowNumber))).toBe(11)
+      } finally {
+        workbookSpy.mockRestore()
+      }
     })
 
     it('normalizes complex cell types (date, formula, hyperlink, rich text) to primitives', async () => {

--- a/apps/frontend/__tests__/app/api/upload/route.test.ts
+++ b/apps/frontend/__tests__/app/api/upload/route.test.ts
@@ -64,6 +64,22 @@ describe('POST /api/upload', () => {
       })
       expect(file.arrayBuffer).not.toHaveBeenCalled()
     })
+
+    it('accepts a preview file exactly at the 100MB limit', async () => {
+      const file = {
+        name: 'limit.csv',
+        size: 100 * 1024 * 1024,
+        arrayBuffer: jest.fn<Promise<ArrayBuffer>, []>().mockResolvedValue(
+          new TextEncoder().encode('name\nAlice\n').buffer as ArrayBuffer
+        ),
+      }
+
+      const res = await POST(makeRequestWithFile(file))
+
+      expect(res.status).toBe(200)
+      expect((await res.json()).previewData).toEqual([['Alice']])
+      expect(file.arrayBuffer).toHaveBeenCalledTimes(1)
+    })
   })
 
   describe('.xlsx parsing', () => {
@@ -138,6 +154,42 @@ describe('POST /api/upload', () => {
         expect(worksheet.eachRow).not.toHaveBeenCalled()
         expect(worksheet.getRow).toHaveBeenCalledTimes(11)
         expect(Math.max(...worksheet.getRow.mock.calls.map(([rowNumber]) => rowNumber))).toBe(11)
+      } finally {
+        workbookSpy.mockRestore()
+      }
+    })
+
+    it('does not read past the worksheet row count for small sheets', async () => {
+      const file = {
+        name: 'small.xlsx',
+        size: 1024,
+        arrayBuffer: jest.fn<Promise<ArrayBuffer>, []>().mockResolvedValue(new ArrayBuffer(8)),
+      }
+      const worksheet = {
+        rowCount: 3,
+        columnCount: 1,
+        dimensions: { left: 1, right: 1 },
+        getRow: jest.fn((rowNumber: number) => ({
+          values: [undefined, rowNumber === 1 ? 'col' : `v${rowNumber - 2}`],
+        })),
+      }
+      const workbook = {
+        xlsx: { load: jest.fn().mockResolvedValue(undefined) },
+        worksheets: [worksheet],
+      }
+      const workbookSpy = jest
+        .spyOn(ExcelJS, 'Workbook')
+        .mockImplementation(() => workbook as unknown as ExcelJS.Workbook)
+
+      try {
+        const res = await POST(makeRequestWithFile(file))
+        expect(res.status).toBe(200)
+
+        const body = await res.json()
+        expect(body.headers).toEqual(['col'])
+        expect(body.previewData).toEqual([['v0'], ['v1']])
+        expect(worksheet.getRow).toHaveBeenCalledTimes(3)
+        expect(Math.max(...worksheet.getRow.mock.calls.map(([rowNumber]) => rowNumber))).toBe(3)
       } finally {
         workbookSpy.mockRestore()
       }

--- a/apps/frontend/app/api/upload/route.ts
+++ b/apps/frontend/app/api/upload/route.ts
@@ -6,6 +6,10 @@ import { parse } from 'csv-parse/sync'
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
 
+const PREVIEW_UPLOAD_MAX_BYTES = 100 * 1024 * 1024
+const PREVIEW_UPLOAD_MAX_LABEL = '100MB'
+const PREVIEW_ROW_LIMIT = 11 // header + 10 preview rows
+
 type CellPrimitive = string | number | boolean | null
 
 /**
@@ -40,6 +44,13 @@ export async function POST(request: Request) {
 
     if (!file) {
       return NextResponse.json({ error: 'No file provided' }, { status: 400 })
+    }
+
+    if (file.size > PREVIEW_UPLOAD_MAX_BYTES) {
+      return NextResponse.json(
+        { error: `File exceeds the ${PREVIEW_UPLOAD_MAX_LABEL} preview limit. Use chunked upload for larger files.` },
+        { status: 413 }
+      )
     }
 
     // Read the file content
@@ -96,23 +107,22 @@ export async function POST(request: Request) {
 
       // Collect rows that carry content, dropping fully-empty separator rows so
       // they don't consume preview slots. We only need 11 rows (header + 10
-      // preview); eachRow can't break, but returning early skips per-row work
-      // once we have enough.
+      // preview), so read rows by index and stop once the preview is full.
       const rows: CellPrimitive[][] = []
-      worksheet.eachRow({ includeEmpty: true }, (row) => {
-        if (rows.length >= 11) return
+      for (let rowNumber = 1; rowNumber <= worksheet.rowCount && rows.length < PREVIEW_ROW_LIMIT; rowNumber++) {
+        const row = worksheet.getRow(rowNumber)
         const rowData = toRow(row.values as unknown[])
         if (rowData.some((cell) => cell !== null)) {
           rows.push(rowData)
         }
-      })
+      }
 
       if (rows.length === 0) {
         return NextResponse.json({ error: 'File is empty' }, { status: 400 })
       }
 
       headers = rows[0].map((cell) => (cell === null ? '' : String(cell)))
-      previewData = rows.slice(1, 11)
+      previewData = rows.slice(1, PREVIEW_ROW_LIMIT)
     } else {
       return NextResponse.json(
         { error: 'Unsupported file type' },

--- a/apps/frontend/app/api/upload/route.ts
+++ b/apps/frontend/app/api/upload/route.ts
@@ -7,7 +7,7 @@ export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
 
 const PREVIEW_UPLOAD_MAX_BYTES = 100 * 1024 * 1024
-const PREVIEW_UPLOAD_MAX_LABEL = '100MB'
+const PREVIEW_UPLOAD_MAX_LABEL = `${PREVIEW_UPLOAD_MAX_BYTES / (1024 * 1024)}MB`
 const PREVIEW_ROW_LIMIT = 11 // header + 10 preview rows
 
 type CellPrimitive = string | number | boolean | null
@@ -46,6 +46,9 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: 'No file provided' }, { status: 400 })
     }
 
+    // request.formData() has already parsed the multipart body; proxy/platform
+    // request-size limits remain the real memory boundary. This route guard
+    // prevents allocating another ArrayBuffer for oversized preview parsing.
     if (file.size > PREVIEW_UPLOAD_MAX_BYTES) {
       return NextResponse.json(
         { error: `File exceeds the ${PREVIEW_UPLOAD_MAX_LABEL} preview limit. Use chunked upload for larger files.` },


### PR DESCRIPTION
## Summary
Implements #173: Harden /api/upload preview parser: file-size guard + large-file row reading

- Adds a 100MB pre-parse guard for the preview upload route and returns 413 before reading oversized files into memory.
- Replaces ExcelJS eachRow preview collection with bounded indexed getRow reads that stop after header + 10 preview rows.
- Extends route tests to cover the 413 guard, no arrayBuffer call on oversized files, and bounded Excel preview row reads.

## Acceptance Criteria
- [x] Oversized preview files are rejected before file.arrayBuffer()
- [x] Oversized preview files return HTTP 413
- [x] Excel preview row collection avoids walking the whole worksheet after preview rows are collected
- [x] Existing CSV/XLSX preview parsing behavior remains covered

## Test Plan
- [x] npm test -- __tests__/app/api/upload/route.test.ts --runInBand
- [x] npm run type-check
- [x] npm run lint
- [x] npm test -- --runInBand

## Implementation Notes
The preview parser limit is 100MB to match the upload UI and backend API docs. The 100GB references are treated as chunked/distributed upload scope, distinct from this Next.js preview parser.

Closes #173

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added 100MB maximum upload size limit; oversized files return an error with guidance for chunked uploads

* **Bug Fixes**
  * Improved Excel file preview generation performance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->