### PR TITLE
feat(ml): AutoML training job status, progress & model comparison (#75)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,12 @@ This is a Narrative Modeling App - an AI-guided platform that democratizes machi
 - AWS S3 for file storage
 - Background tasks for AI processing
 
+#### AutoML training (issue #75)
+- `POST /api/v1/ml/train` runs real AutoML training in a FastAPI `BackgroundTasks` job and creates a `TrainingJob` (`app/models/training_job.py`, registered in `app/models/registry.py`).
+- `GET /api/v1/ml/{model_id}/status` returns live progress, the ranked model comparison, rule-based algorithm recommendations, and a plain-language best-model explanation; failures are recorded on the job (status `failed` + `error`) instead of being silently re-raised.
+- The engine (`app/services/model_training/automl_engine.py`) applies basic class-imbalance handling (`class_weight="balanced"` when the majority/minority ratio exceeds 2:1) and accepts a `progress_callback`. Result summaries live in `app/services/model_training/comparison.py`.
+- **Out of scope / deferred:** real-time WebSocket progress (#76), job cancellation, time-series (ARIMA/Prophet), SMOTE resampling, Quick/Comprehensive training modes (#101), hyperparameter tuning (#77).
+
 ### MCP Server
 - Located in `apps/mcp/`
 - FastMCP framework

--- a/apps/backend/app/api/routes/model_training.py
+++ b/apps/backend/app/api/routes/model_training.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel
 import pandas as pd
 import numpy as np
 import io
+import uuid
 from datetime import datetime, timezone
 import logging
 
@@ -115,8 +116,11 @@ async def train_model(
     if not user_data:
         raise HTTPException(status_code=404, detail="Dataset not found")
 
-    # Create a temporary model entry
-    model_id = f"model_{datetime.now(timezone.utc).strftime('%Y%m%d_%H%M%S')}"
+    # Create a unique model id. A short uuid suffix avoids collisions between
+    # requests made within the same second (the id is the lookup key for the
+    # TrainingJob status endpoint, so it must be unique).
+    timestamp = datetime.now(timezone.utc).strftime('%Y%m%d_%H%M%S')
+    model_id = f"model_{timestamp}_{uuid.uuid4().hex[:8]}"
 
     # Persist a pending TrainingJob synchronously so the status endpoint can be
     # polled immediately (before the background task has had a chance to run).
@@ -171,6 +175,12 @@ async def train_model_task(
     try:
         logger.info(f"Starting model training for dataset {request.dataset_id}")
 
+        # Mark RUNNING at task entry so the status reflects real activity during
+        # the (potentially slow) S3 download and dataset parse, not just model fit.
+        if training_job:
+            training_job.mark_started()
+            await training_job.save()
+
         # Extract S3 file key (parse_s3_url handles all persisted URL shapes)
         _, file_key = parse_s3_url(user_data.s3_url)
 
@@ -194,10 +204,6 @@ async def train_model_task(
             df = pd.read_parquet(file_io)
         else:
             raise ValueError(f"Unsupported file type: {user_data.file_type}")
-
-        if training_job:
-            training_job.mark_started()
-            await training_job.save()
 
         # Create feature engineering config
         feature_config = None

--- a/apps/backend/app/api/routes/model_training.py
+++ b/apps/backend/app/api/routes/model_training.py
@@ -14,6 +14,8 @@ import logging
 from app.auth.nextauth_auth import get_current_user_id
 from app.models.user_data import UserData
 from app.models.ml_model import MLModel
+from app.models.batch_job import JobStatus
+from app.models.training_job import TrainingJob, ModelComparisonEntry
 from app.services.s3_service import get_file_from_s3
 from app.utils.s3 import parse_s3_url
 from app.services.model_storage import ModelStorageService
@@ -21,6 +23,12 @@ from app.services.model_training import (
     AutoMLEngine,
     FeatureEngineeringConfig
 )
+from app.services.model_training.algorithm_selector import AlgorithmSelector
+from app.services.model_training.comparison import (
+    build_best_model_explanation,
+    build_data_profile,
+)
+from dataclasses import asdict
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
@@ -72,6 +80,23 @@ class PredictResponse(BaseModel):
     model_info: Dict[str, Any]
 
 
+class TrainingStatusResponse(BaseModel):
+    """Status and results of an async training job"""
+    model_id: str
+    status: str  # pending | running | completed | failed
+    progress: float  # 0.0 - 1.0
+    current_algorithm: Optional[str] = None
+    completed_algorithms: int = 0
+    total_algorithms: int = 0
+    metrics: Dict[str, Any] = {}
+    model_comparison: List[Dict[str, Any]] = []
+    algorithm_recommendations: List[Dict[str, Any]] = []
+    best_model_id: Optional[str] = None
+    best_algorithm: Optional[str] = None
+    explanation: Optional[str] = None
+    error: Optional[str] = None
+
+
 @router.post("/train", response_model=TrainModelResponse)
 async def train_model(
     request: TrainModelRequest,
@@ -89,10 +114,21 @@ async def train_model(
     
     if not user_data:
         raise HTTPException(status_code=404, detail="Dataset not found")
-    
+
     # Create a temporary model entry
     model_id = f"model_{datetime.now(timezone.utc).strftime('%Y%m%d_%H%M%S')}"
-    
+
+    # Persist a pending TrainingJob synchronously so the status endpoint can be
+    # polled immediately (before the background task has had a chance to run).
+    training_job = TrainingJob(
+        model_id=model_id,
+        user_id=current_user_id,
+        dataset_id=request.dataset_id,
+        target_column=request.target_column,
+        status=JobStatus.PENDING,
+    )
+    await training_job.insert()
+
     # Start training in background
     background_tasks.add_task(
         train_model_task,
@@ -101,11 +137,11 @@ async def train_model(
         current_user_id,
         model_id
     )
-    
+
     return TrainModelResponse(
         model_id=model_id,
         status="training",
-        message="Model training started. Check status endpoint for progress."
+        message="Model training started. Poll GET /ml/{model_id}/status for progress."
     )
 
 
@@ -115,7 +151,23 @@ async def train_model_task(
     user_id: str,
     model_id: str
 ):
-    """Background task for model training"""
+    """Background task for model training.
+
+    Tracks lifecycle on the ``TrainingJob`` document (created by ``train_model``)
+    so that ``GET /ml/{model_id}/status`` reflects real progress, the model
+    comparison, the algorithm recommendations, and any failure.
+    """
+    # Best-effort lookup of the tracking job; training proceeds even if it is
+    # missing or the lookup fails (e.g. DB unavailable).
+    try:
+        training_job = await TrainingJob.find_one(
+            TrainingJob.model_id == model_id,
+            TrainingJob.user_id == user_id,
+        )
+    except Exception as exc:
+        logger.warning(f"Could not load TrainingJob {model_id}: {exc}")
+        training_job = None
+
     try:
         logger.info(f"Starting model training for dataset {request.dataset_id}")
 
@@ -142,12 +194,16 @@ async def train_model_task(
             df = pd.read_parquet(file_io)
         else:
             raise ValueError(f"Unsupported file type: {user_data.file_type}")
-        
+
+        if training_job:
+            training_job.mark_started()
+            await training_job.save()
+
         # Create feature engineering config
         feature_config = None
         if request.feature_config:
             feature_config = FeatureEngineeringConfig(**request.feature_config)
-        
+
         # Create AutoML engine
         training_config = request.training_config or {}
         engine = AutoMLEngine(
@@ -156,10 +212,23 @@ async def train_model_task(
             test_size=training_config.get("test_size", 0.2),
             random_state=42
         )
-        
+
+        # Progress callback persists per-algorithm progress to the TrainingJob.
+        async def on_progress(completed: int, total: int, current: Optional[str]):
+            if not training_job:
+                return
+            training_job.update_progress(
+                completed_algorithms=completed,
+                total_algorithms=total,
+                current_algorithm=current,
+            )
+            await training_job.save()
+
         # Run AutoML
-        result = await engine.run(df, request.target_column, feature_config)
-        
+        result = await engine.run(
+            df, request.target_column, feature_config, progress_callback=on_progress
+        )
+
         # Prepare metadata
         model_metadata = {
             "name": request.name or f"{result.best_model.name} on {user_data.filename}",
@@ -176,7 +245,7 @@ async def train_model_task(
             },
             "training_config": training_config
         }
-        
+
         # Save model with the pre-generated model_id
         storage_service = ModelStorageService()
         ml_model = await storage_service.save_model(
@@ -187,13 +256,57 @@ async def train_model_task(
             model_metadata,
             model_id=model_id
         )
-        
+
+        # Persist comparison + recommendations + best-model explanation on the job.
+        if training_job:
+            comparison = [
+                ModelComparisonEntry(**row)
+                for row in result.metadata.get("model_comparison", [])
+            ]
+            recommendations = await _build_algorithm_recommendations(
+                df, request.target_column, result.problem_type
+            )
+            explanation = build_best_model_explanation(
+                result.best_model, result.all_models, result.problem_type
+            )
+            training_job.mark_completed(
+                best_model_id=ml_model.model_id,
+                best_algorithm=result.best_model.name,
+                best_model_explanation=explanation,
+                model_comparison=comparison,
+                algorithm_recommendations=recommendations,
+                metrics=model_metadata["metrics"],
+            )
+            await training_job.save()
+
         logger.info(f"Model training completed: {ml_model.model_id}")
-        
+
     except Exception as e:
         logger.error(f"Error training model: {str(e)}")
-        # In production, you'd want to update a status in the database
-        raise
+        if training_job:
+            training_job.mark_failed(str(e))
+            await training_job.save()
+        # Swallow here: this runs as a fire-and-forget BackgroundTask, so the
+        # failure is recorded on the TrainingJob (above) rather than re-raised
+        # into a context where nothing can handle it.
+
+
+async def _build_algorithm_recommendations(
+    df: pd.DataFrame, target_column: str, problem_type
+) -> List[Dict[str, Any]]:
+    """Build plain-language algorithm recommendations for a dataset.
+
+    Uses the rule-based ``AlgorithmSelector`` (no LLM/API call). Returns an empty
+    list and logs on any failure so recommendations never break training.
+    """
+    try:
+        profile = build_data_profile(df, target_column, problem_type)
+        selector = AlgorithmSelector()
+        recommendations = await selector.select_algorithms(problem_type, profile, {})
+        return [asdict(rec) for rec in recommendations]
+    except Exception as exc:
+        logger.warning(f"Failed to build algorithm recommendations: {exc}")
+        return []
 
 
 @router.get("/", response_model=List[ModelInfo])
@@ -228,6 +341,44 @@ async def list_models(
         )
         for model in models
     ]
+
+
+@router.get("/{model_id}/status", response_model=TrainingStatusResponse)
+async def get_training_status(
+    model_id: str,
+    current_user_id: str = Depends(get_current_user_id)
+):
+    """
+    Get the status, progress, and results of an async training job.
+
+    The frontend polls this endpoint after starting training. While training is
+    in progress it returns live per-algorithm progress; on completion it returns
+    the model comparison, algorithm recommendations, and the best-model
+    explanation; on failure it returns the error message.
+    """
+    job = await TrainingJob.find_one(
+        TrainingJob.model_id == model_id,
+        TrainingJob.user_id == current_user_id,
+    )
+
+    if not job:
+        raise HTTPException(status_code=404, detail="Training job not found")
+
+    return TrainingStatusResponse(
+        model_id=job.model_id,
+        status=job.status.value,
+        progress=job.progress.fraction,
+        current_algorithm=job.progress.current_algorithm,
+        completed_algorithms=job.progress.completed_algorithms,
+        total_algorithms=job.progress.total_algorithms,
+        metrics=job.metrics,
+        model_comparison=[entry.model_dump() for entry in job.model_comparison],
+        algorithm_recommendations=job.algorithm_recommendations,
+        best_model_id=job.best_model_id,
+        best_algorithm=job.best_algorithm,
+        explanation=job.best_model_explanation,
+        error=job.error,
+    )
 
 
 @router.get("/{model_id}", response_model=MLModel)

--- a/apps/backend/app/api/routes/model_training.py
+++ b/apps/backend/app/api/routes/model_training.py
@@ -230,7 +230,7 @@ async def train_model_task(
         )
 
         # Prepare metadata
-        model_metadata = {
+        model_metadata: Dict[str, Any] = {
             "name": request.name or f"{result.best_model.name} on {user_data.filename}",
             "description": request.description,
             "problem_type": result.problem_type.value,

--- a/apps/backend/app/api/routes/model_training.py
+++ b/apps/backend/app/api/routes/model_training.py
@@ -145,7 +145,7 @@ async def train_model(
     return TrainModelResponse(
         model_id=model_id,
         status="training",
-        message="Model training started. Poll GET /ml/{model_id}/status for progress."
+        message=f"Model training started. Poll GET /api/v1/ml/{model_id}/status for progress."
     )
 
 
@@ -290,8 +290,15 @@ async def train_model_task(
     except Exception as e:
         logger.error(f"Error training model: {str(e)}")
         if training_job:
-            training_job.mark_failed(str(e))
-            await training_job.save()
+            # Guard the failure-recording itself: a secondary error here (e.g. a
+            # transient DB outage during save) must not escape the background task.
+            try:
+                training_job.mark_failed(str(e))
+                await training_job.save()
+            except Exception as save_exc:
+                logger.error(
+                    f"Failed to persist FAILED status for {model_id}: {save_exc}"
+                )
         # Swallow here: this runs as a fire-and-forget BackgroundTask, so the
         # failure is recorded on the TrainingJob (above) rather than re-raised
         # into a context where nothing can handle it.

--- a/apps/backend/app/models/registry.py
+++ b/apps/backend/app/models/registry.py
@@ -21,6 +21,7 @@ from app.models.model import ModelConfig
 from app.models.plot import Plot
 from app.models.revised_data import RevisedData
 from app.models.trained_model import TrainedModel
+from app.models.training_job import TrainingJob
 from app.models.transformation import TransformationConfig
 from app.models.user_data import UserData
 from app.models.version import DatasetVersion, TransformationLineage
@@ -52,6 +53,7 @@ DOCUMENT_MODELS = [
     SharedRecipe,
     StoredFeature,
     TrainedModel,
+    TrainingJob,
     TransformationConfig,
     TransformationLineage,
     TransformationRecipe,

--- a/apps/backend/app/models/training_job.py
+++ b/apps/backend/app/models/training_job.py
@@ -31,7 +31,7 @@ class TrainingProgress(BaseModel):
         """Completion as a 0.0-1.0 fraction (0.0 when total is unknown)."""
         if self.total_algorithms <= 0:
             return 0.0
-        return min(self.completed_algorithms / self.total_algorithms, 1.0)
+        return max(0.0, min(self.completed_algorithms / self.total_algorithms, 1.0))
 
     @property
     def percentage(self) -> float:
@@ -103,11 +103,15 @@ class TrainingJob(Document):
         total_algorithms: Optional[int] = None,
         current_algorithm: Optional[str] = None,
     ) -> None:
-        """Update progress counters; only provided fields are changed."""
+        """Update progress counters; only provided fields are changed.
+
+        Counters are floored at 0 so a stray negative value can never surface as
+        negative progress in the status payload.
+        """
         if total_algorithms is not None:
-            self.progress.total_algorithms = total_algorithms
+            self.progress.total_algorithms = max(0, total_algorithms)
         if completed_algorithms is not None:
-            self.progress.completed_algorithms = completed_algorithms
+            self.progress.completed_algorithms = max(0, completed_algorithms)
         if current_algorithm is not None:
             self.progress.current_algorithm = current_algorithm
         self.updated_at = _utcnow()

--- a/apps/backend/app/models/training_job.py
+++ b/apps/backend/app/models/training_job.py
@@ -1,0 +1,149 @@
+"""
+Training job document for tracking AutoML training progress and results.
+
+A ``TrainingJob`` is created when ``POST /api/v1/ml/train`` is called and is
+updated as the background training task runs. It is the source of truth for the
+``GET /api/v1/ml/{model_id}/status`` endpoint: status, per-algorithm progress,
+the model comparison table, the selected best model, and any error.
+"""
+
+from typing import List, Dict, Any, Optional
+from datetime import datetime, timezone
+from beanie import Document, Indexed
+from pydantic import Field, BaseModel
+
+from app.models.batch_job import JobStatus
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+class TrainingProgress(BaseModel):
+    """Per-algorithm progress for a training job."""
+
+    completed_algorithms: int = Field(default=0)
+    total_algorithms: int = Field(default=0)
+    current_algorithm: Optional[str] = None
+
+    @property
+    def fraction(self) -> float:
+        """Completion as a 0.0-1.0 fraction (0.0 when total is unknown)."""
+        if self.total_algorithms <= 0:
+            return 0.0
+        return min(self.completed_algorithms / self.total_algorithms, 1.0)
+
+    @property
+    def percentage(self) -> float:
+        """Completion as a 0-100 percentage rounded to two decimals."""
+        return round(self.fraction * 100, 2)
+
+
+class ModelComparisonEntry(BaseModel):
+    """One row of the model comparison table."""
+
+    algorithm: str
+    cv_score: Optional[float] = None
+    test_score: Optional[float] = None
+    training_time: Optional[float] = None
+
+
+class TrainingJob(Document):
+    """Tracks the lifecycle of an AutoML training run."""
+
+    # Identification (model_id doubles as the resulting MLModel id on success)
+    model_id: Indexed(str) = Field(description="Unique training/model identifier")
+    user_id: Indexed(str)
+    dataset_id: str
+    target_column: str
+
+    # Status and progress
+    status: JobStatus = Field(default=JobStatus.PENDING)
+    progress: TrainingProgress = Field(default_factory=TrainingProgress)
+
+    # Results
+    algorithm_recommendations: List[Dict[str, Any]] = Field(default_factory=list)
+    model_comparison: List[ModelComparisonEntry] = Field(default_factory=list)
+    best_model_id: Optional[str] = None
+    best_algorithm: Optional[str] = None
+    best_model_explanation: Optional[str] = None
+    metrics: Dict[str, Any] = Field(default_factory=dict)
+
+    # Error handling
+    error: Optional[str] = None
+
+    # Timestamps
+    created_at: datetime = Field(default_factory=_utcnow)
+    updated_at: datetime = Field(default_factory=_utcnow)
+    started_at: Optional[datetime] = None
+    completed_at: Optional[datetime] = None
+
+    class Settings:
+        name = "training_jobs"
+        indexes = [
+            "model_id",
+            "user_id",
+            "status",
+            "created_at",
+        ]
+
+    # -- lifecycle helpers -------------------------------------------------
+
+    def mark_started(self, total_algorithms: int = 0) -> None:
+        """Transition the job to RUNNING and record the algorithm count."""
+        self.status = JobStatus.RUNNING
+        self.started_at = _utcnow()
+        self.updated_at = self.started_at
+        self.progress.total_algorithms = total_algorithms
+        self.progress.completed_algorithms = 0
+
+    def update_progress(
+        self,
+        completed_algorithms: Optional[int] = None,
+        total_algorithms: Optional[int] = None,
+        current_algorithm: Optional[str] = None,
+    ) -> None:
+        """Update progress counters; only provided fields are changed."""
+        if total_algorithms is not None:
+            self.progress.total_algorithms = total_algorithms
+        if completed_algorithms is not None:
+            self.progress.completed_algorithms = completed_algorithms
+        if current_algorithm is not None:
+            self.progress.current_algorithm = current_algorithm
+        self.updated_at = _utcnow()
+
+    def mark_completed(
+        self,
+        *,
+        best_model_id: Optional[str] = None,
+        best_algorithm: Optional[str] = None,
+        best_model_explanation: Optional[str] = None,
+        model_comparison: Optional[List[ModelComparisonEntry]] = None,
+        algorithm_recommendations: Optional[List[Dict[str, Any]]] = None,
+        metrics: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Transition the job to COMPLETED and attach results."""
+        self.status = JobStatus.COMPLETED
+        self.completed_at = _utcnow()
+        self.updated_at = self.completed_at
+        self.progress.current_algorithm = None
+        self.progress.completed_algorithms = self.progress.total_algorithms
+        if best_model_id is not None:
+            self.best_model_id = best_model_id
+        if best_algorithm is not None:
+            self.best_algorithm = best_algorithm
+        if best_model_explanation is not None:
+            self.best_model_explanation = best_model_explanation
+        if model_comparison is not None:
+            self.model_comparison = model_comparison
+        if algorithm_recommendations is not None:
+            self.algorithm_recommendations = algorithm_recommendations
+        if metrics is not None:
+            self.metrics = metrics
+
+    def mark_failed(self, error: str) -> None:
+        """Transition the job to FAILED and record the error message."""
+        self.status = JobStatus.FAILED
+        self.completed_at = _utcnow()
+        self.updated_at = self.completed_at
+        self.error = error

--- a/apps/backend/app/services/model_training/automl_engine.py
+++ b/apps/backend/app/services/model_training/automl_engine.py
@@ -2,7 +2,7 @@
 Core AutoML engine for automated model selection and training
 """
 
-from typing import Dict, List, Any, Optional, Tuple
+from typing import Awaitable, Callable, Dict, List, Any, Optional, Tuple
 import pandas as pd
 import numpy as np
 from dataclasses import dataclass
@@ -72,16 +72,24 @@ class AutoMLEngine:
         self,
         df: pd.DataFrame,
         target_column: str,
-        feature_config: Optional[FeatureEngineeringConfig] = None
+        feature_config: Optional[FeatureEngineeringConfig] = None,
+        progress_callback: Optional[
+            Callable[[int, int, str], Awaitable[None]]
+        ] = None,
     ) -> AutoMLResult:
         """
         Run the AutoML pipeline
-        
+
         Args:
             df: Input dataframe
             target_column: Name of target column
             feature_config: Feature engineering configuration
-            
+            progress_callback: Optional async callback invoked as
+                ``await progress_callback(completed, total, current_algorithm)``
+                before each candidate is trained and once more when all
+                candidates finish. Callback errors are swallowed so progress
+                reporting never breaks training.
+
         Returns:
             AutoMLResult with best model and metadata
         """
@@ -99,35 +107,52 @@ class AutoMLEngine:
         X = df.drop(columns=[target_column])
         y = df[target_column]
         
+        is_classification = problem_type in [
+            ProblemType.BINARY_CLASSIFICATION,
+            ProblemType.MULTICLASS_CLASSIFICATION,
+        ]
+
         # Split data
         X_train, X_test, y_train, y_test = train_test_split(
             X, y, test_size=self.test_size, random_state=self.random_state,
-            stratify=y if problem_type in [
-                ProblemType.BINARY_CLASSIFICATION,
-                ProblemType.MULTICLASS_CLASSIFICATION
-            ] else None
+            stratify=y if is_classification else None
         )
-        
+
+        # Detect class imbalance and enable basic handling (class weighting).
+        # This is the lightweight "basic class-imbalance handling" of the beta
+        # scope: no resampling (SMOTE etc.), just class_weight="balanced" on the
+        # estimators that support it.
+        class_balance_ratio, class_weight = self._assess_class_balance(
+            y_train, is_classification
+        )
+
         # Feature engineering
         if feature_config:
             self.feature_engineer.config = feature_config
-        
+
         feature_result = await self.feature_engineer.fit_transform(
             X_train, y_train, problem_type.value
         )
         X_train_transformed = feature_result.X_transformed
-        
+
         # Transform test data
         X_test_transformed = await self.feature_engineer.transform(X_test)
-        
+
         # Get candidate models
-        candidates = self._get_candidate_models(problem_type, X_train_transformed.shape)
+        candidates = self._get_candidate_models(
+            problem_type, X_train_transformed.shape, class_weight=class_weight
+        )
         
         # Train and evaluate models
+        selected_candidates = candidates[:self.max_models]
+        total_candidates = len(selected_candidates)
         trained_models = []
-        for candidate in candidates[:self.max_models]:
+        for index, candidate in enumerate(selected_candidates):
             logger.info(f"Training {candidate.name}...")
-            
+            await self._report_progress(
+                progress_callback, index, total_candidates, candidate.name
+            )
+
             try:
                 # Train model
                 model_start = datetime.now(timezone.utc)
@@ -157,22 +182,39 @@ class AutoMLEngine:
                 logger.error(f"Error training {candidate.name}: {str(e)}")
                 continue
         
+        # Final progress tick: all candidates processed.
+        await self._report_progress(
+            progress_callback, total_candidates, total_candidates, None
+        )
+
         # Select best model
         if not trained_models:
             raise ValueError("No models were successfully trained")
         best_model = max(trained_models, key=lambda m: m.cv_score)
-        
+        ranked_models = sorted(trained_models, key=lambda m: m.cv_score, reverse=True)
+
         # Get feature importance if available
         feature_importance = self._get_feature_importance(
             best_model.estimator,
             feature_result.feature_names
         )
-        
+
         total_time = (datetime.now(timezone.utc) - start_time).total_seconds()
-        
+
+        # Side-by-side comparison of every trained candidate, ranked by CV score.
+        model_comparison = [
+            {
+                "algorithm": m.name,
+                "cv_score": m.cv_score,
+                "test_score": m.test_score,
+                "training_time": m.training_time,
+            }
+            for m in ranked_models
+        ]
+
         return AutoMLResult(
             best_model=best_model,
-            all_models=sorted(trained_models, key=lambda m: m.cv_score, reverse=True),
+            all_models=ranked_models,
             problem_type=problem_type,
             feature_names=feature_result.feature_names,
             feature_importance=feature_importance,
@@ -182,39 +224,89 @@ class AutoMLEngine:
                 "n_features_original": len(X.columns),
                 "n_features_engineered": len(feature_result.feature_names),
                 "feature_engineering": feature_result.metadata,
+                "model_comparison": model_comparison,
+                "class_balance": {
+                    "ratio": class_balance_ratio,
+                    "balancing_applied": class_weight is not None,
+                },
                 "detection_result": {
                     "confidence": detection_result.confidence,
                     "reasoning": detection_result.reasoning
                 }
             }
         )
+
+    @staticmethod
+    async def _report_progress(
+        progress_callback: Optional[Callable[[int, int, str], Awaitable[None]]],
+        completed: int,
+        total: int,
+        current_algorithm: Optional[str],
+    ) -> None:
+        """Invoke the progress callback, swallowing any error it raises."""
+        if progress_callback is None:
+            return
+        try:
+            await progress_callback(completed, total, current_algorithm)
+        except Exception as exc:  # progress reporting must never break training
+            logger.warning(f"Progress callback failed: {exc}")
+
+    @staticmethod
+    def _assess_class_balance(
+        y_train: pd.Series, is_classification: bool
+    ) -> Tuple[Optional[float], Optional[str]]:
+        """Return (majority/minority ratio, class_weight) for the training labels.
+
+        ``class_weight`` is ``"balanced"`` when the ratio exceeds 2:1, otherwise
+        ``None``. For regression both values are ``None``.
+        """
+        if not is_classification:
+            return None, None
+        counts = y_train.value_counts()
+        if len(counts) < 2 or counts.min() == 0:
+            return None, None
+        ratio = float(counts.max() / counts.min())
+        class_weight = "balanced" if ratio > 2.0 else None
+        return ratio, class_weight
     
     def _get_candidate_models(
         self,
         problem_type: ProblemType,
-        data_shape: Tuple[int, int]
+        data_shape: Tuple[int, int],
+        class_weight: Optional[str] = None
     ) -> List[ModelCandidate]:
-        """Get candidate models based on problem type and data characteristics"""
+        """Get candidate models based on problem type and data characteristics.
+
+        ``class_weight`` (e.g. ``"balanced"``) is applied to the classifiers that
+        support it — Logistic Regression, Random Forest, SVM and LightGBM — to
+        provide basic class-imbalance handling. XGBoost, Gradient Boosting and KNN
+        do not take a ``class_weight`` and are left unchanged.
+        """
         n_samples, n_features = data_shape
         candidates = []
-        
+
         if problem_type in [ProblemType.BINARY_CLASSIFICATION, ProblemType.MULTICLASS_CLASSIFICATION]:
             # Logistic Regression
             candidates.append(ModelCandidate(
                 name="Logistic Regression",
-                estimator=LogisticRegression(random_state=self.random_state, max_iter=1000),
-                hyperparameters={"C": 1.0, "penalty": "l2"}
+                estimator=LogisticRegression(
+                    random_state=self.random_state,
+                    max_iter=1000,
+                    class_weight=class_weight
+                ),
+                hyperparameters={"C": 1.0, "penalty": "l2", "class_weight": class_weight}
             ))
-            
+
             # Random Forest
             candidates.append(ModelCandidate(
                 name="Random Forest",
                 estimator=RandomForestClassifier(
                     n_estimators=100,
                     random_state=self.random_state,
-                    n_jobs=-1
+                    n_jobs=-1,
+                    class_weight=class_weight
                 ),
-                hyperparameters={"n_estimators": 100, "max_depth": None}
+                hyperparameters={"n_estimators": 100, "max_depth": None, "class_weight": class_weight}
             ))
             
             # XGBoost
@@ -236,11 +328,12 @@ class AutoMLEngine:
                     n_estimators=100,
                     random_state=self.random_state,
                     n_jobs=-1,
-                    verbosity=-1
+                    verbosity=-1,
+                    class_weight=class_weight
                 ),
-                hyperparameters={"n_estimators": 100, "learning_rate": 0.1}
+                hyperparameters={"n_estimators": 100, "learning_rate": 0.1, "class_weight": class_weight}
             ))
-            
+
             # Gradient Boosting
             if n_samples < 10000:  # Slower for large datasets
                 candidates.append(ModelCandidate(
@@ -259,9 +352,10 @@ class AutoMLEngine:
                     estimator=SVC(
                         kernel='rbf',
                         random_state=self.random_state,
-                        probability=True
+                        probability=True,
+                        class_weight=class_weight
                     ),
-                    hyperparameters={"C": 1.0, "kernel": "rbf"}
+                    hyperparameters={"C": 1.0, "kernel": "rbf", "class_weight": class_weight}
                 ))
             
             # KNN (for smaller datasets)

--- a/apps/backend/app/services/model_training/automl_engine.py
+++ b/apps/backend/app/services/model_training/automl_engine.py
@@ -74,7 +74,7 @@ class AutoMLEngine:
         target_column: str,
         feature_config: Optional[FeatureEngineeringConfig] = None,
         progress_callback: Optional[
-            Callable[[int, int, str], Awaitable[None]]
+            Callable[[int, int, Optional[str]], Awaitable[None]]
         ] = None,
     ) -> AutoMLResult:
         """

--- a/apps/backend/app/services/model_training/comparison.py
+++ b/apps/backend/app/services/model_training/comparison.py
@@ -80,7 +80,7 @@ def build_best_model_explanation(
         (m for m in all_models if m.name != best_model.name and m.cv_score is not None),
         None,
     )
-    if runner_up is not None:
+    if runner_up is not None and runner_up.cv_score is not None:
         margin = best_model.cv_score - runner_up.cv_score
         parts.append(
             f", outperforming the next-best model ({runner_up.name}, "

--- a/apps/backend/app/services/model_training/comparison.py
+++ b/apps/backend/app/services/model_training/comparison.py
@@ -1,0 +1,148 @@
+"""
+Helpers for summarising AutoML results: a model comparison table, a deterministic
+(no-LLM) best-model explanation, and a ``DataProfile`` builder for the algorithm
+recommender.
+
+These are pure functions so they can be unit-tested without a database, S3, or an
+OpenAI key. The plain-language explanation here is rule-based on purpose: it gives
+the user a "why this model" narrative without any runtime LLM call or cost.
+"""
+
+from typing import List, Optional
+import pandas as pd
+
+from .automl_engine import ModelCandidate
+from .algorithm_selector import DataProfile
+from .problem_detector import ProblemType
+
+
+def build_model_comparison(all_models: List[ModelCandidate]) -> List[dict]:
+    """Build a side-by-side comparison table from trained candidates.
+
+    Returns a list of dicts (algorithm, cv_score, test_score, training_time)
+    ordered by CV score descending — ready to persist on a ``TrainingJob``.
+    """
+    ordered = sorted(
+        all_models,
+        key=lambda m: (m.cv_score if m.cv_score is not None else float("-inf")),
+        reverse=True,
+    )
+    return [
+        {
+            "algorithm": m.name,
+            "cv_score": m.cv_score,
+            "test_score": m.test_score,
+            "training_time": m.training_time,
+        }
+        for m in ordered
+    ]
+
+
+def _score_label(problem_type: ProblemType) -> str:
+    """Human-readable name of the primary CV scoring metric."""
+    if problem_type == ProblemType.BINARY_CLASSIFICATION:
+        return "ROC AUC"
+    if problem_type == ProblemType.MULTICLASS_CLASSIFICATION:
+        return "weighted F1"
+    if problem_type == ProblemType.REGRESSION:
+        return "cross-validated error"
+    return "cross-validated score"
+
+
+def build_best_model_explanation(
+    best_model: ModelCandidate,
+    all_models: List[ModelCandidate],
+    problem_type: ProblemType,
+) -> str:
+    """Produce a plain-language explanation of why ``best_model`` was chosen.
+
+    Deterministic and LLM-free: compares the best model's cross-validated score
+    against the runner-up and notes the candidate pool size.
+    """
+    metric = _score_label(problem_type)
+    n = len(all_models)
+
+    if best_model.cv_score is None:
+        return (
+            f"{best_model.name} was selected as the best model from "
+            f"{n} trained candidate{'s' if n != 1 else ''}."
+        )
+
+    parts = [
+        f"{best_model.name} was selected as the best model, with a {metric} of "
+        f"{best_model.cv_score:.3f} across cross-validation"
+    ]
+    if best_model.test_score is not None:
+        parts.append(f" and a hold-out test score of {best_model.test_score:.3f}")
+    parts.append(f". It was compared against {n} candidate{'s' if n != 1 else ''}")
+
+    runner_up = next(
+        (m for m in all_models if m.name != best_model.name and m.cv_score is not None),
+        None,
+    )
+    if runner_up is not None:
+        margin = best_model.cv_score - runner_up.cv_score
+        parts.append(
+            f", outperforming the next-best model ({runner_up.name}, "
+            f"{runner_up.cv_score:.3f}) by {abs(margin):.3f}"
+        )
+    parts.append(".")
+    return "".join(parts)
+
+
+def build_data_profile(
+    df: pd.DataFrame,
+    target_column: str,
+    problem_type: ProblemType,
+    high_cardinality_threshold: int = 100,
+) -> DataProfile:
+    """Build a ``DataProfile`` of the feature columns for the algorithm recommender.
+
+    The target column is excluded from the feature counts. ``class_balance_ratio``
+    is the majority/minority class ratio for classification, ``None`` for regression.
+    """
+    features = df.drop(columns=[target_column], errors="ignore")
+    n_samples = len(df)
+    n_features = features.shape[1]
+
+    numeric_cols = features.select_dtypes(include=["number"]).columns
+    n_numeric = len(numeric_cols)
+    n_categorical = n_features - n_numeric
+
+    total_cells = n_samples * n_features
+    missing_pct = (
+        float(features.isnull().sum().sum()) / total_cells * 100 if total_cells else 0.0
+    )
+
+    high_cardinality = sum(
+        1
+        for col in features.columns
+        if features[col].nunique(dropna=True) > high_cardinality_threshold
+    )
+
+    class_balance_ratio: Optional[float] = None
+    if problem_type in (
+        ProblemType.BINARY_CLASSIFICATION,
+        ProblemType.MULTICLASS_CLASSIFICATION,
+    ):
+        counts = df[target_column].value_counts()
+        if len(counts) > 1 and counts.min() > 0:
+            class_balance_ratio = float(counts.max() / counts.min())
+
+    if n_samples < 5000:
+        size_category = "small"
+    elif n_samples < 50000:
+        size_category = "medium"
+    else:
+        size_category = "large"
+
+    return DataProfile(
+        n_samples=n_samples,
+        n_features=n_features,
+        n_numeric_features=n_numeric,
+        n_categorical_features=n_categorical,
+        class_balance_ratio=class_balance_ratio,
+        missing_value_percentage=missing_pct,
+        high_cardinality_features=high_cardinality,
+        dataset_size_category=size_category,
+    )

--- a/apps/backend/tests/integration/test_training_workflow.py
+++ b/apps/backend/tests/integration/test_training_workflow.py
@@ -1,0 +1,111 @@
+"""
+Integration test for the async AutoML training workflow (issue #75).
+
+Exercises the real ``train_model_task`` against a real MongoDB ``TrainingJob`` and
+a real ``AutoMLEngine`` training on a sample CSV. Only the S3 boundary is stubbed
+(reading the dataset bytes and persisting the model artifact), since LocalStack is
+not guaranteed to be running; everything else — the ML training, the model
+comparison, the algorithm recommendations, and the job lifecycle — is real.
+"""
+
+import io
+from unittest.mock import patch, AsyncMock, MagicMock
+
+import pytest
+import numpy as np
+import pandas as pd
+
+from app.models.training_job import TrainingJob
+from app.models.batch_job import JobStatus
+
+
+@pytest.fixture
+def sample_classification_csv() -> bytes:
+    """A small but learnable binary-classification dataset as CSV bytes."""
+    rng = np.random.RandomState(42)
+    n = 150
+    # Two separable-ish clusters so models actually learn something.
+    x1 = np.concatenate([rng.randn(n) - 1.5, rng.randn(n) + 1.5])
+    x2 = np.concatenate([rng.randn(n) - 1.0, rng.randn(n) + 1.0])
+    cat = rng.choice(["A", "B", "C"], size=2 * n)
+    target = np.array([0] * n + [1] * n)
+    df = pd.DataFrame(
+        {"x1": x1, "x2": x2, "category": cat, "target": target}
+    )
+    buf = io.StringIO()
+    df.to_csv(buf, index=False)
+    return buf.getvalue().encode("utf-8")
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_train_workflow_completes_with_comparison(
+    setup_database, sample_classification_csv
+):
+    """POST-style training task trains a real model and records full results."""
+    from app.api.routes.model_training import train_model_task, TrainModelRequest
+
+    model_id = "model_integration_workflow"
+    user_id = "integration_user"
+
+    # Pending job, as POST /ml/train would create.
+    job = TrainingJob(
+        model_id=model_id,
+        user_id=user_id,
+        dataset_id="dataset_integration",
+        target_column="target",
+    )
+    await job.insert()
+
+    user_data = MagicMock()
+    user_data.s3_url = "s3://bucket/datasets/integration/data.csv"
+    user_data.file_type = "csv"
+    user_data.filename = "data.csv"
+
+    request = TrainModelRequest(
+        dataset_id="dataset_integration",
+        target_column="target",
+        training_config={"max_models": 3, "cv_folds": 3},
+    )
+
+    # Stub only the S3 boundaries: dataset read and model artifact write.
+    saved_model = MagicMock(model_id=model_id)
+
+    try:
+        with patch(
+            "app.api.routes.model_training.get_file_from_s3",
+            new_callable=AsyncMock,
+            return_value=sample_classification_csv,
+        ), patch(
+            "app.services.model_storage.ModelStorageService.save_model",
+            new_callable=AsyncMock,
+            return_value=saved_model,
+        ):
+            await train_model_task(user_data, request, user_id, model_id)
+
+        refreshed = await TrainingJob.find_one(TrainingJob.model_id == model_id)
+
+        # Job reached COMPLETED with a real trained best model.
+        assert refreshed.status == JobStatus.COMPLETED
+        assert refreshed.best_algorithm is not None
+        assert refreshed.best_model_id == model_id
+
+        # Model comparison populated and ranked by CV score (descending).
+        assert len(refreshed.model_comparison) >= 1
+        cv_scores = [
+            row.cv_score
+            for row in refreshed.model_comparison
+            if row.cv_score is not None
+        ]
+        assert cv_scores == sorted(cv_scores, reverse=True)
+
+        # Plain-language explanation and algorithm recommendations present.
+        assert refreshed.best_model_explanation
+        assert refreshed.best_algorithm in refreshed.best_model_explanation
+        assert len(refreshed.algorithm_recommendations) >= 1
+        assert "algorithm_name" in refreshed.algorithm_recommendations[0]
+
+        # Progress shows full completion.
+        assert refreshed.progress.fraction == 1.0
+    finally:
+        await job.delete()

--- a/apps/backend/tests/test_api/test_model_training.py
+++ b/apps/backend/tests/test_api/test_model_training.py
@@ -332,3 +332,159 @@ class TestModelTrainingBackgroundTask:
                     mock_s3.assert_called_once()
                     mock_run.assert_called_once()
                     mock_save.assert_called_once()
+
+
+class TestTrainingStatusEndpoint:
+    """Test GET /api/v1/ml/{model_id}/status and job lifecycle tracking."""
+
+    @pytest.mark.asyncio
+    async def test_train_creates_pending_job(self, async_authorized_client):
+        """POST /train persists a pending TrainingJob and it is queryable."""
+        from app.models.training_job import TrainingJob
+        from app.models.batch_job import JobStatus
+
+        mock_user_data = MagicMock(
+            id="dataset_123",
+            user_id="test_user_123",
+            file_key="uploads/test_user/test_data.csv",
+        )
+
+        with patch('app.models.user_data.UserData.find_one', new_callable=AsyncMock) as mock_find:
+            mock_find.return_value = mock_user_data
+            with patch('app.api.routes.model_training.train_model_task', new_callable=AsyncMock):
+                response = await async_authorized_client.post(
+                    "/api/v1/ml/train",
+                    json={"dataset_id": "dataset_123", "target_column": "target"},
+                )
+
+        assert response.status_code == 200
+        model_id = response.json()["model_id"]
+
+        # A pending TrainingJob now exists for this model_id.
+        job = await TrainingJob.find_one(TrainingJob.model_id == model_id)
+        assert job is not None
+        assert job.status == JobStatus.PENDING
+
+        # And the status endpoint reports it.
+        status_resp = await async_authorized_client.get(f"/api/v1/ml/{model_id}/status")
+        assert status_resp.status_code == 200
+        body = status_resp.json()
+        assert body["status"] == "pending"
+        assert body["progress"] == 0.0
+
+        await job.delete()
+
+    @pytest.mark.asyncio
+    async def test_status_returns_completed_results(self, async_authorized_client):
+        """A completed job returns comparison, recommendations, and explanation."""
+        from app.models.training_job import TrainingJob, ModelComparisonEntry
+
+        job = TrainingJob(
+            model_id="model_status_done",
+            user_id="test_user_123",
+            dataset_id="dataset_123",
+            target_column="target",
+        )
+        job.mark_started(total_algorithms=2)
+        job.mark_completed(
+            best_model_id="model_status_done",
+            best_algorithm="XGBoost",
+            best_model_explanation="XGBoost won.",
+            model_comparison=[
+                ModelComparisonEntry(algorithm="XGBoost", cv_score=0.91, test_score=0.9),
+                ModelComparisonEntry(algorithm="Random Forest", cv_score=0.88),
+            ],
+            algorithm_recommendations=[{"algorithm_name": "XGBoost", "priority": 9}],
+            metrics={"cv_score": 0.91, "test_score": 0.9},
+        )
+        await job.insert()
+
+        try:
+            resp = await async_authorized_client.get(
+                "/api/v1/ml/model_status_done/status"
+            )
+            assert resp.status_code == 200
+            body = resp.json()
+            assert body["status"] == "completed"
+            assert body["progress"] == 1.0
+            assert body["best_algorithm"] == "XGBoost"
+            assert body["explanation"] == "XGBoost won."
+            assert len(body["model_comparison"]) == 2
+            assert body["model_comparison"][0]["algorithm"] == "XGBoost"
+            assert body["algorithm_recommendations"][0]["algorithm_name"] == "XGBoost"
+            assert body["metrics"]["cv_score"] == 0.91
+        finally:
+            await job.delete()
+
+    @pytest.mark.asyncio
+    async def test_status_returns_failure(self, async_authorized_client):
+        """A failed job surfaces the error message."""
+        from app.models.training_job import TrainingJob
+
+        job = TrainingJob(
+            model_id="model_status_failed",
+            user_id="test_user_123",
+            dataset_id="dataset_123",
+            target_column="target",
+        )
+        job.mark_started(total_algorithms=2)
+        job.mark_failed("Unsupported file type: txt")
+        await job.insert()
+
+        try:
+            resp = await async_authorized_client.get(
+                "/api/v1/ml/model_status_failed/status"
+            )
+            assert resp.status_code == 200
+            body = resp.json()
+            assert body["status"] == "failed"
+            assert body["error"] == "Unsupported file type: txt"
+        finally:
+            await job.delete()
+
+    @pytest.mark.asyncio
+    async def test_status_not_found(self, async_authorized_client):
+        """Unknown model_id returns 404."""
+        resp = await async_authorized_client.get("/api/v1/ml/does_not_exist/status")
+        assert resp.status_code == 404
+
+    @pytest.mark.integration
+    @pytest.mark.asyncio
+    async def test_train_model_task_marks_failure(self, sample_dataset, setup_database):
+        """A task failure transitions the TrainingJob to FAILED with an error."""
+        from app.api.routes.model_training import train_model_task, TrainModelRequest
+        from app.models.training_job import TrainingJob
+        from app.models.batch_job import JobStatus
+
+        job = TrainingJob(
+            model_id="model_task_fail",
+            user_id="test_user",
+            dataset_id="dataset_123",
+            target_column="target",
+        )
+        await job.insert()
+
+        # Force an unsupported file type so the task raises internally.
+        sample_dataset.file_type = "txt"
+
+        try:
+            with patch(
+                'app.services.s3_service.S3Service.download_file_bytes',
+                new_callable=AsyncMock,
+            ) as mock_s3:
+                mock_s3.return_value = b"irrelevant"
+                request = TrainModelRequest(
+                    dataset_id="dataset_123", target_column="target"
+                )
+                # Should NOT raise — failure is recorded on the job.
+                await train_model_task(
+                    sample_dataset, request, "test_user", "model_task_fail"
+                )
+
+            refreshed = await TrainingJob.find_one(
+                TrainingJob.model_id == "model_task_fail"
+            )
+            assert refreshed.status == JobStatus.FAILED
+            assert refreshed.error is not None
+        finally:
+            await job.delete()

--- a/apps/backend/tests/test_model_training/test_automl_engine.py
+++ b/apps/backend/tests/test_model_training/test_automl_engine.py
@@ -377,7 +377,140 @@ class TestAutoMLEngine:
                             mock_cv.return_value = np.array([0.9, 0.91, 0.89])
                             
                             result = await engine.run(df, 'target')
-                            
+
                             # Check feature engineering metadata is included
                             assert 'feature_engineering' in result.metadata
                             assert result.metadata['feature_engineering']['original_features'] == ['num1', 'num2']
+
+
+class TestAutoMLEngineEnhancements:
+    """Tests for class-imbalance handling, progress callbacks, and comparison."""
+
+    @pytest.fixture
+    def engine(self):
+        return AutoMLEngine(max_models=3, cv_folds=3, test_size=0.2, random_state=42)
+
+    @pytest.fixture
+    def imbalanced_data(self):
+        np.random.seed(42)
+        n_samples = 200
+        X = pd.DataFrame({
+            'feature1': np.random.randn(n_samples),
+            'feature2': np.random.randn(n_samples),
+        })
+        # 90/10 imbalance -> ratio 9:1, well above the 2:1 threshold
+        y = pd.Series([0] * 180 + [1] * 20)
+        df = pd.concat([X, pd.DataFrame({'target': y})], axis=1)
+        return df
+
+    def test_assess_class_balance_flags_imbalance(self, engine):
+        y = pd.Series([0] * 80 + [1] * 20)  # 4:1
+        ratio, weight = engine._assess_class_balance(y, is_classification=True)
+        assert ratio == 4.0
+        assert weight == "balanced"
+
+    def test_assess_class_balance_balanced_data(self, engine):
+        y = pd.Series([0] * 55 + [1] * 45)  # ~1.2:1
+        ratio, weight = engine._assess_class_balance(y, is_classification=True)
+        assert weight is None
+
+    def test_assess_class_balance_regression(self, engine):
+        y = pd.Series(np.random.randn(100))
+        ratio, weight = engine._assess_class_balance(y, is_classification=False)
+        assert ratio is None
+        assert weight is None
+
+    def test_candidate_models_apply_class_weight(self, engine):
+        candidates = engine._get_candidate_models(
+            ProblemType.BINARY_CLASSIFICATION, (1000, 20), class_weight="balanced"
+        )
+        by_name = {c.name: c for c in candidates}
+        # Estimators that support class_weight should receive it.
+        assert by_name["Logistic Regression"].estimator.class_weight == "balanced"
+        assert by_name["Random Forest"].estimator.class_weight == "balanced"
+
+    @pytest.mark.asyncio
+    async def test_run_reports_progress(self, engine, imbalanced_data):
+        mock_detection = ProblemDetectionResult(
+            problem_type=ProblemType.BINARY_CLASSIFICATION,
+            target_column='target',
+            confidence=0.95,
+            reasoning="Binary classification",
+            metadata={},
+        )
+
+        async def mock_detect(df, target):
+            return mock_detection
+
+        calls = []
+
+        async def on_progress(completed, total, current):
+            calls.append((completed, total, current))
+
+        with patch.object(engine.problem_detector, 'detect_problem_type',
+                          side_effect=mock_detect):
+            result = await engine.run(
+                imbalanced_data, 'target', progress_callback=on_progress
+            )
+
+        # Callback fired for each candidate plus a final completion tick.
+        assert len(calls) >= 2
+        # Final tick reports all candidates completed with no current algorithm.
+        final_completed, final_total, final_current = calls[-1]
+        assert final_completed == final_total
+        assert final_current is None
+        # class_balance metadata reflects that balancing was applied.
+        assert result.metadata['class_balance']['balancing_applied'] is True
+        assert result.metadata['class_balance']['ratio'] > 2.0
+
+    @pytest.mark.asyncio
+    async def test_run_includes_model_comparison(self, engine, imbalanced_data):
+        mock_detection = ProblemDetectionResult(
+            problem_type=ProblemType.BINARY_CLASSIFICATION,
+            target_column='target',
+            confidence=0.95,
+            reasoning="Binary classification",
+            metadata={},
+        )
+
+        async def mock_detect(df, target):
+            return mock_detection
+
+        with patch.object(engine.problem_detector, 'detect_problem_type',
+                          side_effect=mock_detect):
+            result = await engine.run(imbalanced_data, 'target')
+
+        comparison = result.metadata['model_comparison']
+        assert len(comparison) == len(result.all_models)
+        # Ranked by CV score descending.
+        scores = [row['cv_score'] for row in comparison]
+        assert scores == sorted(scores, reverse=True)
+        for row in comparison:
+            assert set(row) >= {"algorithm", "cv_score", "test_score", "training_time"}
+
+    @pytest.mark.asyncio
+    async def test_progress_callback_error_does_not_break_training(
+        self, engine, imbalanced_data
+    ):
+        mock_detection = ProblemDetectionResult(
+            problem_type=ProblemType.BINARY_CLASSIFICATION,
+            target_column='target',
+            confidence=0.95,
+            reasoning="Binary classification",
+            metadata={},
+        )
+
+        async def mock_detect(df, target):
+            return mock_detection
+
+        async def bad_callback(completed, total, current):
+            raise RuntimeError("callback exploded")
+
+        with patch.object(engine.problem_detector, 'detect_problem_type',
+                          side_effect=mock_detect):
+            result = await engine.run(
+                imbalanced_data, 'target', progress_callback=bad_callback
+            )
+
+        # Training still completes despite the failing callback.
+        assert result.best_model is not None

--- a/apps/backend/tests/test_model_training/test_automl_engine.py
+++ b/apps/backend/tests/test_model_training/test_automl_engine.py
@@ -429,6 +429,21 @@ class TestAutoMLEngineEnhancements:
         assert by_name["Logistic Regression"].estimator.class_weight == "balanced"
         assert by_name["Random Forest"].estimator.class_weight == "balanced"
 
+    def test_all_candidates_build_with_class_weight(self, engine):
+        """Threading class_weight must not break estimators that don't accept it.
+
+        XGBoost, Gradient Boosting and KNN do not take a ``class_weight``; the
+        full candidate list (small dataset -> includes SVM/KNN) must still build.
+        """
+        candidates = engine._get_candidate_models(
+            ProblemType.BINARY_CLASSIFICATION, (1000, 20), class_weight="balanced"
+        )
+        names = {c.name for c in candidates}
+        # All expected candidates present and constructed without error.
+        assert {"XGBoost", "Gradient Boosting", "K-Nearest Neighbors", "SVM"} <= names
+        for candidate in candidates:
+            assert candidate.estimator is not None
+
     @pytest.mark.asyncio
     async def test_run_reports_progress(self, engine, imbalanced_data):
         mock_detection = ProblemDetectionResult(

--- a/apps/backend/tests/test_model_training/test_comparison.py
+++ b/apps/backend/tests/test_model_training/test_comparison.py
@@ -1,0 +1,119 @@
+"""
+Tests for AutoML result-summary helpers (comparison table, best-model
+explanation, data profile). All pure functions — no DB/S3/LLM required.
+"""
+
+import pandas as pd
+import numpy as np
+
+from app.services.model_training.automl_engine import ModelCandidate
+from app.services.model_training.problem_detector import ProblemType
+from app.services.model_training.comparison import (
+    build_model_comparison,
+    build_best_model_explanation,
+    build_data_profile,
+)
+
+
+def _candidate(name, cv, test=None, t=1.0):
+    return ModelCandidate(
+        name=name,
+        estimator=object(),
+        hyperparameters={},
+        training_time=t,
+        cv_score=cv,
+        test_score=test,
+    )
+
+
+class TestBuildModelComparison:
+    def test_orders_by_cv_score_descending(self):
+        models = [
+            _candidate("A", 0.80),
+            _candidate("B", 0.92),
+            _candidate("C", 0.88),
+        ]
+        table = build_model_comparison(models)
+
+        assert [row["algorithm"] for row in table] == ["B", "C", "A"]
+        assert table[0]["cv_score"] == 0.92
+
+    def test_includes_all_metric_fields(self):
+        table = build_model_comparison([_candidate("A", 0.9, 0.85, 2.5)])
+        row = table[0]
+        assert set(row) == {"algorithm", "cv_score", "test_score", "training_time"}
+        assert row["test_score"] == 0.85
+        assert row["training_time"] == 2.5
+
+    def test_handles_missing_cv_score(self):
+        models = [_candidate("A", None), _candidate("B", 0.7)]
+        table = build_model_comparison(models)
+        # The scored model ranks first; the unscored one sinks to the bottom.
+        assert table[0]["algorithm"] == "B"
+
+
+class TestBuildBestModelExplanation:
+    def test_mentions_best_model_and_runner_up(self):
+        best = _candidate("XGBoost", 0.93, 0.90)
+        models = [best, _candidate("Random Forest", 0.88)]
+        text = build_best_model_explanation(
+            best, models, ProblemType.BINARY_CLASSIFICATION
+        )
+        assert "XGBoost" in text
+        assert "Random Forest" in text
+        assert "0.93" in text
+        assert "ROC AUC" in text
+
+    def test_single_candidate_has_no_runner_up(self):
+        best = _candidate("Linear Regression", 0.75)
+        text = build_best_model_explanation(
+            best, [best], ProblemType.REGRESSION
+        )
+        assert "Linear Regression" in text
+        assert "1 candidate" in text
+
+    def test_handles_missing_score(self):
+        best = _candidate("KNN", None)
+        text = build_best_model_explanation(
+            best, [best], ProblemType.BINARY_CLASSIFICATION
+        )
+        assert "KNN" in text
+
+
+class TestBuildDataProfile:
+    def test_counts_feature_types_excluding_target(self):
+        df = pd.DataFrame(
+            {
+                "num1": np.arange(100),
+                "num2": np.random.randn(100),
+                "cat1": ["a", "b"] * 50,
+                "target": np.random.choice([0, 1], 100),
+            }
+        )
+        profile = build_data_profile(
+            df, "target", ProblemType.BINARY_CLASSIFICATION
+        )
+        assert profile.n_samples == 100
+        assert profile.n_features == 3  # target excluded
+        assert profile.n_numeric_features == 2
+        assert profile.n_categorical_features == 1
+        assert profile.dataset_size_category == "small"
+
+    def test_class_balance_ratio_for_classification(self):
+        df = pd.DataFrame(
+            {
+                "f": np.arange(100),
+                "target": [0] * 80 + [1] * 20,  # 4:1 imbalance
+            }
+        )
+        profile = build_data_profile(
+            df, "target", ProblemType.BINARY_CLASSIFICATION
+        )
+        assert profile.class_balance_ratio == 4.0
+
+    def test_class_balance_ratio_none_for_regression(self):
+        df = pd.DataFrame(
+            {"f": np.arange(50), "target": np.random.randn(50)}
+        )
+        profile = build_data_profile(df, "target", ProblemType.REGRESSION)
+        assert profile.class_balance_ratio is None

--- a/apps/backend/tests/test_models/test_training_job.py
+++ b/apps/backend/tests/test_models/test_training_job.py
@@ -1,0 +1,91 @@
+"""
+Unit tests for the TrainingJob document lifecycle helpers.
+
+These exercise pure in-memory state transitions (no DB insert), so they run
+without MongoDB.
+"""
+
+import pytest
+
+from app.models.training_job import (
+    TrainingJob,
+    TrainingProgress,
+    ModelComparisonEntry,
+)
+from app.models.batch_job import JobStatus
+
+pytestmark = [pytest.mark.unit, pytest.mark.usefixtures("beanie_models_initialized")]
+
+
+def _job() -> TrainingJob:
+    return TrainingJob(
+        model_id="model_test_1",
+        user_id="user_1",
+        dataset_id="dataset_1",
+        target_column="target",
+    )
+
+
+class TestTrainingProgress:
+    def test_fraction_zero_when_total_unknown(self):
+        assert TrainingProgress().fraction == 0.0
+
+    def test_fraction_and_percentage(self):
+        p = TrainingProgress(completed_algorithms=2, total_algorithms=4)
+        assert p.fraction == 0.5
+        assert p.percentage == 50.0
+
+    def test_fraction_capped_at_one(self):
+        p = TrainingProgress(completed_algorithms=5, total_algorithms=4)
+        assert p.fraction == 1.0
+
+
+class TestTrainingJobLifecycle:
+    def test_defaults_to_pending(self):
+        assert _job().status == JobStatus.PENDING
+
+    def test_mark_started(self):
+        job = _job()
+        job.mark_started(total_algorithms=5)
+        assert job.status == JobStatus.RUNNING
+        assert job.started_at is not None
+        assert job.progress.total_algorithms == 5
+        assert job.progress.completed_algorithms == 0
+
+    def test_update_progress_partial(self):
+        job = _job()
+        job.mark_started(total_algorithms=5)
+        job.update_progress(completed_algorithms=2, current_algorithm="XGBoost")
+        assert job.progress.completed_algorithms == 2
+        assert job.progress.current_algorithm == "XGBoost"
+        assert job.progress.total_algorithms == 5  # unchanged
+
+    def test_mark_completed_attaches_results(self):
+        job = _job()
+        job.mark_started(total_algorithms=3)
+        comparison = [ModelComparisonEntry(algorithm="XGBoost", cv_score=0.9)]
+        job.mark_completed(
+            best_model_id="model_test_1",
+            best_algorithm="XGBoost",
+            best_model_explanation="because",
+            model_comparison=comparison,
+            algorithm_recommendations=[{"algorithm_name": "XGBoost"}],
+            metrics={"cv_score": 0.9},
+        )
+        assert job.status == JobStatus.COMPLETED
+        assert job.completed_at is not None
+        assert job.best_algorithm == "XGBoost"
+        assert job.best_model_explanation == "because"
+        assert job.model_comparison[0].algorithm == "XGBoost"
+        assert job.metrics["cv_score"] == 0.9
+        # Progress is forced to 100% on completion.
+        assert job.progress.completed_algorithms == job.progress.total_algorithms
+        assert job.progress.current_algorithm is None
+
+    def test_mark_failed_records_error(self):
+        job = _job()
+        job.mark_started(total_algorithms=3)
+        job.mark_failed("boom")
+        assert job.status == JobStatus.FAILED
+        assert job.error == "boom"
+        assert job.completed_at is not None

--- a/apps/frontend/__tests__/app/model/page.test.tsx
+++ b/apps/frontend/__tests__/app/model/page.test.tsx
@@ -88,7 +88,18 @@ describe('ModelPage training wiring', () => {
         { algorithm: 'XGBoost', cv_score: 0.91, test_score: 0.9, training_time: 1.2 },
         { algorithm: 'Random Forest', cv_score: 0.88, test_score: 0.86, training_time: 0.8 },
       ],
-      algorithm_recommendations: [],
+      algorithm_recommendations: [
+        {
+          algorithm_name: 'XGBoost',
+          priority: 9,
+          expected_performance: '85-95% accuracy',
+          training_time_estimate: '3-10 minutes',
+          interpretability_score: 5,
+          explanation: 'State-of-the-art gradient boosting, often best performance',
+          pros: ['Often best accuracy'],
+          cons: ['Less interpretable'],
+        },
+      ],
     });
 
     render(<ModelPage />);
@@ -114,6 +125,11 @@ describe('ModelPage training wiring', () => {
     expect(screen.getAllByText('XGBoost').length).toBeGreaterThanOrEqual(1);
     expect(screen.getByText('Random Forest')).toBeInTheDocument();
     expect(screen.getByText(/XGBoost won/)).toBeInTheDocument();
+    // Algorithm recommendations are rendered for the analyst (acceptance criterion).
+    expect(screen.getByText('Why these algorithms?')).toBeInTheDocument();
+    expect(
+      screen.getByText(/State-of-the-art gradient boosting/)
+    ).toBeInTheDocument();
     expect(mockCompleteStage).toHaveBeenCalledWith(
       WorkflowStage.MODEL_TRAINING,
       expect.objectContaining({ modelId: 'model_1', bestAlgorithm: 'XGBoost' })

--- a/apps/frontend/__tests__/app/model/page.test.tsx
+++ b/apps/frontend/__tests__/app/model/page.test.tsx
@@ -1,0 +1,150 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ModelPage from '@/app/model/page';
+import { WorkflowStage } from '@/lib/types/workflow';
+
+// Router
+const mockPush = jest.fn();
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush, replace: jest.fn(), prefetch: jest.fn() }),
+}));
+
+// Authenticated session
+jest.mock('next-auth/react', () => ({
+  useSession: () => ({ data: { user: { id: 'u1' } }, status: 'authenticated' }),
+}));
+
+jest.mock('@/lib/auth-helpers', () => ({
+  getAuthToken: jest.fn().mockResolvedValue('mock-token'),
+}));
+
+jest.mock('@/lib/constants', () => ({
+  API_URL: 'http://localhost:8000/api/v1',
+}));
+
+// Workflow context: model-training stage accessible, dataset present.
+const mockCompleteStage = jest.fn();
+const mockWorkflowContext = {
+  state: {
+    currentStage: WorkflowStage.MODEL_TRAINING,
+    completedStages: new Set<WorkflowStage>(),
+    stageData: {} as Record<WorkflowStage, unknown>,
+    datasetId: 'ds-1',
+    modelId: undefined,
+  },
+  canAccessStage: jest.fn(() => true),
+  completeStage: mockCompleteStage,
+  setCurrentStage: jest.fn(),
+  setDatasetId: jest.fn(),
+  resetWorkflow: jest.fn(),
+  loadWorkflow: jest.fn(),
+  saveWorkflow: jest.fn(),
+};
+jest.mock('@/lib/contexts/WorkflowContext', () => ({
+  useWorkflow: () => mockWorkflowContext,
+}));
+
+// Model service: trainModel + getTrainingStatus are driven per-test.
+const mockTrainModel = jest.fn();
+const mockGetTrainingStatus = jest.fn();
+jest.mock('@/lib/services/model', () => ({
+  modelService: {
+    trainModel: (...args: unknown[]) => mockTrainModel(...args),
+    getTrainingStatus: (...args: unknown[]) => mockGetTrainingStatus(...args),
+  },
+}));
+
+// Schema endpoint for column loading.
+const mockFetch = jest.fn();
+global.fetch = mockFetch as unknown as typeof fetch;
+
+function mockColumnsLoaded() {
+  mockFetch.mockResolvedValue({
+    ok: true,
+    json: async () => ({ columns: [{ name: 'target' }, { name: 'x1' }] }),
+  });
+}
+
+describe('ModelPage training wiring', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockColumnsLoaded();
+  });
+
+  it('starts real training and shows the comparison on completion', async () => {
+    mockTrainModel.mockResolvedValue({ model_id: 'model_1', status: 'training', message: 'ok' });
+    mockGetTrainingStatus.mockResolvedValue({
+      model_id: 'model_1',
+      status: 'completed',
+      progress: 1.0,
+      current_algorithm: null,
+      completed_algorithms: 2,
+      total_algorithms: 2,
+      metrics: { cv_score: 0.91 },
+      best_algorithm: 'XGBoost',
+      explanation: 'XGBoost won with a ROC AUC of 0.910.',
+      model_comparison: [
+        { algorithm: 'XGBoost', cv_score: 0.91, test_score: 0.9, training_time: 1.2 },
+        { algorithm: 'Random Forest', cv_score: 0.88, test_score: 0.86, training_time: 0.8 },
+      ],
+      algorithm_recommendations: [],
+    });
+
+    render(<ModelPage />);
+
+    // Wait for columns to load and select the target.
+    await waitFor(() => expect(screen.getByRole('option', { name: 'target' })).toBeInTheDocument());
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'target' } });
+
+    fireEvent.click(screen.getByRole('button', { name: /Start Training/i }));
+
+    // trainModel called with the correct real payload.
+    await waitFor(() => expect(mockTrainModel).toHaveBeenCalled());
+    expect(mockTrainModel).toHaveBeenCalledWith({
+      dataset_id: 'ds-1',
+      target_column: 'target',
+    });
+
+    // Status is polled after ~2s; allow time for the first poll to resolve.
+    expect(
+      await screen.findByText('Training complete!', {}, { timeout: 5000 })
+    ).toBeInTheDocument();
+    // 'XGBoost' appears both as the best-model label and in the comparison table.
+    expect(screen.getAllByText('XGBoost').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText('Random Forest')).toBeInTheDocument();
+    expect(screen.getByText(/XGBoost won/)).toBeInTheDocument();
+    expect(mockCompleteStage).toHaveBeenCalledWith(
+      WorkflowStage.MODEL_TRAINING,
+      expect.objectContaining({ modelId: 'model_1', bestAlgorithm: 'XGBoost' })
+    );
+  }, 15000);
+
+  it('surfaces a backend failure status as an error message', async () => {
+    mockTrainModel.mockResolvedValue({ model_id: 'model_2', status: 'training', message: 'ok' });
+    mockGetTrainingStatus.mockResolvedValue({
+      model_id: 'model_2',
+      status: 'failed',
+      progress: 0,
+      completed_algorithms: 0,
+      total_algorithms: 0,
+      metrics: {},
+      model_comparison: [],
+      algorithm_recommendations: [],
+      error: 'Unsupported file type: txt',
+    });
+
+    render(<ModelPage />);
+
+    await waitFor(() => expect(screen.getByRole('option', { name: 'target' })).toBeInTheDocument());
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'target' } });
+    fireEvent.click(screen.getByRole('button', { name: /Start Training/i }));
+
+    await waitFor(() => expect(mockTrainModel).toHaveBeenCalled());
+
+    expect(
+      await screen.findByText('Training failed', {}, { timeout: 5000 })
+    ).toBeInTheDocument();
+    expect(screen.getByText('Unsupported file type: txt')).toBeInTheDocument();
+  }, 15000);
+});

--- a/apps/frontend/__tests__/lib/services/model.test.ts
+++ b/apps/frontend/__tests__/lib/services/model.test.ts
@@ -136,4 +136,41 @@ describe('modelService instance export', () => {
 
     await expect(modelService.predict('m6', { data: [] })).rejects.toThrow('bad input');
   });
+
+  it('getTrainingStatus() requests the status endpoint and returns the job state', async () => {
+    const status = {
+      model_id: 'm8',
+      status: 'running',
+      progress: 0.5,
+      current_algorithm: 'XGBoost',
+      completed_algorithms: 1,
+      total_algorithms: 2,
+      metrics: {},
+      model_comparison: [],
+      algorithm_recommendations: [],
+    };
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue(status),
+    });
+
+    const result = await modelService.getTrainingStatus('m8');
+
+    expect(result).toEqual(status);
+    const [url, init] = (global.fetch as jest.Mock).mock.calls[0];
+    expect(url).toBe('http://localhost:8000/api/v1/ml/m8/status');
+    const headers = (init?.headers ?? {}) as Record<string, string>;
+    expect(headers.Authorization).toBe('Bearer svc-token');
+  });
+
+  it('getTrainingStatus() throws the backend detail message on error', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: false,
+      json: jest.fn().mockResolvedValue({ detail: 'Training job not found' }),
+    });
+
+    await expect(modelService.getTrainingStatus('missing')).rejects.toThrow(
+      'Training job not found'
+    );
+  });
 });

--- a/apps/frontend/app/model/page.tsx
+++ b/apps/frontend/app/model/page.tsx
@@ -22,6 +22,16 @@ const STATUS_POLL_INTERVAL_MS = 2000;
 // dead background job doesn't leave the UI polling forever.
 const MAX_STATUS_POLLS = 600;
 
+/**
+ * Model training page.
+ *
+ * Lets the analyst pick a target column and run AutoML training, then polls
+ * `GET /api/v1/ml/{model_id}/status` and renders live progress followed by the
+ * model comparison, the best-model explanation, and the algorithm
+ * recommendations on completion (or the error on failure). The backend
+ * auto-detects the problem type and compares algorithms, so the target column
+ * is the only required input.
+ */
 export default function ModelPage() {
   const { data: session } = useSession();
   const { state, completeStage, canAccessStage } = useWorkflow();

--- a/apps/frontend/app/model/page.tsx
+++ b/apps/frontend/app/model/page.tsx
@@ -6,6 +6,7 @@ import { WorkflowStage } from '@/lib/types/workflow';
 import { useRouter } from 'next/navigation';
 import { API_URL } from '@/lib/constants';
 import { getAuthToken } from '@/lib/auth-helpers';
+import { modelService, TrainingStatus } from '@/lib/services/model';
 import { Brain, Zap, Settings, PlayCircle, AlertCircle } from 'lucide-react';
 import { useSession } from 'next-auth/react';
 
@@ -15,6 +16,9 @@ interface ModelConfig {
   algorithm: string;
   hyperparameters: Record<string, unknown>;
 }
+
+// How often to poll the training status endpoint, in milliseconds.
+const STATUS_POLL_INTERVAL_MS = 2000;
 
 export default function ModelPage() {
   const { data: session } = useSession();
@@ -29,6 +33,8 @@ export default function ModelPage() {
   });
   const [columns, setColumns] = useState<string[]>([]);
   const [trainingProgress, setTrainingProgress] = useState(0);
+  const [trainingStatus, setTrainingStatus] = useState<TrainingStatus | null>(null);
+  const [trainingError, setTrainingError] = useState<string | null>(null);
 
   useEffect(() => {
     if (!canAccessStage(WorkflowStage.MODEL_TRAINING)) {
@@ -64,77 +70,60 @@ export default function ModelPage() {
   };
 
   const handleTrainModel = async () => {
+    if (!state.datasetId) return;
+
     setTraining(true);
     setTrainingProgress(0);
+    setTrainingStatus(null);
+    setTrainingError(null);
 
     try {
-      const token = await getAuthToken();
-      
-      // Start training
-      const response = await fetch(`${API_URL}/models/train`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${token}`
-        },
-        body: JSON.stringify({
-          dataset_id: state.datasetId,
-          ...modelConfig
-        })
+      // Start real AutoML training. The backend auto-detects the problem type
+      // and the engine compares candidate algorithms, so we only need the
+      // dataset and target column here.
+      const result = await modelService.trainModel({
+        dataset_id: state.datasetId,
+        target_column: modelConfig.target_column,
       });
 
-      if (response.ok) {
-        const result = await response.json();
-        
-        // Simulate progress updates
-        const progressInterval = setInterval(() => {
-          setTrainingProgress(prev => {
-            if (prev >= 90) {
-              clearInterval(progressInterval);
-              return 100;
-            }
-            return prev + 10;
-          });
-        }, 1000);
+      // Poll the real status endpoint until the job completes or fails, driving
+      // the progress bar from the job's actual per-algorithm progress.
+      const checkStatus = async () => {
+        try {
+          const status = await modelService.getTrainingStatus(result.model_id);
+          setTrainingStatus(status);
+          setTrainingProgress(Math.round(status.progress * 100));
 
-        // Poll for training status
-        const checkStatus = async () => {
-          const statusResponse = await fetch(
-            `${API_URL}/models/${result.model_id}/status`,
-            {
-              headers: {
-                'Authorization': `Bearer ${token}`
-              }
-            }
-          );
-
-          if (statusResponse.ok) {
-            const status = await statusResponse.json();
-            if (status.status === 'completed') {
-              clearInterval(progressInterval);
-              setTrainingProgress(100);
-              
-              completeStage(WorkflowStage.MODEL_TRAINING, {
-                modelId: result.model_id,
-                config: modelConfig,
-                metrics: status.metrics,
-                timestamp: new Date().toISOString()
-              });
-            } else if (status.status === 'failed') {
-              clearInterval(progressInterval);
-              setTraining(false);
-              // Handle error
-            } else {
-              // Check again in 2 seconds
-              setTimeout(checkStatus, 2000);
-            }
+          if (status.status === 'completed') {
+            setTrainingProgress(100);
+            completeStage(WorkflowStage.MODEL_TRAINING, {
+              modelId: result.model_id,
+              config: modelConfig,
+              metrics: status.metrics,
+              bestAlgorithm: status.best_algorithm,
+              timestamp: new Date().toISOString(),
+            });
+          } else if (status.status === 'failed') {
+            setTrainingError(status.error || 'Training failed');
+            setTraining(false);
+          } else {
+            setTimeout(checkStatus, STATUS_POLL_INTERVAL_MS);
           }
-        };
+        } catch (error) {
+          console.error('Failed to fetch training status:', error);
+          setTrainingError(
+            error instanceof Error ? error.message : 'Failed to fetch training status'
+          );
+          setTraining(false);
+        }
+      };
 
-        setTimeout(checkStatus, 2000);
-      }
+      setTimeout(checkStatus, STATUS_POLL_INTERVAL_MS);
     } catch (error) {
       console.error('Failed to train model:', error);
+      setTrainingError(
+        error instanceof Error ? error.message : 'Failed to start training'
+      );
       setTraining(false);
     }
   };
@@ -154,6 +143,18 @@ export default function ModelPage() {
           <Brain className="w-6 h-6 text-indigo-500" />
           Model Training
         </h1>
+
+        {/* Training errors are shown above the form so they remain visible after
+            a failure returns the user to the configuration view. */}
+        {trainingError && (
+          <div className="mb-6 p-3 bg-red-50 rounded-lg border border-red-200 flex items-start gap-2">
+            <AlertCircle className="w-5 h-5 text-red-600 mt-0.5" />
+            <div className="text-sm text-red-800">
+              <p className="font-semibold">Training failed</p>
+              <p>{trainingError}</p>
+            </div>
+          </div>
+        )}
 
         {!training ? (
           <div className="space-y-6">
@@ -295,7 +296,11 @@ export default function ModelPage() {
 
             <div className="space-y-2">
               <div className="flex justify-between text-sm">
-                <span>Progress</span>
+                <span>
+                  {trainingStatus?.current_algorithm
+                    ? `Training ${trainingStatus.current_algorithm}`
+                    : 'Progress'}
+                </span>
                 <span>{trainingProgress}%</span>
               </div>
               <div className="bg-gray-200 rounded-full h-4 overflow-hidden">
@@ -304,35 +309,73 @@ export default function ModelPage() {
                   style={{ width: `${trainingProgress}%` }}
                 />
               </div>
+              {trainingStatus && trainingStatus.total_algorithms > 0 && (
+                <p className="text-sm text-gray-500 text-right">
+                  {trainingStatus.completed_algorithms} of{' '}
+                  {trainingStatus.total_algorithms} algorithms trained
+                </p>
+              )}
             </div>
 
-            <div className="grid grid-cols-3 gap-4 text-center">
-              <div>
-                <p className="text-2xl font-bold text-gray-900">
-                  {modelConfig.algorithm === 'auto' ? 'AutoML' : modelConfig.algorithm}
-                </p>
-                <p className="text-sm text-gray-500">Algorithm</p>
-              </div>
-              <div>
-                <p className="text-2xl font-bold text-gray-900">
-                  {modelConfig.problem_type}
-                </p>
-                <p className="text-sm text-gray-500">Problem Type</p>
-              </div>
-              <div>
-                <p className="text-2xl font-bold text-gray-900">
-                  {modelConfig.target_column}
-                </p>
-                <p className="text-sm text-gray-500">Target</p>
-              </div>
-            </div>
+            {trainingStatus?.status === 'completed' && (
+              <div className="space-y-4">
+                <div className="text-center">
+                  <p className="text-green-600 font-medium">Training complete!</p>
+                  {trainingStatus.best_algorithm && (
+                    <p className="text-sm text-gray-600 mt-1">
+                      Best model:{' '}
+                      <span className="font-semibold">
+                        {trainingStatus.best_algorithm}
+                      </span>
+                    </p>
+                  )}
+                </div>
 
-            {trainingProgress === 100 && (
-              <div className="text-center">
-                <p className="text-green-600 font-medium">Training complete!</p>
-                <p className="text-sm text-gray-600 mt-1">
-                  Redirecting to evaluation...
-                </p>
+                {trainingStatus.explanation && (
+                  <p className="text-sm text-gray-600 bg-gray-50 rounded-lg p-3">
+                    {trainingStatus.explanation}
+                  </p>
+                )}
+
+                {trainingStatus.model_comparison.length > 0 && (
+                  <div className="overflow-x-auto">
+                    <table className="w-full text-sm">
+                      <thead>
+                        <tr className="text-left text-gray-500 border-b">
+                          <th className="py-2 pr-4">Algorithm</th>
+                          <th className="py-2 pr-4">CV Score</th>
+                          <th className="py-2 pr-4">Test Score</th>
+                          <th className="py-2">Time (s)</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {trainingStatus.model_comparison.map((row) => (
+                          <tr
+                            key={row.algorithm}
+                            className={
+                              row.algorithm === trainingStatus.best_algorithm
+                                ? 'bg-yellow-50 font-medium'
+                                : ''
+                            }
+                          >
+                            <td className="py-2 pr-4">{row.algorithm}</td>
+                            <td className="py-2 pr-4">
+                              {row.cv_score != null ? row.cv_score.toFixed(3) : '—'}
+                            </td>
+                            <td className="py-2 pr-4">
+                              {row.test_score != null ? row.test_score.toFixed(3) : '—'}
+                            </td>
+                            <td className="py-2">
+                              {row.training_time != null
+                                ? row.training_time.toFixed(1)
+                                : '—'}
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                )}
               </div>
             )}
           </div>

--- a/apps/frontend/app/model/page.tsx
+++ b/apps/frontend/app/model/page.tsx
@@ -1,24 +1,26 @@
 'use client';
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useWorkflow } from '@/lib/contexts/WorkflowContext';
 import { WorkflowStage } from '@/lib/types/workflow';
 import { useRouter } from 'next/navigation';
 import { API_URL } from '@/lib/constants';
 import { getAuthToken } from '@/lib/auth-helpers';
 import { modelService, TrainingStatus } from '@/lib/services/model';
-import { Brain, Zap, Settings, PlayCircle, AlertCircle } from 'lucide-react';
+import { Brain, Zap, PlayCircle, AlertCircle } from 'lucide-react';
 import { useSession } from 'next-auth/react';
 
 interface ModelConfig {
-  problem_type: 'classification' | 'regression';
+  // AutoML auto-detects the problem type and chooses the algorithm, so the
+  // target column is the only user-provided training input.
   target_column: string;
-  algorithm: string;
-  hyperparameters: Record<string, unknown>;
 }
 
 // How often to poll the training status endpoint, in milliseconds.
 const STATUS_POLL_INTERVAL_MS = 2000;
+// Stop polling after this many attempts (~20 min) and surface a timeout, so a
+// dead background job doesn't leave the UI polling forever.
+const MAX_STATUS_POLLS = 600;
 
 export default function ModelPage() {
   const { data: session } = useSession();
@@ -26,15 +28,20 @@ export default function ModelPage() {
   const router = useRouter();
   const [training, setTraining] = useState(false);
   const [modelConfig, setModelConfig] = useState<ModelConfig>({
-    problem_type: 'classification',
-    target_column: '',
-    algorithm: 'auto',
-    hyperparameters: {}
+    target_column: ''
   });
   const [columns, setColumns] = useState<string[]>([]);
   const [trainingProgress, setTrainingProgress] = useState(0);
   const [trainingStatus, setTrainingStatus] = useState<TrainingStatus | null>(null);
   const [trainingError, setTrainingError] = useState<string | null>(null);
+  const pollTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Stop any in-flight status polling when the component unmounts.
+  useEffect(() => {
+    return () => {
+      if (pollTimeoutRef.current) clearTimeout(pollTimeoutRef.current);
+    };
+  }, []);
 
   useEffect(() => {
     if (!canAccessStage(WorkflowStage.MODEL_TRAINING)) {
@@ -87,8 +94,12 @@ export default function ModelPage() {
       });
 
       // Poll the real status endpoint until the job completes or fails, driving
-      // the progress bar from the job's actual per-algorithm progress.
+      // the progress bar from the job's actual per-algorithm progress. Bounded
+      // by MAX_STATUS_POLLS so a dead job surfaces a timeout instead of polling
+      // forever; the timeout id is tracked for unmount cleanup.
+      let attempts = 0;
       const checkStatus = async () => {
+        attempts += 1;
         try {
           const status = await modelService.getTrainingStatus(result.model_id);
           setTrainingStatus(status);
@@ -106,8 +117,11 @@ export default function ModelPage() {
           } else if (status.status === 'failed') {
             setTrainingError(status.error || 'Training failed');
             setTraining(false);
+          } else if (attempts >= MAX_STATUS_POLLS) {
+            setTrainingError('Training timed out. Please try again.');
+            setTraining(false);
           } else {
-            setTimeout(checkStatus, STATUS_POLL_INTERVAL_MS);
+            pollTimeoutRef.current = setTimeout(checkStatus, STATUS_POLL_INTERVAL_MS);
           }
         } catch (error) {
           console.error('Failed to fetch training status:', error);
@@ -118,7 +132,7 @@ export default function ModelPage() {
         }
       };
 
-      setTimeout(checkStatus, STATUS_POLL_INTERVAL_MS);
+      pollTimeoutRef.current = setTimeout(checkStatus, STATUS_POLL_INTERVAL_MS);
     } catch (error) {
       console.error('Failed to train model:', error);
       setTrainingError(
@@ -158,36 +172,20 @@ export default function ModelPage() {
 
         {!training ? (
           <div className="space-y-6">
-            {/* Problem Type Selection */}
-            <div>
-              <label className="block text-sm font-medium mb-2">Problem Type</label>
-              <div className="grid grid-cols-2 gap-4">
-                <button
-                  onClick={() => setModelConfig(prev => ({ ...prev, problem_type: 'classification' }))}
-                  className={`p-4 border-2 rounded-lg transition-colors ${
-                    modelConfig.problem_type === 'classification'
-                      ? 'border-blue-500 bg-blue-50'
-                      : 'border-gray-300 hover:border-gray-400'
-                  }`}
-                >
-                  <h3 className="font-semibold">Classification</h3>
-                  <p className="text-sm text-gray-600 mt-1">
-                    Predict categories or classes
-                  </p>
-                </button>
-                <button
-                  onClick={() => setModelConfig(prev => ({ ...prev, problem_type: 'regression' }))}
-                  className={`p-4 border-2 rounded-lg transition-colors ${
-                    modelConfig.problem_type === 'regression'
-                      ? 'border-blue-500 bg-blue-50'
-                      : 'border-gray-300 hover:border-gray-400'
-                  }`}
-                >
-                  <h3 className="font-semibold">Regression</h3>
-                  <p className="text-sm text-gray-600 mt-1">
-                    Predict continuous values
-                  </p>
-                </button>
+            {/* AutoML auto-detects the problem type and compares several
+                algorithms, so the only required input is the target column.
+                (Manual problem-type / single-algorithm selection and Quick/
+                Comprehensive modes are tracked separately — see issues #76/#101.) */}
+            <div className="p-4 bg-indigo-50 rounded-lg border border-indigo-200 flex items-start gap-3">
+              <Zap className="w-5 h-5 text-indigo-500 mt-0.5" />
+              <div className="text-sm text-indigo-900">
+                <p className="font-semibold">AI-guided AutoML</p>
+                <p className="mt-1 text-indigo-800">
+                  We automatically detect whether this is a classification or
+                  regression problem, train and cross-validate several algorithms
+                  (Logistic/Linear Regression, Random Forest, XGBoost and more),
+                  and pick the best model — with an explanation of why.
+                </p>
               </div>
             </div>
 
@@ -204,49 +202,9 @@ export default function ModelPage() {
                   <option key={column} value={column}>{column}</option>
                 ))}
               </select>
-            </div>
-
-            {/* Algorithm Selection */}
-            <div>
-              <label className="block text-sm font-medium mb-2">Algorithm</label>
-              <div className="grid grid-cols-3 gap-3">
-                <button
-                  onClick={() => setModelConfig(prev => ({ ...prev, algorithm: 'auto' }))}
-                  className={`p-3 border rounded-lg transition-colors ${
-                    modelConfig.algorithm === 'auto'
-                      ? 'border-blue-500 bg-blue-50'
-                      : 'border-gray-300 hover:border-gray-400'
-                  }`}
-                >
-                  <Zap className="w-5 h-5 mx-auto mb-1 text-yellow-500" />
-                  <p className="text-sm font-medium">AutoML</p>
-                  <p className="text-xs text-gray-500">Let AI choose</p>
-                </button>
-                <button
-                  onClick={() => setModelConfig(prev => ({ ...prev, algorithm: 'random_forest' }))}
-                  className={`p-3 border rounded-lg transition-colors ${
-                    modelConfig.algorithm === 'random_forest'
-                      ? 'border-blue-500 bg-blue-50'
-                      : 'border-gray-300 hover:border-gray-400'
-                  }`}
-                >
-                  <Settings className="w-5 h-5 mx-auto mb-1 text-green-500" />
-                  <p className="text-sm font-medium">Random Forest</p>
-                  <p className="text-xs text-gray-500">Robust & accurate</p>
-                </button>
-                <button
-                  onClick={() => setModelConfig(prev => ({ ...prev, algorithm: 'xgboost' }))}
-                  className={`p-3 border rounded-lg transition-colors ${
-                    modelConfig.algorithm === 'xgboost'
-                      ? 'border-blue-500 bg-blue-50'
-                      : 'border-gray-300 hover:border-gray-400'
-                  }`}
-                >
-                  <Settings className="w-5 h-5 mx-auto mb-1 text-purple-500" />
-                  <p className="text-sm font-medium">XGBoost</p>
-                  <p className="text-xs text-gray-500">High performance</p>
-                </button>
-              </div>
+              <p className="text-xs text-gray-500 mt-1">
+                The column you want the model to predict.
+              </p>
             </div>
 
             {/* Warning */}
@@ -374,6 +332,35 @@ export default function ModelPage() {
                         ))}
                       </tbody>
                     </table>
+                  </div>
+                )}
+
+                {trainingStatus.algorithm_recommendations.length > 0 && (
+                  <div className="space-y-2">
+                    <h3 className="text-sm font-semibold text-gray-700">
+                      Why these algorithms?
+                    </h3>
+                    <div className="space-y-2">
+                      {trainingStatus.algorithm_recommendations.map((rec) => (
+                        <div
+                          key={rec.algorithm_name}
+                          className="border border-gray-200 rounded-lg p-3"
+                        >
+                          <div className="flex items-center justify-between">
+                            <span className="font-medium text-sm">
+                              {rec.algorithm_name}
+                            </span>
+                            <span className="text-xs text-gray-500">
+                              Priority {rec.priority}/10 · Interpretability{' '}
+                              {rec.interpretability_score}/10
+                            </span>
+                          </div>
+                          <p className="text-sm text-gray-600 mt-1">
+                            {rec.explanation}
+                          </p>
+                        </div>
+                      ))}
+                    </div>
                   </div>
                 )}
               </div>

--- a/apps/frontend/lib/services/model.ts
+++ b/apps/frontend/lib/services/model.ts
@@ -160,6 +160,15 @@ export class ModelService {
     return response.json()
   }
 
+  /**
+   * Fetch the status and results of an async training job.
+   *
+   * @param modelId - The id returned by {@link trainModel}.
+   * @param token - Bearer token, or `null` to omit the Authorization header.
+   * @returns The job status: progress while running; comparison, best model,
+   *   explanation and recommendations when completed; or the error when failed.
+   * @throws Error with the backend `detail` message on a non-OK response.
+   */
   static async getTrainingStatus(
     modelId: string,
     token: string | null
@@ -252,6 +261,7 @@ class ModelServiceClient {
     return ModelService.getModel(modelId, token)
   }
 
+  /** Resolve the auth token automatically and fetch a training job's status. */
   async getTrainingStatus(modelId: string): Promise<TrainingStatus> {
     const token = await getAuthToken()
     return ModelService.getTrainingStatus(modelId, token)

--- a/apps/frontend/lib/services/model.ts
+++ b/apps/frontend/lib/services/model.ts
@@ -44,6 +44,40 @@ export interface ModelInfo {
   version?: string | number
 }
 
+export interface ModelComparisonEntry {
+  algorithm: string
+  cv_score?: number | null
+  test_score?: number | null
+  training_time?: number | null
+}
+
+export interface AlgorithmRecommendation {
+  algorithm_name: string
+  priority: number
+  expected_performance: string
+  training_time_estimate: string
+  interpretability_score: number
+  explanation: string
+  pros: string[]
+  cons: string[]
+}
+
+export interface TrainingStatus {
+  model_id: string
+  status: 'pending' | 'running' | 'completed' | 'failed'
+  progress: number // 0.0 - 1.0
+  current_algorithm?: string | null
+  completed_algorithms: number
+  total_algorithms: number
+  metrics: Record<string, unknown>
+  model_comparison: ModelComparisonEntry[]
+  algorithm_recommendations: AlgorithmRecommendation[]
+  best_model_id?: string | null
+  best_algorithm?: string | null
+  explanation?: string | null
+  error?: string | null
+}
+
 export interface PredictRequest {
   data: Record<string, any>[]
   include_probabilities?: boolean
@@ -126,6 +160,25 @@ export class ModelService {
     return response.json()
   }
 
+  static async getTrainingStatus(
+    modelId: string,
+    token: string | null
+  ): Promise<TrainingStatus> {
+    const response = await fetch(
+      `${API_BASE_URL}/ml/${modelId}/status`,
+      {
+        headers: await this.getHeaders(token)
+      }
+    )
+
+    if (!response.ok) {
+      const error = await response.json().catch(() => ({}))
+      throw new Error(error.detail || 'Failed to fetch training status')
+    }
+
+    return response.json()
+  }
+
   static async predict(
     modelId: string,
     request: PredictRequest,
@@ -197,6 +250,11 @@ class ModelServiceClient {
   async getModel(modelId: string): Promise<ModelInfo> {
     const token = await getAuthToken()
     return ModelService.getModel(modelId, token)
+  }
+
+  async getTrainingStatus(modelId: string): Promise<TrainingStatus> {
+    const token = await getAuthToken()
+    return ModelService.getTrainingStatus(modelId, token)
   }
 
   async trainModel(

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,0 +1,62 @@
+# Issue #75 — Core AutoML Training Pipeline (P2.1)
+
+## Reality check vs. the issue's "Current State (verified 2026-06-05)"
+
+The issue (and the Traycer plan) describe `POST /ml/train` as a stub and the engine as missing.
+**That is no longer true.** As of today the following already exist and are functional:
+
+- `automl_engine.py` — trains real models (LogReg/RF/XGBoost/LightGBM/GB/SVM/KNN; LinReg/Ridge/RF/XGBoost/…), stratified split, k-fold CV, best-model selection, feature importance.
+- `problem_detector.py`, `feature_engineer.py`, `algorithm_selector.py`, `explanation_service.py` (OpenAI + fallback) — all implemented.
+- `model_storage.py` — joblib → S3 + `MLModel` metadata → MongoDB; load/list/delete.
+- `POST /ml/train` (real background training), `GET /ml/`, `GET /ml/{id}`, `POST /ml/{id}/predict`, `DELETE`, `PUT deactivate` — all working.
+- `imbalanced-learn`, `statsmodels`, `prophet` already in `pyproject.toml`.
+
+**Therefore this is a focused gap-fill, not a greenfield build.** We target ONLY the unmet acceptance
+criteria and explicitly do NOT add the Traycer over-scope (WebSocket, ARIMA/Prophet, SMOTE, training modes).
+
+## Genuine remaining gaps (the real work)
+
+1. No training **job/status tracking** — `train_model_task` is fire-and-forget; failures are silently re-raised. No status endpoint (the response literally says "Check status endpoint" but none exists).
+2. **Model comparison** computed (`all_models`) but discarded — only best model saved; not exposed via API; no AI best-model explanation surfaced.
+3. Engine has **no basic class-imbalance handling**, and does not wire in the existing `AlgorithmSelector` recommendations or `ExplanationService`.
+4. **Frontend `app/model/page.tsx` is broken**: posts to `/models/train` (wrong; should be `/ml/train`), wrong payload shape, polls non-existent `/models/{id}/status`, fake simulated progress.
+5. No tests for the new status/job layer or the frontend wiring.
+
+## Plan (TDD throughout)
+
+> **Scope decisions (Phase 4):** Gap-fill only. **Job cancellation is OUT** (deferred — Known Limitation
+> for AC4's "cancellable" clause). Explanations use `ExplanationService`'s **deterministic rule-based
+> fallback** (no OpenAI runtime calls/API key required). Also post a correction comment on issue #75.
+
+### Backend
+- [ ] **B1. `TrainingJob` model** (`app/models/training_job.py`, register in `app/models/registry.py`), keyed by `model_id`: `user_id`, `dataset_id`, `target_column`, `status` (pending/running/completed/failed), `progress` (0–1 + current/total/current_algorithm), `algorithm_recommendations`, `model_comparison` (list of {algorithm, cv_score, test_score, training_time}), `best_model_id`, `best_model_explanation`, `error`, timestamps. → unit tests.
+- [ ] **B2. Engine: basic class-imbalance + surface recommendations/explanation.** Add `class_weight="balanced"` for supporting classifiers when imbalance ratio > 2 (lightweight "basic" handling, no resampling). Surface `AlgorithmSelector` recommendations + `ExplanationService` best-model explanation (**rule-based fallback path**, no API key needed) and the full `all_models` comparison in the result. → engine tests.
+- [ ] **B3. Refactor `train_model_task`**: create/update `TrainingJob` (status=running), update `progress` via per-model callback, persist comparison + best explanation on success (completed), set status=failed + `error` on exception (no more silent re-raise).
+- [ ] **B4. Endpoint**: `GET /ml/{model_id}/status` → {status, progress, metrics, comparison, best_model_id, explanation, error}. Create the `pending` `TrainingJob` synchronously in `train_model` before returning. → API tests (running/completed/failed).
+- [ ] **B5. Integration test** (service-gated): POST `/ml/train` on a sample CSV → poll status → completed with persisted model + comparison.
+
+### Frontend
+- [ ] **F1. Fix `app/model/page.tsx`**: route through `ModelService`; POST `/ml/train` with correct payload; poll `/ml/{model_id}/status`; drive real progress from `job.progress`; show comparison + best model on completion.
+- [ ] **F2. `ModelService`**: add `getTrainingStatus(modelId)`, align types. → jest tests (service + page happy/failure paths, mocked fetch).
+
+### Docs / housekeeping
+- [ ] **D1.** Update `CLAUDE.md` "Current Stage" + a short AutoML status/endpoints note; OpenAPI reflects new routes automatically.
+- [ ] **D2.** Post a comment on issue #75 correcting the outdated "Current State" and listing done-vs-remaining.
+
+## Explicitly deferred (out of scope per the issue itself)
+- Real-time WebSocket UI → **#76 (P2.2)**
+- Time-series ARIMA/Prophet → post-beta
+- SMOTE/resampling beyond `class_weight` → post-beta
+- Quick/Comprehensive training modes → **#101 (P5.9)**
+- Hyperparameter tuning / GridSearch → **#77 (P5.1)**
+
+## Acceptance criteria coverage
+- AC1 problem-type detection — already ✅ (engine uses `problem_detector`)
+- AC2 algorithm recommendation + plain-language explanation — **B2** (wire existing selector/explanation)
+- AC3 split / stratified / k-fold / basic imbalance — split+stratify+CV ✅; imbalance via **B2**
+- AC4 async + progress queryable — **B1/B3/B4**; **cancellable = deferred (Known Limitation)**
+- AC5 artifacts→S3, metadata→MongoDB — already ✅
+- AC6 model comparison + best-model selection + explanation — **B2/B3/B4**
+- AC7 `POST /ml/train` trains ✅; `GET` returns real status/results — **B4**
+- AC8 frontend wired to real endpoints — **F1/F2**
+- AC9 TDD >85% on new code; integration test on sample CSV; train workflow test — tests across B/F


### PR DESCRIPTION
## Summary
Implements the remaining gaps of #75 (P2.1 — core AutoML training pipeline).

**Important — the issue's "Current State (verified 2026-06-05)" was out of date.** The AutoML engine, problem detector, feature engineer, algorithm selector, OpenAI explanation service, S3/Mongo model storage, and a working `POST /api/v1/ml/train` (real background training) **already existed** on `main`. `POST /ml/train` is **not** a stub. This PR is a focused **gap-fill** to the unmet acceptance criteria, not a greenfield build. (A correction comment was posted on the issue.)

### What this PR adds
- **Training job status layer** — new `TrainingJob` document (`app/models/training_job.py`, registered in the canonical Beanie registry) + `GET /api/v1/ml/{model_id}/status`. Previously `train_model_task` was fire-and-forget with no status, and failures were silently re-raised.
- **Model comparison + best-model explanation** — the engine already computed `all_models` but discarded them; now the ranked side-by-side comparison (algorithm, CV score, test score, training time) is persisted and exposed, along with a plain-language, deterministic (LLM-free) best-model explanation.
- **Algorithm recommendations** — surfaced via the existing rule-based `AlgorithmSelector` (no runtime OpenAI) and rendered in the UI.
- **Basic class-imbalance handling** — `class_weight="balanced"` on the estimators that support it when the majority/minority ratio exceeds 2:1.
- **Frontend wiring** — `app/model/page.tsx` posted to a non-existent `/models/train` and polled a non-existent `/models/{id}/status` with a fake progress bar. It now starts real training, polls the real status endpoint, drives the progress bar from the job's actual per-algorithm progress, and renders the comparison, best-model explanation, and recommendations on completion. Misleading manual problem-type / single-algorithm selectors (silently ignored by the AutoML backend) were replaced with an honest AI-guided AutoML info card.

## Acceptance Criteria
- [x] Automatic problem type detection — already present; engine uses `problem_detector`
- [x] Algorithm recommendation with plain-language explanation — rule-based `AlgorithmSelector`, surfaced via API + UI
- [x] Training pipeline: train/test split, stratified sampling, k-fold CV, **basic** class-imbalance handling
- [x] Async training with progress state queryable via API — `TrainingJob` + status endpoint *(cancellable: deferred, see below)*
- [x] Model artifacts → S3, metadata → MongoDB — already present
- [x] Model comparison: side-by-side metrics, training time, best-model selection with explanation
- [x] `POST /ml/train` trains; `GET /ml/{model_id}/status` returns real status/results
- [x] Frontend wired to real endpoints
- [x] TDD: unit + API + integration tests; diff coverage 95% on new lines

## Test Plan
- [x] Unit tests written (TDD): `TrainingJob` lifecycle, comparison helpers, engine class-imbalance/progress/comparison
- [x] API tests: status endpoint (pending/running/completed/failed), job creation, failure recording
- [x] Integration test: real AutoML training on a sample CSV → job completed with comparison (S3 boundary stubbed; LocalStack not required)
- [x] Frontend jest: `getTrainingStatus` service + page happy/failure paths
- [x] All tests passing (backend affected: 51; frontend suite: 899 passed / 10 skipped)
- [x] Diff coverage ≥85% on changed lines — **95%**
- [x] Linting clean (ruff + eslint); type-check clean (tsc); mypy advisory (only pre-existing predict-endpoint warnings remain)
- [x] Internal code review (advisory) completed
- [x] Cross-family review pass: **codex** (+ internal Claude review); all findings triaged and fixed
- [x] Test mutation sanity check completed

## Known Limitations / Intentionally Deferred
- **Job cancellation** (AC4's "cancellable" clause) — deferred. True cancellation is unreliable with in-process FastAPI `BackgroundTasks`; it fits better once a real task queue lands. (Per the Phase-4 scope decision.)
- **Real-time progress** uses polling, not WebSockets — real-time UI is **#76 (P2.2)**.
- **AI explanations** use a deterministic rule-based path (no runtime OpenAI calls/API key) — per the scope decision.
- **Forcing a specific algorithm / problem type** from the UI is not supported — the backend auto-detects the problem type and AutoML compares candidates. The (previously dead) manual selectors were removed rather than wired to unsupported behavior.
- Out of scope per the issue/roadmap: time-series ARIMA/Prophet (post-beta), SMOTE resampling (post-beta), Quick/Comprehensive training modes (**#101**), hyperparameter tuning (**#77**).
- Pre-existing mypy advisory warnings on the `predict` endpoint (`MLModel | None` derefs) are left as-is — unrelated to this issue.

## Implementation Notes
- Single feature branch, TDD throughout. Plan recorded in `tasks/todo.md`.
- The engine gained an optional `progress_callback` and a `model_comparison`/`class_balance` summary in result metadata; pure result-summary helpers live in `app/services/model_training/comparison.py`.
- `model_id` now carries a short uuid suffix so same-second requests can't collide on the status lookup key.

Closes #75

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Live async training with a polling status endpoint; progress, per-algorithm progress, comparisons, recommendations, and best-model explanation surfaced in the UI
  * Frontend wired to real backend training flow and simplified training config

* **Bug Fixes**
  * Failures recorded on training jobs and surfaced to the UI without crashing background tasks

* **Tests**
  * New unit/integration tests covering training workflow, engine behavior, comparison helpers, and status endpoint

* **Documentation**
  * Updated AutoML training docs with lifecycle, endpoints, and scope notes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->