### PR TITLE
fix(deploy): staging uses MongoDB Atlas, .env.staging env-file, frontend port 3011

### DIFF
--- a/.env.staging.example
+++ b/.env.staging.example
@@ -18,7 +18,7 @@
 # MongoDB Atlas Connection (REQUIRED)
 # Format: mongodb+srv://username:password@cluster.mongodb.net/dbname?retryWrites=true&w=majority
 MONGODB_URI=mongodb+srv://USERNAME:PASSWORD@CLUSTER.mongodb.net/narrative_staging?retryWrites=true&w=majority
-MONGODB_DB=narrative_staging
+MONGODB_DB=narrative_modeling-staging
 
 # Redis Connection — do NOT set REDIS_URL here. docker-compose.staging.yml
 # builds it from REDIS_PASSWORD (env files do not interpolate ${VARS}).

--- a/.env.staging.example
+++ b/.env.staging.example
@@ -20,8 +20,8 @@
 MONGODB_URI=mongodb+srv://USERNAME:PASSWORD@CLUSTER.mongodb.net/narrative_staging?retryWrites=true&w=majority
 MONGODB_DB=narrative_staging
 
-# Redis Connection
-REDIS_URL=redis://:REDIS_PASSWORD@redis:6379/0
+# Redis Connection — do NOT set REDIS_URL here. docker-compose.staging.yml
+# builds it from REDIS_PASSWORD (env files do not interpolate ${VARS}).
 
 # ═══════════════════════════════════════════════════════════════
 # CACHE CREDENTIALS
@@ -64,8 +64,9 @@ ALLOWED_ORIGINS=https://narrative.yourdomain.com,https://staging.yourdomain.com
 # FRONTEND CONFIGURATION
 # ═══════════════════════════════════════════════════════════════
 
-# Public API URL (accessible from browser)
-NEXT_PUBLIC_API_URL=https://narrative.yourdomain.com/api
+# Public API URL (accessible from browser) — MUST include the /api/v1 prefix;
+# the frontend uses this value as the full base URL for backend calls.
+NEXT_PUBLIC_API_URL=https://narrative.yourdomain.com/api/v1
 
 # NextAuth configuration
 NEXTAUTH_URL=https://narrative.yourdomain.com

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,7 +7,10 @@ name: Deploy (Staging)
 # in as the deploy user, pulls main, and rebuilds the stack with
 # docker-compose.staging.yml (which builds apps/backend/Dockerfile and
 # apps/frontend/Dockerfile). Application secrets live in .env.staging ON THE
-# SERVER and are never passed through CI.
+# SERVER and are never passed through CI; compose is invoked with
+# `--env-file .env.staging` so those values are interpolated. MongoDB is a
+# managed Atlas cluster (MONGODB_URI in .env.staging) — no Mongo container is
+# deployed.
 #
 # Required repository secrets (Settings → Secrets and variables → Actions):
 #   STAGING_SSH_PRIVATE_KEY  - private key authorized for the deploy user
@@ -80,8 +83,9 @@ jobs:
              git fetch --prune origin
              git checkout main
              git reset --hard origin/main
-             docker compose -f docker-compose.staging.yml up -d --build
-             docker compose -f docker-compose.staging.yml ps"
+             test -f .env.staging || { echo '.env.staging missing on server'; exit 1; }
+             docker compose -f docker-compose.staging.yml --env-file .env.staging up -d --build --remove-orphans
+             docker compose -f docker-compose.staging.yml --env-file .env.staging ps"
 
       - name: Health check
         if: steps.preflight.outputs.configured == 'true'

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -1,20 +1,22 @@
-version: '3.8'
-
 # ═══════════════════════════════════════════════════════════════
 # Narrative Modeling App - STAGING DEPLOYMENT
-# Server: 47.88.89.175
+# Server: dev.briaanalytics.com (47.88.89.175)
 # Environment: Staging (pre-production)
 # ═══════════════════════════════════════════════════════════════
 #
 # SECURITY NOTICE:
 # This configuration uses authentication and secure settings
 # Suitable for staging/production environments
-# All secrets should be provided via .env.staging file
+# All secrets are provided via .env.staging on the server; run
+# compose with `--env-file .env.staging` (deploy.yml does this).
+#
+# MongoDB is NOT run here — staging uses a MongoDB Atlas cluster.
+# Set MONGODB_URI (mongodb+srv://...) and MONGODB_DB in .env.staging.
 #
 # Port Assignments (to avoid conflicts on shared server):
-# - Frontend: 3010 (internal), proxied via nginx
-# - Backend: 8010 (internal), proxied via nginx
-# - MongoDB: 27018 (host port)
+# - Frontend: 3011 (host), proxied via nginx (3010 is taken by
+#   another app on the shared VPS)
+# - Backend: 8010 (host), proxied via nginx
 # - Redis: 6381 (host port)
 # ═══════════════════════════════════════════════════════════════
 
@@ -34,8 +36,9 @@ services:
       DEBUG: "false"
       LOG_LEVEL: info
 
-      # Database
-      MONGODB_URI: mongodb://narrative_user:${MONGODB_PASSWORD}@mongodb:27017/narrative_staging?authSource=admin
+      # Database (MongoDB Atlas — values come from .env.staging)
+      MONGODB_URI: ${MONGODB_URI}
+      MONGODB_DB: ${MONGODB_DB:-narrative_modeling-staging}
 
       # Redis
       REDIS_URL: redis://:${REDIS_PASSWORD}@redis:6379/0
@@ -55,8 +58,6 @@ services:
     volumes:
       - backend_logs:/app/logs
     depends_on:
-      mongodb:
-        condition: service_healthy
       redis:
         condition: service_healthy
     healthcheck:
@@ -78,7 +79,7 @@ services:
     container_name: narrative-staging-frontend
     restart: unless-stopped
     ports:
-      - "3010:3000"  # Custom port to avoid conflicts
+      - "3011:3000"  # Custom port to avoid conflicts (3010 is taken on the shared VPS)
     environment:
       NODE_ENV: production
       NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL}
@@ -96,32 +97,6 @@ services:
       timeout: 10s
       retries: 3
       start_period: 40s
-    networks:
-      - narrative-network
-
-  # MongoDB Database
-  mongodb:
-    image: mongo:7.0
-    container_name: narrative-staging-mongodb
-    restart: unless-stopped
-    ports:
-      - "27018:27017"  # Custom port to avoid conflicts
-    environment:
-      MONGO_INITDB_ROOT_USERNAME: admin
-      MONGO_INITDB_ROOT_PASSWORD: ${MONGODB_ROOT_PASSWORD}
-      MONGO_INITDB_DATABASE: narrative_staging
-    volumes:
-      - mongodb_data:/data/db
-      - mongodb_config:/data/configdb
-      - ./scripts/mongodb-init.js:/docker-entrypoint-initdb.d/init.js:ro
-    command: mongod --auth
-    healthcheck:
-      test: |
-        mongosh --username admin --password ${MONGODB_ROOT_PASSWORD} --eval "db.adminCommand('ping')" --quiet
-      interval: 10s
-      timeout: 5s
-      retries: 5
-      start_period: 30s
     networks:
       - narrative-network
 
@@ -144,10 +119,6 @@ services:
       - narrative-network
 
 volumes:
-  mongodb_data:
-    driver: local
-  mongodb_config:
-    driver: local
   redis_data:
     driver: local
   backend_logs:

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -37,11 +37,11 @@ services:
       LOG_LEVEL: info
 
       # Database (MongoDB Atlas — values come from .env.staging)
-      MONGODB_URI: ${MONGODB_URI}
+      MONGODB_URI: ${MONGODB_URI:?MONGODB_URI (Atlas connection string) must be set in .env.staging}
       MONGODB_DB: ${MONGODB_DB:-narrative_modeling-staging}
 
       # Redis
-      REDIS_URL: redis://:${REDIS_PASSWORD}@redis:6379/0
+      REDIS_URL: redis://:${REDIS_PASSWORD:?REDIS_PASSWORD must be set in .env.staging}@redis:6379/0
 
       # S3 Storage (use real AWS S3 for staging)
       AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
@@ -75,6 +75,8 @@ services:
       context: ./apps/frontend
       dockerfile: Dockerfile
       args:
+        # Full backend base URL INCLUDING the /api/v1 prefix, e.g.
+        # https://dev.briaanalytics.com/api/v1 — baked in at build time.
         NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL}
     container_name: narrative-staging-frontend
     restart: unless-stopped

--- a/docs/deployment/STAGING_DEPLOYMENT_GUIDE.md
+++ b/docs/deployment/STAGING_DEPLOYMENT_GUIDE.md
@@ -68,9 +68,9 @@ chown -R narrative-deploy:narrative-deploy /opt/narrative-modeling-app
 ```bash
 # On your local machine or staging server, generate secrets:
 
-# MongoDB passwords
-openssl rand -base64 32  # For MONGODB_ROOT_PASSWORD
-openssl rand -base64 32  # For MONGODB_PASSWORD
+# MongoDB: staging uses a managed MongoDB Atlas cluster — no local Mongo
+# container or passwords. Get the mongodb+srv:// connection string from the
+# Atlas UI (Database → Connect → Drivers) for MONGODB_URI.
 
 # Redis password
 openssl rand -base64 32  # For REDIS_PASSWORD
@@ -103,16 +103,16 @@ nano .env.staging
 ```
 
 **Required values**:
-- `MONGODB_ROOT_PASSWORD`: Generated secret
-- `MONGODB_PASSWORD`: Generated secret
-- `REDIS_PASSWORD`: Generated secret
+- `MONGODB_URI`: MongoDB Atlas connection string (`mongodb+srv://...`)
+- `MONGODB_DB`: Staging database name (e.g. `narrative_modeling-staging`)
+- `REDIS_PASSWORD`: Generated secret (do **not** set `REDIS_URL` — compose builds it)
 - `AWS_ACCESS_KEY_ID`: Your AWS key
 - `AWS_SECRET_ACCESS_KEY`: Your AWS secret
 - `S3_BUCKET_NAME`: narrative-staging-uploads
 - `OPENAI_API_KEY`: Your OpenAI key
 - `BACKEND_SECRET_KEY`: Generated secret
 - `NEXTAUTH_SECRET`: Generated secret
-- `NEXT_PUBLIC_API_URL`: https://narrative.yourdomain.com/api
+- `NEXT_PUBLIC_API_URL`: https://narrative.yourdomain.com/api/v1 (must include `/api/v1`)
 - `NEXTAUTH_URL`: https://narrative.yourdomain.com
 - `ALLOWED_ORIGINS`: https://narrative.yourdomain.com
 - Google/GitHub OAuth credentials (if using authentication)
@@ -139,17 +139,15 @@ git clone https://github.com/frankbria/narrative-modeling-app.git .
 # Checkout main branch
 git checkout main
 
-# Copy environment file
-cp .env.staging .env
-
-# Build and start services
-docker compose -f docker-compose.staging.yml up -d --build
+# Build and start services (--env-file is required: compose only auto-reads
+# a file literally named .env, and secrets live in .env.staging)
+docker compose -f docker-compose.staging.yml --env-file .env.staging up -d --build
 
 # Check status
-docker compose -f docker-compose.staging.yml ps
+docker compose -f docker-compose.staging.yml --env-file .env.staging ps
 
 # View logs
-docker compose -f docker-compose.staging.yml logs -f
+docker compose -f docker-compose.staging.yml --env-file .env.staging logs -f
 ```
 
 ### Option B: Automated Deployment (via GitHub Actions)
@@ -157,7 +155,7 @@ docker compose -f docker-compose.staging.yml logs -f
 Implemented in `.github/workflows/deploy.yml` (issue #150). On every push to
 `main` (and via manual `workflow_dispatch`), the workflow SSHes into the staging
 server, fast-forwards the deploy checkout to `origin/main`, and rebuilds the
-stack with `docker compose -f docker-compose.staging.yml up -d --build`, then
+stack with `docker compose -f docker-compose.staging.yml --env-file .env.staging up -d --build`, then
 polls the backend `/health` endpoint (host port 8010).
 
 **One-time setup** — add these repository secrets
@@ -226,11 +224,10 @@ certbot renew --dry-run
 # Check UFW status
 ufw status
 
-# Allow required ports (if not already allowed)
-ufw allow 3010/tcp comment 'Narrative Frontend'
-ufw allow 8010/tcp comment 'Narrative Backend'
-ufw allow 27018/tcp comment 'Narrative MongoDB'
-ufw allow 6381/tcp comment 'Narrative Redis'
+# No app ports need to be opened: nginx (80/443) proxies to the frontend
+# (3011) and backend (8010) on localhost, and Redis (6381) is internal.
+# MongoDB is in Atlas — ensure the server's public IP is in the Atlas
+# project's IP Access List instead.
 
 # Reload firewall
 ufw reload
@@ -245,12 +242,11 @@ ufw status numbered
 
 ```bash
 # Check all containers are running
-docker compose -f docker-compose.staging.yml ps
+docker compose -f docker-compose.staging.yml --env-file .env.staging ps
 
 # Expected output:
 # narrative-staging-backend    Up (healthy)
 # narrative-staging-frontend   Up (healthy)
-# narrative-staging-mongodb    Up (healthy)
 # narrative-staging-redis      Up (healthy)
 
 # Test backend health endpoint
@@ -258,7 +254,7 @@ curl http://localhost:8010/health
 # Expected: {"status": "healthy"}
 
 # Test frontend
-curl http://localhost:3010
+curl http://localhost:3011
 # Expected: HTML response
 
 # Test via nginx (external access)
@@ -291,23 +287,23 @@ Access the application in browser:
 
 ```bash
 # All services
-docker compose -f docker-compose.staging.yml logs -f
+docker compose -f docker-compose.staging.yml --env-file .env.staging logs -f
 
 # Specific service
-docker compose -f docker-compose.staging.yml logs -f backend
+docker compose -f docker-compose.staging.yml --env-file .env.staging logs -f backend
 
 # Last 100 lines
-docker compose -f docker-compose.staging.yml logs --tail=100 backend
+docker compose -f docker-compose.staging.yml --env-file .env.staging logs --tail=100 backend
 ```
 
 ### Restart Services
 
 ```bash
 # Restart all
-docker compose -f docker-compose.staging.yml restart
+docker compose -f docker-compose.staging.yml --env-file .env.staging restart
 
 # Restart specific service
-docker compose -f docker-compose.staging.yml restart backend
+docker compose -f docker-compose.staging.yml --env-file .env.staging restart backend
 ```
 
 ### Update Application
@@ -321,28 +317,20 @@ cd /opt/narrative-modeling-app/staging
 git pull origin main
 
 # Rebuild and restart
-docker compose -f docker-compose.staging.yml up -d --build
+docker compose -f docker-compose.staging.yml --env-file .env.staging up -d --build
 
 # Verify
-docker compose -f docker-compose.staging.yml ps
+docker compose -f docker-compose.staging.yml --env-file .env.staging ps
 ```
 
 ### Database Backup
 
+MongoDB lives in Atlas — use Atlas's built-in backups (Cloud Backup is on by
+default for M10+; for free/shared tiers run `mongodump` against the Atlas URI):
+
 ```bash
-# Create backup directory
-mkdir -p /opt/narrative-modeling-app/backups
-
-# Backup MongoDB
-docker exec narrative-staging-mongodb mongodump \
-  --username admin \
-  --password YOUR_MONGODB_ROOT_PASSWORD \
-  --authenticationDatabase admin \
-  --out /data/backup
-
-# Copy backup from container
-docker cp narrative-staging-mongodb:/data/backup \
-  /opt/narrative-modeling-app/backups/mongodb-$(date +%Y%m%d-%H%M%S)
+mongodump --uri "$MONGODB_URI" \
+  --out /opt/narrative-modeling-app/backups/mongodb-$(date +%Y%m%d-%H%M%S)
 ```
 
 ---
@@ -353,29 +341,25 @@ docker cp narrative-staging-mongodb:/data/backup \
 
 ```bash
 # Check logs for errors
-docker compose -f docker-compose.staging.yml logs [service-name]
+docker compose -f docker-compose.staging.yml --env-file .env.staging logs [service-name]
 
 # Check container status
-docker compose -f docker-compose.staging.yml ps -a
+docker compose -f docker-compose.staging.yml --env-file .env.staging ps -a
 
 # Inspect specific container
 docker inspect narrative-staging-backend
 ```
 
-### MongoDB authentication issues
+### MongoDB (Atlas) connection issues
 
 ```bash
-# Connect to MongoDB container
-docker exec -it narrative-staging-mongodb mongosh \
-  --username admin \
-  --password YOUR_MONGODB_ROOT_PASSWORD \
-  --authenticationDatabase admin
+# Test the Atlas connection string from the server
+mongosh "$MONGODB_URI" --eval "db.adminCommand('ping')"
 
-# List users
-db.getSiblingDB('admin').getUsers()
-
-# Check application user
-db.getSiblingDB('narrative_staging').getUsers()
+# Common causes:
+# - Server IP missing from the Atlas project's IP Access List
+# - Wrong username/password in MONGODB_URI
+# - DNS: mongodb+srv requires working SRV lookups (dig SRV _mongodb._tcp.<cluster-host>)
 ```
 
 ### Nginx issues
@@ -395,11 +379,10 @@ systemctl restart nginx
 
 ```bash
 # Check if services can communicate
-docker exec narrative-staging-backend ping mongodb
 docker exec narrative-staging-backend ping redis
 
-# Check DNS resolution
-docker exec narrative-staging-backend nslookup mongodb
+# Check Atlas reachability from inside the backend container
+docker exec narrative-staging-backend python -c "import os,pymongo; pymongo.MongoClient(os.environ['MONGODB_URI']).admin.command('ping'); print('atlas ok')"
 ```
 
 ---
@@ -410,17 +393,17 @@ If deployment fails:
 
 ```bash
 # Stop services
-docker compose -f docker-compose.staging.yml down
+docker compose -f docker-compose.staging.yml --env-file .env.staging down
 
 # Checkout previous working commit
 git log --oneline -n 10  # Find previous commit
 git checkout <previous-commit-hash>
 
 # Rebuild and restart
-docker compose -f docker-compose.staging.yml up -d --build
+docker compose -f docker-compose.staging.yml --env-file .env.staging up -d --build
 
 # Verify
-docker compose -f docker-compose.staging.yml ps
+docker compose -f docker-compose.staging.yml --env-file .env.staging ps
 ```
 
 ---
@@ -430,7 +413,7 @@ docker compose -f docker-compose.staging.yml ps
 Post-deployment security verification:
 
 - [ ] All services running with authentication enabled
-- [ ] MongoDB requires username/password
+- [ ] Atlas IP Access List restricted to the staging server (no 0.0.0.0/0)
 - [ ] Redis requires password
 - [ ] SSL/TLS certificate installed and valid
 - [ ] Firewall rules configured
@@ -446,9 +429,8 @@ Post-deployment security verification:
 1. **Set up automated backups** (daily MongoDB dumps to S3)
 2. **Configure monitoring** (Prometheus + Grafana or similar)
 3. **Set up log aggregation** (ELK stack or CloudWatch)
-4. **Create GitHub Actions deployment workflow** for automated deployments
-5. **Document production deployment** process
-6. **Set up staging→production promotion** workflow
+4. **Document production deployment** process
+5. **Set up staging→production promotion** workflow
 
 ---
 

--- a/nginx-staging.conf
+++ b/nginx-staging.conf
@@ -19,9 +19,9 @@ upstream narrative_backend {
     keepalive 32;
 }
 
-# Upstream frontend
+# Upstream frontend (3011 — 3010 is taken by another app on the shared VPS)
 upstream narrative_frontend {
-    server 127.0.0.1:3010;
+    server 127.0.0.1:3011;
     keepalive 32;
 }
 
@@ -93,9 +93,11 @@ server {
         proxy_read_timeout 60s;
     }
 
-    # Backend API routes
+    # Backend API routes. NO trailing slash on proxy_pass: the backend mounts
+    # its routers under /api/v1, so the /api prefix must be preserved.
+    # (NEXT_PUBLIC_API_URL = https://<domain>/api/v1)
     location /api/ {
-        proxy_pass http://narrative_backend/;
+        proxy_pass http://narrative_backend;
         proxy_http_version 1.1;
 
         # Proxy headers

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,62 +1,20 @@
-# Issue #75 — Core AutoML Training Pipeline (P2.1)
+# Staging deploy fix — Atlas Mongo + real GH CI deploy
 
-## Reality check vs. the issue's "Current State (verified 2026-06-05)"
+## Problems found
+1. `docker-compose.staging.yml` hardcodes `MONGODB_URI` to a local `mongodb` container and gates backend startup on it — but staging uses MongoDB Atlas (`mongodb+srv://` in `.env.staging`).
+2. Compose never passes `MONGODB_DB`, which `apps/backend/app/main.py` requires.
+3. `deploy.yml` runs compose with no `--env-file`; `.env.staging` values are only picked up today because a duplicate `.env` copy exists.
+4. Port conflict: podcaststudiohub (separate app, `PORT=3010` in its own .env.production) occupies 3010; narrative frontend + nginx upstream also claim 3010. → Move narrative frontend to **3011** (verified free), don't touch the other app.
+5. API path mismatch: frontend expects `NEXT_PUBLIC_API_URL` to include `/api/v1` (fallback `http://localhost:8000/api/v1`), but server env has `.../api` AND nginx strips `/api` (trailing-slash proxy_pass) while backend routes start with `/api/v1`. → nginx should NOT strip; env should be `https://dev.briaanalytics.com/api/v1`.
+6. GH secrets `STAGING_*` not set → deploy workflow no-ops.
 
-The issue (and the Traycer plan) describe `POST /ml/train` as a stub and the engine as missing.
-**That is no longer true.** As of today the following already exist and are functional:
-
-- `automl_engine.py` — trains real models (LogReg/RF/XGBoost/LightGBM/GB/SVM/KNN; LinReg/Ridge/RF/XGBoost/…), stratified split, k-fold CV, best-model selection, feature importance.
-- `problem_detector.py`, `feature_engineer.py`, `algorithm_selector.py`, `explanation_service.py` (OpenAI + fallback) — all implemented.
-- `model_storage.py` — joblib → S3 + `MLModel` metadata → MongoDB; load/list/delete.
-- `POST /ml/train` (real background training), `GET /ml/`, `GET /ml/{id}`, `POST /ml/{id}/predict`, `DELETE`, `PUT deactivate` — all working.
-- `imbalanced-learn`, `statsmodels`, `prophet` already in `pyproject.toml`.
-
-**Therefore this is a focused gap-fill, not a greenfield build.** We target ONLY the unmet acceptance
-criteria and explicitly do NOT add the Traycer over-scope (WebSocket, ARIMA/Prophet, SMOTE, training modes).
-
-## Genuine remaining gaps (the real work)
-
-1. No training **job/status tracking** — `train_model_task` is fire-and-forget; failures are silently re-raised. No status endpoint (the response literally says "Check status endpoint" but none exists).
-2. **Model comparison** computed (`all_models`) but discarded — only best model saved; not exposed via API; no AI best-model explanation surfaced.
-3. Engine has **no basic class-imbalance handling**, and does not wire in the existing `AlgorithmSelector` recommendations or `ExplanationService`.
-4. **Frontend `app/model/page.tsx` is broken**: posts to `/models/train` (wrong; should be `/ml/train`), wrong payload shape, polls non-existent `/models/{id}/status`, fake simulated progress.
-5. No tests for the new status/job layer or the frontend wiring.
-
-## Plan (TDD throughout)
-
-> **Scope decisions (Phase 4):** Gap-fill only. **Job cancellation is OUT** (deferred — Known Limitation
-> for AC4's "cancellable" clause). Explanations use `ExplanationService`'s **deterministic rule-based
-> fallback** (no OpenAI runtime calls/API key required). Also post a correction comment on issue #75.
-
-### Backend
-- [ ] **B1. `TrainingJob` model** (`app/models/training_job.py`, register in `app/models/registry.py`), keyed by `model_id`: `user_id`, `dataset_id`, `target_column`, `status` (pending/running/completed/failed), `progress` (0–1 + current/total/current_algorithm), `algorithm_recommendations`, `model_comparison` (list of {algorithm, cv_score, test_score, training_time}), `best_model_id`, `best_model_explanation`, `error`, timestamps. → unit tests.
-- [ ] **B2. Engine: basic class-imbalance + surface recommendations/explanation.** Add `class_weight="balanced"` for supporting classifiers when imbalance ratio > 2 (lightweight "basic" handling, no resampling). Surface `AlgorithmSelector` recommendations + `ExplanationService` best-model explanation (**rule-based fallback path**, no API key needed) and the full `all_models` comparison in the result. → engine tests.
-- [ ] **B3. Refactor `train_model_task`**: create/update `TrainingJob` (status=running), update `progress` via per-model callback, persist comparison + best explanation on success (completed), set status=failed + `error` on exception (no more silent re-raise).
-- [ ] **B4. Endpoint**: `GET /ml/{model_id}/status` → {status, progress, metrics, comparison, best_model_id, explanation, error}. Create the `pending` `TrainingJob` synchronously in `train_model` before returning. → API tests (running/completed/failed).
-- [ ] **B5. Integration test** (service-gated): POST `/ml/train` on a sample CSV → poll status → completed with persisted model + comparison.
-
-### Frontend
-- [ ] **F1. Fix `app/model/page.tsx`**: route through `ModelService`; POST `/ml/train` with correct payload; poll `/ml/{model_id}/status`; drive real progress from `job.progress`; show comparison + best model on completion.
-- [ ] **F2. `ModelService`**: add `getTrainingStatus(modelId)`, align types. → jest tests (service + page happy/failure paths, mocked fetch).
-
-### Docs / housekeeping
-- [ ] **D1.** Update `CLAUDE.md` "Current Stage" + a short AutoML status/endpoints note; OpenAPI reflects new routes automatically.
-- [ ] **D2.** Post a comment on issue #75 correcting the outdated "Current State" and listing done-vs-remaining.
-
-## Explicitly deferred (out of scope per the issue itself)
-- Real-time WebSocket UI → **#76 (P2.2)**
-- Time-series ARIMA/Prophet → post-beta
-- SMOTE/resampling beyond `class_weight` → post-beta
-- Quick/Comprehensive training modes → **#101 (P5.9)**
-- Hyperparameter tuning / GridSearch → **#77 (P5.1)**
-
-## Acceptance criteria coverage
-- AC1 problem-type detection — already ✅ (engine uses `problem_detector`)
-- AC2 algorithm recommendation + plain-language explanation — **B2** (wire existing selector/explanation)
-- AC3 split / stratified / k-fold / basic imbalance — split+stratify+CV ✅; imbalance via **B2**
-- AC4 async + progress queryable — **B1/B3/B4**; **cancellable = deferred (Known Limitation)**
-- AC5 artifacts→S3, metadata→MongoDB — already ✅
-- AC6 model comparison + best-model selection + explanation — **B2/B3/B4**
-- AC7 `POST /ml/train` trains ✅; `GET` returns real status/results — **B4**
-- AC8 frontend wired to real endpoints — **F1/F2**
-- AC9 TDD >85% on new code; integration test on sample CSV; train workflow test — tests across B/F
+## Plan
+- [ ] Repo branch `fix/staging-deploy-atlas`:
+  - [ ] compose: drop mongodb service/volumes/depends_on; `MONGODB_URI`/`MONGODB_DB` from env; frontend host port 3011
+  - [ ] deploy.yml: `--env-file .env.staging` on compose commands
+  - [ ] nginx-staging.conf (repo copy): upstream 3011; `/api/` proxy without prefix strip
+  - [ ] .env.staging.example: Atlas URI example, MONGODB_DB, NEXT_PUBLIC_API_URL with /api/v1
+  - [ ] STAGING_DEPLOYMENT_GUIDE.md: reflect Atlas + env-file + ports
+- [ ] PR → CI green → merge
+- [ ] Server: fix NEXT_PUBLIC_API_URL in .env.staging; remove stale narrative-staging-mongodb container; install updated nginx conf (nginx -t, reload); pull main
+- [ ] Set GH secrets (STAGING_SSH_PRIVATE_KEY/HOST/USER); workflow_dispatch deploy.yml; verify /health via 8010 + https://dev.briaanalytics.com


### PR DESCRIPTION
## Problem
The staging deploy introduced in #175 couldn't actually work against the real server:

1. **`docker-compose.staging.yml` ran its own MongoDB container** and hardcoded `MONGODB_URI` to it — but staging uses a **MongoDB Atlas** cluster (`mongodb+srv://` in `.env.staging` on the server). The backend was also gated on the local mongo's healthcheck.
2. **`MONGODB_DB` was never passed** to the backend, which `app/main.py` requires at startup.
3. **`.env.staging` was never loaded**: compose only auto-reads a file literally named `.env`, and `deploy.yml` passed no `--env-file`.
4. **Port conflict on the shared VPS**: another app already binds 3010, which the frontend and the nginx upstream both claimed. Frontend moves to **3011** (verified free).
5. **API path mismatch**: the frontend treats `NEXT_PUBLIC_API_URL` as the full base incl. `/api/v1` (see `apps/frontend/lib/config.ts`), but nginx stripped the `/api` prefix while the backend mounts routers at `/api/v1`.

## Changes
- **compose**: remove mongodb service/volumes/depends_on; `MONGODB_URI`/`MONGODB_DB` from env; frontend host port 3011
- **deploy.yml**: `--env-file .env.staging` + `--remove-orphans`; fail fast if `.env.staging` missing on server
- **nginx-staging.conf**: upstream 3011; `proxy_pass` without trailing slash so `/api/v1/...` reaches the backend intact (explicit `/api/health` → `/health` mapping kept)
- **.env.staging.example** + **STAGING_DEPLOYMENT_GUIDE.md**: Atlas instructions, `/api/v1` in `NEXT_PUBLIC_API_URL`, no `REDIS_URL` in env file (env files don't interpolate)

## Verification
- `docker compose -f docker-compose.staging.yml --env-file <test env> config` parses; Atlas URI/DB flow through; port 3011 published; no mongo service
- `deploy.yml` YAML parses
- Server-side counterpart changes (live nginx conf, `.env.staging` fix, stale container cleanup) are applied separately on the VPS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Deployment now validates staging env configuration and fails with a clear error if missing; deploys with env-file handling and removes orphan containers.

* **Documentation**
  * Staging guide updated for MongoDB Atlas usage, Redis guidance, API base URL now including /api/v1, and revised verification/troubleshooting steps.

* **Chores**
  * Staging switched to managed MongoDB Atlas; removed local MongoDB service.
  * Frontend staging port changed to 3011.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->