### PR TITLE
fix(frontend): lazy-init OpenAI client so next build works without secrets

### DIFF
--- a/apps/frontend/app/api/chat/route.ts
+++ b/apps/frontend/app/api/chat/route.ts
@@ -5,9 +5,18 @@ import { OpenAI } from 'openai'
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
 
-const openai = new OpenAI({
-  apiKey: process.env.OPENAI_API_KEY,
-})
+// Lazily constructed: the OpenAI SDK throws when apiKey is undefined, which
+// breaks `next build` page-data collection in environments without secrets
+// (e.g. Docker image builds).
+let openaiClient: OpenAI | null = null
+function getOpenAI(): OpenAI {
+  if (!openaiClient) {
+    openaiClient = new OpenAI({
+      apiKey: process.env.OPENAI_API_KEY,
+    })
+  }
+  return openaiClient
+}
 
 const model = process.env.OPENAI_MODEL || 'gpt-3.5-turbo'
 
@@ -36,7 +45,7 @@ export async function POST(request: Request) {
       { role: 'user', content: message }
     ]
 
-    const response = await openai.chat.completions.create({
+    const response = await getOpenAI().chat.completions.create({
       model,
       messages,
       temperature: 0.7,


### PR DESCRIPTION
## Problem
The first armed staging deploy (run 27242636458) failed building the frontend Docker image:
`Failed to collect page data for /api/chat` — `app/api/chat/route.ts` constructs `new OpenAI({ apiKey: process.env.OPENAI_API_KEY })` at module scope, and the SDK throws when the key is undefined. Docker builds have no secrets (correctly so); CI only passed because `ci.yml` injects `OPENAI_API_KEY: fake-openai-key-for-ci-only`.

## Fix
Construct the client lazily on first request (`getOpenAI()`); behavior at request time is unchanged.

## Verification
- `env -u OPENAI_API_KEY npm run build` — succeeds (previously the exact failure)
- `npm run type-check` — clean
- `npm test` — 899 passed, 10 skipped

Unblocks the staging deploy for #179 / #150.