### PR TITLE
fix(frontend): provide build-time dummy env in Docker builder stage

### DIFF
--- a/apps/frontend/Dockerfile
+++ b/apps/frontend/Dockerfile
@@ -20,7 +20,19 @@ ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
-RUN npm run build
+# Build-time-only dummies, mirroring ci.yml's "Production build" env: `next
+# build` imports route modules for page-data collection, and auth.ts/lib/db.ts
+# need these to exist (CI=true is lib/db.ts's escape hatch for a missing
+# MONGODB_URI). Scoped to this RUN only — the runner stage gets its real
+# environment from docker-compose at runtime.
+RUN CI=true \
+    NEXTAUTH_SECRET=build-time-dummy-not-used-at-runtime \
+    NEXTAUTH_URL=http://localhost:3000 \
+    GOOGLE_CLIENT_ID=dummy-client-id \
+    GOOGLE_CLIENT_SECRET=dummy-client-secret \
+    GITHUB_ID=dummy-client-id \
+    GITHUB_SECRET=dummy-client-secret \
+    npm run build
 
 # ── runner: minimal runtime image ──────────────────────────────────────────
 FROM node:18-alpine AS runner


### PR DESCRIPTION
## Problem
Second staging deploy failure (run 27243032826): frontend image build fails with `Failed to collect page data for /api/data/[id]/preview`. `next build` imports route modules; `auth.ts`/`lib/db.ts` throw when NextAuth/OAuth vars are absent and `MONGODB_URI` is missing (`lib/db.ts` only tolerates a missing URI when `CI=true`). `ci.yml` injects exactly these dummies for its production-build job — the Docker build had none.

## Fix
Mirror ci.yml's documented build-time dummy env in the Dockerfile **builder stage**, scoped to the `npm run build` RUN. The runner stage is a separate stage whose real environment comes from `docker-compose.staging.yml` at runtime — no dummy value ships in the final image.

## Verification
`docker build --build-arg NEXT_PUBLIC_API_URL=... apps/frontend` (the exact VPS invocation, no other env) now completes successfully locally.

Unblocks the staging deploy for #179/#150 (follow-up to #180).