### PR TITLE
fix(deploy): pass NEXTAUTH_SECRET to backend, MONGODB_URI to frontend, URL-safe Redis password

### DIFF
--- a/.env.staging.example
+++ b/.env.staging.example
@@ -27,8 +27,10 @@ MONGODB_DB=narrative_modeling-staging
 # CACHE CREDENTIALS
 # ═══════════════════════════════════════════════════════════════
 
-# Redis password
-REDIS_PASSWORD=REPLACE_WITH_STRONG_PASSWORD_32_CHARS
+# Redis password — MUST be URL-safe (hex; generate with `openssl rand -hex 32`)
+# because compose embeds it in redis://:PASSWORD@redis:6379/0. base64 output
+# can contain / + = which break URL parsing.
+REDIS_PASSWORD=REPLACE_WITH_OPENSSL_RAND_HEX_32
 
 # ═══════════════════════════════════════════════════════════════
 # AWS S3 STORAGE

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -55,6 +55,9 @@ services:
       # Security
       SECRET_KEY: ${BACKEND_SECRET_KEY}
       ALLOWED_ORIGINS: ${ALLOWED_ORIGINS}
+      # The backend validates NextAuth JWTs, so it needs the same secret the
+      # frontend signs them with (app/auth/nextauth_auth.py).
+      NEXTAUTH_SECRET: ${NEXTAUTH_SECRET:?NEXTAUTH_SECRET must be set in .env.staging}
     volumes:
       - backend_logs:/app/logs
     depends_on:
@@ -85,6 +88,9 @@ services:
     environment:
       NODE_ENV: production
       NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL}
+      # NextAuth's MongoDB adapter (auth.ts -> lib/db.ts) connects at runtime;
+      # lib/db.ts throws on startup without this.
+      MONGODB_URI: ${MONGODB_URI:?MONGODB_URI (Atlas connection string) must be set in .env.staging}
       NEXTAUTH_URL: ${NEXTAUTH_URL}
       NEXTAUTH_SECRET: ${NEXTAUTH_SECRET}
       GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID}

--- a/docs/deployment/STAGING_DEPLOYMENT_GUIDE.md
+++ b/docs/deployment/STAGING_DEPLOYMENT_GUIDE.md
@@ -72,8 +72,9 @@ chown -R narrative-deploy:narrative-deploy /opt/narrative-modeling-app
 # container or passwords. Get the mongodb+srv:// connection string from the
 # Atlas UI (Database → Connect → Drivers) for MONGODB_URI.
 
-# Redis password
-openssl rand -base64 32  # For REDIS_PASSWORD
+# Redis password — hex, NOT base64: the password is embedded in a redis:// URL
+# and base64's / + = characters break URL parsing
+openssl rand -hex 32  # For REDIS_PASSWORD
 
 # Backend secret key
 openssl rand -hex 32  # For BACKEND_SECRET_KEY (64 chars)


### PR DESCRIPTION
Follow-up to #179/#181 — the first *successful* staging deploy (run 27243434565) came up healthy but the logs surfaced three runtime env gaps:

1. **Backend missing `NEXTAUTH_SECRET`** — `app/auth/nextauth_auth.py` validates the NextAuth JWTs with it; without it every authenticated request 401s (logged `NEXTAUTH_SECRET environment variable is not set`).
2. **Frontend missing `MONGODB_URI`** — the NextAuth MongoDB adapter (`auth.ts` → `lib/db.ts`) throws at runtime, so `https://dev.briaanalytics.com/auth/signin` returned **500**.
3. **`REDIS_PASSWORD` URL-safety** — compose embeds it in `redis://:PASSWORD@redis:6379/0`; the base64 password generated per the old docs contains `/ + =` and broke URL parsing (backend logged `Port could not be cast to integer value`). Docs/example now prescribe `openssl rand -hex 32`; the server's password has been rotated to hex.

Both new compose vars use `${VAR:?}` guards. Verified with `docker compose config` against a test env file.