### PR TITLE
fix(deploy): set AUTH_TRUST_HOST for NextAuth behind the nginx proxy

### DIFF
--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -92,6 +92,10 @@ services:
       # lib/db.ts throws on startup without this.
       MONGODB_URI: ${MONGODB_URI:?MONGODB_URI (Atlas connection string) must be set in .env.staging}
       NEXTAUTH_URL: ${NEXTAUTH_URL}
+      # NextAuth v5 rejects requests whose Host it doesn't trust (UntrustedHost
+      # 500s on every /api/auth/* route). Behind the nginx reverse proxy the
+      # host arrives via X-Forwarded-Host, so it must be trusted explicitly.
+      AUTH_TRUST_HOST: "true"
       NEXTAUTH_SECRET: ${NEXTAUTH_SECRET}
       GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID}
       GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET}


### PR DESCRIPTION
Staging smoke test found every `/api/auth/*` route 500ing with `[auth][error] UntrustedHost` (frontend container logs). NextAuth v5 requires the host to be trusted when it arrives via a reverse proxy's `X-Forwarded-Host` — `AUTH_TRUST_HOST=true` is the documented switch for proxy deployments.

Knock-on effect this also fixes: the 500's JSON body is truthy, so `useSession()` treated anonymous visitors as **authenticated** and `/auth/signin` rendered its "Redirecting to application..." branch instead of the OAuth sign-in buttons.

Follow-up to #182; verified with `docker compose config`.