### PR TITLE
fix(frontend): re-enable data-preparation smoke tests + harden prepare page (#155)

### DIFF
--- a/apps/frontend/app/datasets/[id]/prepare/page.tsx
+++ b/apps/frontend/app/datasets/[id]/prepare/page.tsx
@@ -474,7 +474,10 @@ export default function DatasetPreparePage() {
       </div>
 
       {/* Edit Transformation Dialog */}
-      {editingIndex !== null && (() => {
+      {/* Guard on transformations[editingIndex]: the index can briefly outlive
+          its array entry (e.g. a delete while the dialog is open), and accessing
+          .type on undefined would crash the page. */}
+      {editingIndex !== null && transformations[editingIndex] && (() => {
         const editingType = transformations[editingIndex].type;
         const typeMeta = transformationTypes.find(
           (t) => t.type === editingType

--- a/apps/frontend/e2e/workflows/data-preparation.spec.ts
+++ b/apps/frontend/e2e/workflows/data-preparation.spec.ts
@@ -43,16 +43,27 @@ async function seedPreparationWorkflow(
     stage_data: {},
   };
   // PUT updates the workflow the upload flow already created; fall back to POST
-  // if no workflow exists yet (upload didn't persist one).
+  // if no workflow exists yet (upload didn't persist one). Fail loudly on any
+  // other status so a broken seed surfaces as a clear error here instead of a
+  // confusing "element not found" once the page redirects away from /prepare.
   const put = await request.put(`${apiBase}/workflows/${datasetId}`, {
     headers,
     data: workflow,
   });
   if (put.status() === 404) {
-    await request.post(`${apiBase}/workflows/${datasetId}`, {
+    const post = await request.post(`${apiBase}/workflows/${datasetId}`, {
       headers,
       data: workflow,
     });
+    if (!post.ok()) {
+      throw new Error(
+        `seedPreparationWorkflow POST failed (${post.status()}): ${await post.text()}`
+      );
+    }
+  } else if (!put.ok()) {
+    throw new Error(
+      `seedPreparationWorkflow PUT failed (${put.status()}): ${await put.text()}`
+    );
   }
 
   // addInitScript (not evaluate): a still-open page persists its own in-memory

--- a/apps/frontend/e2e/workflows/data-preparation.spec.ts
+++ b/apps/frontend/e2e/workflows/data-preparation.spec.ts
@@ -12,33 +12,74 @@
  */
 
 import { test, expect } from '../fixtures';
-import { join } from 'path';
+import type { Page, APIRequestContext } from '@playwright/test';
+
+/**
+ * Seed the workflow state a real user would have after completing profiling,
+ * so the DATA_PROFILING-gated prepare page is reachable.
+ *
+ * Since #87 the backend is the source of truth during hydration: the upload
+ * flow persists a backend workflow at the data_loading stage, which would
+ * override a localStorage-only seed and re-gate the page. So seed the real
+ * backend workflow (no mocking — E2E uses the live API). With SKIP_AUTH the
+ * backend maps `Bearer dev-user-default` to the same user the frontend session
+ * resolves to, which owns the just-uploaded dataset. The localStorage seed is
+ * kept as the offline fallback layer the app reads when the backend is down.
+ */
+async function seedPreparationWorkflow(
+  page: Page,
+  request: APIRequestContext,
+  datasetId: string
+): Promise<void> {
+  const apiBase =
+    process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000/api/v1';
+  const headers = {
+    Authorization: 'Bearer dev-user-default',
+    'Content-Type': 'application/json',
+  };
+  const workflow = {
+    current_stage: 'data_preparation',
+    completed_stages: ['data_loading', 'data_profiling'],
+    stage_data: {},
+  };
+  // PUT updates the workflow the upload flow already created; fall back to POST
+  // if no workflow exists yet (upload didn't persist one).
+  const put = await request.put(`${apiBase}/workflows/${datasetId}`, {
+    headers,
+    data: workflow,
+  });
+  if (put.status() === 404) {
+    await request.post(`${apiBase}/workflows/${datasetId}`, {
+      headers,
+      data: workflow,
+    });
+  }
+
+  // addInitScript (not evaluate): a still-open page persists its own in-memory
+  // state on changes and would clobber a one-time seed; the init script
+  // re-seeds before app code runs on every navigation.
+  await page.addInitScript((id) => {
+    localStorage.setItem(
+      'workflowState',
+      JSON.stringify({
+        currentStage: 'data_preparation',
+        completedStages: ['data_loading', 'data_profiling'],
+        stageData: {},
+        datasetId: id,
+        lastUpdated: new Date().toISOString(),
+      })
+    );
+  }, datasetId);
+}
 
 test.describe('Data Preparation Page', () => {
   let datasetId: string;
 
-  test.beforeEach(async ({ page, uploadTestDataset }) => {
-    // Upload test dataset
+  test.beforeEach(async ({ page, request, uploadTestDataset }) => {
+    // Upload test dataset, then seed the profiling-complete workflow state so
+    // the DATA_PROFILING-gated prepare page is reachable (see helper).
     datasetId = await uploadTestDataset();
-
-    // The prepare page is stage-gated behind DATA_PROFILING; these tests
-    // target the preparation UI directly, so seed the workflow state a real
-    // user would have after completing the profiling stage.
-    // addInitScript (not evaluate): the still-open explore page persists its
-    // own in-memory state on changes and would clobber a one-time seed; the
-    // init script re-seeds before app code runs on every navigation.
-    await page.addInitScript((id) => {
-      localStorage.setItem(
-        'workflowState',
-        JSON.stringify({
-          currentStage: 'data_preparation',
-          completedStages: ['data_loading', 'data_profiling'],
-          stageData: {},
-          datasetId: id,
-          lastUpdated: new Date().toISOString(),
-        })
-      );
-    }, datasetId);
+    await seedPreparationWorkflow(page, request, datasetId);
   });
 
   test.afterEach(async ({ cleanupDataset }) => {
@@ -47,34 +88,44 @@ test.describe('Data Preparation Page', () => {
     }
   });
 
-  // Disabled pending #155: /datasets/{id}/prepare throws a client-side
-  // exception — previously masked by the gating redirect fixed in PR #154
-  test.fixme('should load data preparation page with dataset info @smoke', async ({ authenticatedPage }) => {
+  test('should load data preparation page with dataset info @smoke', async ({ authenticatedPage }) => {
     await authenticatedPage.goto(`/datasets/${datasetId}/prepare`);
 
     // Verify page title
     await expect(authenticatedPage.locator('h1:has-text("Prepare Data")')).toBeVisible({ timeout: 10000 });
 
-    // Verify dataset metadata is displayed
-    await expect(authenticatedPage.locator('text=/rows/')).toBeVisible();
-    await expect(authenticatedPage.locator('text=/columns/')).toBeVisible();
+    // Verify dataset metadata is displayed. Scope to the "<n> rows"/"<n> columns"
+    // shape: a bare /rows/ also matches transformation descriptions in the
+    // sidebar ("Remove rows with missing values") and trips strict mode.
+    await expect(authenticatedPage.locator('text=/\\d+ rows/')).toBeVisible();
+    await expect(authenticatedPage.locator('text=/\\d+ columns/')).toBeVisible();
 
-    // Verify back button exists
-    await expect(authenticatedPage.locator('button:has-text("Back"), a:has-text("Back")')).toBeVisible();
+    // Verify back button exists. The Back control is an <a> wrapping a <button>,
+    // so the combined selector matches two nodes — assert on the first.
+    await expect(
+      authenticatedPage.locator('button:has-text("Back"), a:has-text("Back")').first()
+    ).toBeVisible();
   });
 
-  // Disabled pending #155: same client-side crash as above
-  test.fixme('should display view mode toggle buttons @smoke', async ({ authenticatedPage }) => {
+  test('should display view mode toggle buttons @smoke', async ({ authenticatedPage }) => {
     await authenticatedPage.goto(`/datasets/${datasetId}/prepare`);
 
     // Verify both view mode buttons exist
     await expect(authenticatedPage.locator('button:has-text("Visual")')).toBeVisible({ timeout: 5000 });
     await expect(authenticatedPage.locator('button:has-text("Chain")')).toBeVisible({ timeout: 5000 });
 
-    // Visual mode should be active by default
-    const visualButton = authenticatedPage.locator('button:has-text("Visual")');
-    const visualButtonClass = await visualButton.getAttribute('class');
-    expect(visualButtonClass).toContain('default'); // Active variant
+    // Visual mode should be active by default. The active toggle uses the
+    // Button "default" variant, which renders `bg-primary` (the inactive
+    // "ghost" variant does not) — the literal token "default" never appears
+    // in the resolved class string.
+    const visualButtonClass = await authenticatedPage
+      .locator('button:has-text("Visual")')
+      .getAttribute('class');
+    expect(visualButtonClass).toContain('bg-primary'); // Active variant
+    const chainButtonClass = await authenticatedPage
+      .locator('button:has-text("Chain")')
+      .getAttribute('class');
+    expect(chainButtonClass).not.toContain('bg-primary'); // Inactive variant
   });
 
   test('should switch between visual and chain view modes', async ({ authenticatedPage }) => {
@@ -84,10 +135,12 @@ test.describe('Data Preparation Page', () => {
     await authenticatedPage.locator('button:has-text("Chain")').click();
     await authenticatedPage.waitForTimeout(500); // Wait for view switch
 
-    // Verify chain view is displayed
+    // Verify chain view is displayed. The active toggle uses the Button
+    // "default" variant, which renders `bg-primary` (the literal token
+    // "default" never appears in the resolved class string).
     const chainButton = authenticatedPage.locator('button:has-text("Chain")');
     const chainButtonClass = await chainButton.getAttribute('class');
-    expect(chainButtonClass).toContain('default'); // Active variant
+    expect(chainButtonClass).toContain('bg-primary'); // Active variant
 
     // Verify card title changed
     await expect(authenticatedPage.locator('text=/Transformation Chain/')).toBeVisible();
@@ -107,9 +160,10 @@ test.describe('Data Preparation Page', () => {
     await authenticatedPage.locator('button:has-text("Chain")').click();
     await authenticatedPage.waitForTimeout(500);
 
-    // Verify empty state message
+    // Verify empty state message. A single text regex — the comma form is not
+    // a valid "or" for the text engine and matched nothing.
     await expect(
-      authenticatedPage.locator('text=/No transformations added yet/i, text=/Add transformations/i')
+      authenticatedPage.getByText(/No transformations added yet/i)
     ).toBeVisible({ timeout: 5000 });
   });
 
@@ -180,8 +234,10 @@ test.describe('Data Preparation Page', () => {
     await authenticatedPage.locator('button:has-text("Chain")').click();
     await authenticatedPage.waitForTimeout(500);
 
-    // Verify main heading has proper structure
-    const heading = authenticatedPage.locator('h1');
+    // Verify main heading has proper structure. Scope to the page heading —
+    // the app shell renders its own <h1> ("Modeling App"), so a bare h1 matches
+    // two nodes and trips strict mode.
+    const heading = authenticatedPage.locator('h1:has-text("Prepare Data")');
     await expect(heading).toBeVisible();
 
     // Verify buttons have accessible names
@@ -197,13 +253,19 @@ test.describe('Data Preparation Page', () => {
 
     await authenticatedPage.goto(`/datasets/${invalidDatasetId}/prepare`);
 
-    // Verify error state displayed
+    // Verify error state displayed. The error card renders both a heading and a
+    // detail paragraph that match this regex, so assert on the first match.
     await expect(
-      authenticatedPage.locator('text=/Error Loading Dataset|Dataset Not Found|Failed to fetch/i')
+      authenticatedPage
+        .locator('text=/Error Loading Dataset|Dataset Not Found|Failed to fetch/i')
+        .first()
     ).toBeVisible({ timeout: 10000 });
 
-    // Verify back to datasets button exists
-    await expect(authenticatedPage.locator('button:has-text("Back to Datasets"), a:has-text("Back")')).toBeVisible();
+    // Verify back to datasets button exists. The control is an <a> wrapping a
+    // <button>, so the combined selector matches two nodes — assert on the first.
+    await expect(
+      authenticatedPage.locator('button:has-text("Back to Datasets"), a:has-text("Back")').first()
+    ).toBeVisible();
   });
 
   test('should handle loading state properly', async ({ authenticatedPage }) => {
@@ -227,8 +289,9 @@ test.describe('Data Preparation Page', () => {
 test.describe('Chain View Functionality', () => {
   let datasetId: string;
 
-  test.beforeEach(async ({ uploadTestDataset }) => {
+  test.beforeEach(async ({ page, request, uploadTestDataset }) => {
     datasetId = await uploadTestDataset();
+    await seedPreparationWorkflow(page, request, datasetId);
   });
 
   test.afterEach(async ({ cleanupDataset }) => {
@@ -244,11 +307,14 @@ test.describe('Chain View Functionality', () => {
     await authenticatedPage.locator('button:has-text("Chain")').click();
     await authenticatedPage.waitForTimeout(500);
 
-    // Check for listbox role (TransformationChainView uses role="list")
+    // TransformationChainView exposes role="list" with a descriptive aria-label
     const chainList = authenticatedPage.locator('[role="list"][aria-label*="Transformation"]');
+    await expect(chainList).toBeVisible();
 
-    // Empty state should show dashed border
-    const emptyState = authenticatedPage.locator('text=/No transformations/');
+    // Empty state should show dashed border. Scope to the visible message — a
+    // bare /No transformations/ also matches the sr-only live-region copy
+    // ("No transformations in pipeline") and trips strict mode.
+    const emptyState = authenticatedPage.getByText(/No transformations added yet/i);
     await expect(emptyState).toBeVisible();
   });
 
@@ -284,8 +350,9 @@ test.describe('Chain View Functionality', () => {
 test.describe('Responsive Design', () => {
   let datasetId: string;
 
-  test.beforeEach(async ({ uploadTestDataset }) => {
+  test.beforeEach(async ({ page, request, uploadTestDataset }) => {
     datasetId = await uploadTestDataset();
+    await seedPreparationWorkflow(page, request, datasetId);
   });
 
   test.afterEach(async ({ cleanupDataset }) => {

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,0 +1,85 @@
+# Lessons
+
+## 2026-06-08 — issue #75 (core AutoML pipeline)
+
+- **Trust the code, not the issue's "Current State".** The ticket (and its
+  Traycer plan) described `POST /ml/train` as a stub and the engine as missing;
+  in reality the engine, problem detector, feature engineer, algorithm selector,
+  explanation service, S3/Mongo storage, and real background training already
+  existed. Always Explore the actual files before scoping — the beta-roadmap
+  tickets' "verified" state notes drift quickly. Scope to the *unmet* acceptance
+  criteria, and post a correction comment on the issue.
+- **Auto-generated plans (Traycer/CodeRabbit) over-scope.** The plan said to
+  "create" files that already existed and pulled in WebSocket/ARIMA/SMOTE/modes
+  the issue itself defers to other tickets. Drive from the acceptance criteria,
+  not the plan's file list.
+- **`showboat exec` execs directly — no shell.** Shell builtins (`echo`),
+  pipes, redirects, and env-var prefixes all fail. Wrap in `bash -c '...'`, or
+  pass a real binary (`cat <file>`). It was also flaky/slow under `uvx` here;
+  the demo *driver script* + a captured evidence file is the reliable fallback
+  when the markdown-packaging tool hangs.
+- **pytest-cov + narrow multi-`--cov=<module>` selection can spuriously fail**
+  unrelated tests in the same run. Use a single broad `--cov=app` to generate
+  coverage.xml for diff-cover; the failures vanished without coverage.
+
+## 2026-06-06 — issue #160 (backend test-suite repair)
+
+- **`str()` is not an enum-to-value guard.** For `class X(str, Enum)`,
+  `str(member)` returns `'X.MEMBER'`, not the value. Use
+  `getattr(v, "value", v)` (or `.value` directly). Caught by a PR reviewer
+  after I shipped `str()` as a "guard" — verify enum coercions empirically,
+  don't assume.
+- **"Service-free" claims must be verified with the service actually absent.**
+  I verified a fixture was IO-free by pointing config env vars at a
+  nonexistent host — but the fixture hardcoded `localhost:27017`, and local
+  MongoDB masked the IO. CI (no Mongo) exposed it. When proving something
+  needs no service, make the service unreachable on the exact code path
+  (or run in an environment without it), not just via config knobs.
+- **Beanie `init_beanie()` always performs IO** (`buildInfo` command), even
+  with `skip_indexes=True`. For service-free Document binding in unit tests,
+  use `mongomock-motor`.
+- **`load_dotenv(override=True)` at import time clobbers pre-set env vars.**
+  Test env overrides must be applied AFTER importing the module that calls
+  it (app/main.py), not before.
+
+## 2026-06-06 (issue #166)
+- **Mutation-check scripts must NOT restore files with `git checkout --`** when the working tree has uncommitted fixes — it silently reverts them to HEAD (lost the HistogramChart auth-token fix mid-gate). Restore via `cp` backups, or commit before mutating.
+- **Verify sed mutation patterns actually matched** before trusting a "survived" result — a non-matching pattern is a no-op mutation and a false survivor (model.ts `/models/predict` vs actual `/ml/${id}/predict`).
+- Coverage-driven tests written "to hit lines" tend to assert only "didn't throw" — pair every diff-coverage push with a mutation pass on the new tests (caught the StatisticsDashboard placeholder test).
+
+## 2026-06-08 (issue #150 — CI pipeline)
+- **After `ruff check --fix --unsafe-fixes`, review EVERY changed file, not just `app/` source.** F841 unsafe-fix rewrites `x = pure_expr()` → `pure_expr()`, leaving a dead no-op statement. I cleaned these in `app/` but skipped the ~20 touched test files; a reviewer then caught a bare `datetime.utcnow()` in a test (and a sweep found a sibling `transform_data.get(...)`). Tests don't fail on a no-op, so the suite stays green and hides it — grep the whole diff for added bare-expression lines. Side-effecting calls (`await foo()`, migrations) are correctly preserved; only pure expressions are dead.
+- **A newly-populated workflow file won't run if its placeholder was `disabled_manually`.** Empty `ci.yml`/`deploy.yml` had been disabled in the repo; populating them wasn't enough — `gh workflow enable` + a fresh trigger (close/reopen PR) was required before CI ran.
+- **LocalStack is unreliable on GitHub runners** — across runs it either failed the Docker Hub image pull (auth-token timeout) or never reached `healthy` in 120s. Don't make it a hard gate: use GitHub `services:` containers for the must-haves (Mongo, Redis) and start LocalStack best-effort (`|| warning`) so S3 tests skip rather than fail the pipeline.
+- **`-m integration` silently deselects unmarked tests in `tests/integration/`** (upload/workflow/OpenAI) — codex flagged that the "integration gate" then covers far less than it appears. Document the scope boundary in the workflow.
+
+## 2026-06-07 (issue #165 — xlsx → exceljs)
+- **Frontend CI runs Node 18** (`.github/workflows/unit-tests.yml`), but local dev is Node 24. The global `File` constructor only exists from Node 20+, so a `new File([buf], name, {type})` test helper passed locally and failed CI with `ReferenceError: File is not defined`. Build upload fixtures as `Blob` and append with a filename — `formData.append('file', blob, name)` — which undici turns into a proper File entry (`.name`/`.arrayBuffer()`) on Node 18 and 24. Verify Node-18-specific code by actually running under `nvm use 18`.
+- **`Buffer.from(arrayBuffer)` fails `tsc` with this repo's `@types/node`** (`Buffer<ArrayBuffer>` not assignable to the exceljs-declared `Buffer`, TS2345). Two separate reviewers suggested it; it's generically valid but wrong here. Cast to `Parameters<typeof fn>[0]` instead. Re-verify "obvious" type suggestions against the actual toolchain before accepting.
+- **Reviewer rounds can contradict each other.** codex R2 (don't let stray cells add phantom columns → key off header) directly conflicted with R3 (don't drop data columns with blank headers). They're structurally identical inputs; no rule satisfies both. Resolved by using the sheet used-range (`worksheet.dimensions`), matching the prior `sheet_to_json({header:1})` `!ref` and prioritizing no-data-loss over a cosmetic phantom column. Don't mechanically apply each review round — reconcile against the real contract and rebut with proof.
+- **`worksheet.eachRow` callback `return` does not stop iteration** in ExcelJS — it only skips that row's work. True early-termination needs `getRow(i)` or the streaming reader.
+
+## Issue #185 (2026-06-10): overflow-x-auto is not enough — check min-width:auto up the flex chain
+`overflow-x-auto` + `min-w-0` on a flex item only zeroes its minimum *inside its own flex row*.
+The element's intrinsic min-content still propagates to ancestor flex items (here `<main>` in
+`display:flex` body), whose default `min-width:auto` then forces whole-page horizontal scroll.
+Jest/jsdom cannot catch this (no layout) — the browser demo gate did. When fixing overflow,
+verify every flex ancestor has `min-w-0` (or measure `scrollWidth` in a real browser at the
+target viewports before claiming the criterion is met).
+
+## Issue #188 (2026-06-11)
+- `gh api -X DELETE` is deny-listed in user settings: plan approval does not cover destructive GitHub API calls — ask explicitly, then use the authorized equivalent.
+- `codex review` CLI: `--base <branch>` cannot be combined with a positional prompt; use `codex review --base main --title "..."` alone.
+- `pull_request`-triggered workflows execute from the PR merge ref, so a PR that hardens a workflow live-tests its own changes — use those runs as demo outcome evidence.
+
+## Issue #79 (2026-06-12)
+- Parallel worktree agents that npm-install new deps leave the main tree's node_modules stale — run `npm install` on the integration branch after merging package.json before judging "failures".
+- Demoing against the live stack surfaces pre-existing integration bugs the test suites can't (UserData.file_type never set; /evaluate/{datasetId} 404; e2e fixture drift → #191) — budget demo time for bug-fixing.
+- Local backend demo in WSL: .env's Atlas mongodb+srv URI fails SRV DNS — override MONGODB_URI=mongodb://localhost:27017 on the command line.
+
+## Issue #191 (2026-06-12): verify bot-plan root causes against failure artifacts
+CodeRabbit's coding plan asserted a "workflow-state race" root cause for the e2e upload fixture failures; the actual Playwright failure artifacts (test-results/*/error-context.md) showed the upload POST never resolving — missing S3 storage, an environment problem. Lesson: before adapting an AI-generated plan, pull the cheapest primary evidence (stale test artifacts, logs) and let it veto the plan's diagnosis. Hardening the fixture alone would have masked the real bug.
+
+## Issue #155 (2026-06-13): a stale bug — the fix already landed; the real work was the tests
+The issue (and its CodeRabbit plan) blamed a `TransformationConfigDialog` props-contract crash. Live browser reproduction against current `main` showed the prepare page already renders fine — #166's TS-error cleanup had fixed the props, and that dialog never even mounts on initial load (`editingIndex` is null). Lesson: reproduce first. A bug filed weeks ago may already be dead; verify before writing a fix for a crash you can't reproduce.
+The actual work was repairing the e2e spec, where re-enabling the `fixme`'d tests exposed: (1) a **#87 regression** — the backend became the workflow hydration source-of-truth, so `addInitScript` localStorage-only seeds no longer grant stage access; seed the real backend workflow (`PUT/POST /workflows/{id}` with `Bearer dev-user-default` under SKIP_AUTH). (2) **Broad locators masked by the crash** — assertions like `toContain('default')` (shadcn active variant is `bg-primary`, no literal "default"), bare `text=/rows/` (sidebar copy collides), and `a:has-text("Back")` matching a link-wrapped button. When a long-disabled test is re-enabled, expect its never-run assertions to be stale too.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,78 +1,42 @@
-# Issue #87 — Backend workflow persistence (replace localStorage-only state)
+# Issue #155 — Fix client-side crash on /datasets/{id}/prepare
 
-> Previous plan (issue #191 — e2e upload fixture) was **completed** and merged in PR #192
-> (commit f4d77b9); see `git log tasks/todo.md`.
+> Previous plan (issue #87 — backend workflow persistence) was **completed** and merged in PR #193
+> (commit ea58249); see `git log tasks/todo.md`.
 
-**Plan source**: CodeRabbit plan comment (2026-06-06), adapted to current codebase.
-**Branch**: `feature/87-workflow-persistence`
+## Verify-before-fix finding
+Reproduced live against current `main`: the prepare page **already renders without crashing**.
+The crash described in the issue was fixed by intervening PRs (notably **#166**, which corrected the
+`TransformationConfigDialog` props contract). The CodeRabbit plan's "Phase 1: fix dialog props" is a
+no-op today, and the dialog never rendered on initial load anyway (`editingIndex` is `null`).
 
-## Adapted Plan
+Confirmed working in browser (churn.csv dataset, seeded `data_loading`+`data_profiling`):
+- h1 "Prepare Data" + metadata + Visual/Chain toggles render
+- both view modes render; chain view lists transformations
+- edit dialog (`TransformationConfigDialog`) opens cleanly — the path CodeRabbit flagged
 
-### Step 1 — Backend data layer (TDD: tests first)
-- [x] Create `apps/backend/tests/test_services/test_workflow_service.py` (RED)
-  - create_workflow: generates workflow_id, initial history entry (version=1)
-  - update_workflow: appends history entry with incremented version, updates `updated_at`
-  - get_by_dataset: returns workflow; raises NotFoundError when absent
-  - duplicate create raises ConflictError
-  - history accumulation over multiple updates; history cap (keep latest 50)
-- [x] Create `apps/backend/app/models/workflow.py`
-  - `StateHistoryEntry(BaseModel)`: version, current_stage, completed_stages, stage_data, model_id, deployment_id, timestamp
-  - `WorkflowState(Document)`: workflow_id (str UUID), user_id `Indexed(str)`, dataset_id `Indexed(str)`, current_stage, completed_stages (List[str]), stage_data (Dict[str, Any]), model_id, deployment_id, state_history, created_at/updated_at via `get_current_time()`
-  - `Settings`: collection `workflow_states`; indexes incl. compound unique `[("user_id",1),("dataset_id",1)]`
-  - Follow `dataset.py` patterns (Field descriptions, model_config json_encoders)
-- [x] Create `apps/backend/app/services/workflow_service.py`
-  - `WorkflowService(BaseService[WorkflowState])`, `_get_id_field() -> "workflow_id"`
-  - `get_by_dataset`, `create_workflow` (app-level duplicate check → ConflictError), `update_workflow` (append history, cap 50), `get_history`
-  - Exceptions from `app.services.exceptions`
-- [x] Register model in `apps/backend/app/models/registry.py` (NOT main.py — registry is canonical)
+## Adapted plan (done)
+1. [x] **Re-enable the two `test.fixme` @smoke tests** (removed `.fixme` + the
+   "Disabled pending #155" comments).
+2. [x] **Add a defensive guard** on the edit-dialog render block (page.tsx) so the IIFE
+   only runs when `transformations[editingIndex]` exists.
+3. [x] **Repair the whole data-preparation spec** — re-enabling the tests surfaced two
+   classes of pre-existing breakage, both fixed:
+   - **#87 gating regression**: the backend became the hydration source of truth, so a
+     localStorage-only seed no longer grants access. Added a `seedPreparationWorkflow`
+     helper that seeds the real backend workflow (live API, no mocking) + localStorage
+     fallback, applied to all three `describe` blocks.
+   - **Masked broad locators**: while the page crashed/redirected these never ran. Fixed
+     `toContain('default')` → `toContain('bg-primary')` (active Button variant), scoped
+     bare `h1`/`text=/rows/`/`text=/No transformations/` and `.first()`'d the
+     link-wrapping-button Back controls, fixed the invalid comma `text=` OR.
+4. [x] **Verified**: `chromium-smoke` @smoke (2 passed) and full `chromium-full` spec
+   (16 passed); type-check clean; eslint clean; 313 transformation jest tests pass.
 
-### Step 2 — Backend API layer (TDD: tests first)
-- [x] Create `apps/backend/tests/test_api/test_workflows.py` (RED) — `@pytest.mark.integration`, `async_authorized_client` + `setup_database`, user `test_user_123`
-  - POST → 201; duplicate POST → 409
-  - GET → 200 with state; missing → 404; other user's workflow → 404 (user-scoped lookup; deviation from plan's 403, see below)
-  - PUT → 200, appends history; missing → 404
-  - GET /history → entries + total_versions
-  - Recovery: create at stage N → new client session → GET returns stage N; history checkpoints reconstructable
-- [x] Create `apps/backend/app/schemas/workflow.py`
-  - `WorkflowCreateRequest`, `WorkflowUpdateRequest` (all-optional), `WorkflowResponse`, `StateHistoryEntryResponse`, `WorkflowHistoryResponse`
-- [x] Create `apps/backend/app/api/routes/workflows.py`
-  - `GET/POST/PUT /workflows/{dataset_id}`, `GET /workflows/{dataset_id}/history`
-  - Auth via `Depends(get_current_user_id)` (`app.auth.nextauth_auth`); HTTPException mapping; logging per `datasets.py`
-- [x] Register router in `apps/backend/app/main.py`: `app.include_router(workflows.router, prefix=f"{settings.API_V1_STR}", tags=["workflows"])`
+## Acceptance criteria
+- [x] `/datasets/{id}/prepare` renders (h1 "Prepare Data", view-mode toggles) for a valid dataset
+- [x] The two fixme'd smoke tests are re-enabled and pass
 
-### Step 3 — Frontend integration (TDD: tests first)
-- [x] Create `apps/frontend/lib/contexts/__tests__/WorkflowContext.persistence.test.tsx` (RED) — mock fetch + getAuthToken
-  - loadWorkflow: backend 200 → state hydrated + localStorage cache refreshed; 404 → localStorage fallback; network error → localStorage fallback
-  - saveWorkflow: POST first time, PUT after exists (and PUT after POST→409)
-  - completeStage triggers saveWorkflow
-- [x] Modify `apps/frontend/lib/contexts/WorkflowContext.tsx`
-  - Remove stub early-return in `loadWorkflow()` (~line 158); URL `${API_URL}/workflows/${datasetId}` (API_URL already includes /api/v1)
-  - Auth via existing `getAuthToken()` helper, conditional Bearer header (ModelService pattern)
-  - `saveWorkflow()`: POST when not yet created, PUT thereafter; 409 → PUT; failure → localStorage fallback (existing useEffect stays as cache layer)
-  - `completeStage()` fires saveWorkflow after state update (stage boundaries are infrequent — no debounce; YAGNI)
-  - Page-load recovery: backend state wins; 404/network error → keep localStorage state
-  - Set ↔ Array serialization preserved (completedStages)
-
-### Step 4 — Quality gates & docs
-- [x] Backend: `cd apps/backend && uv run pytest tests/test_services/test_workflow_service.py tests/test_api/test_workflows.py -v` then full relevant suite; ruff
-- [x] Frontend: `npm test`, `npm run type-check`
-- [x] Update CLAUDE.md (issue #87 section), e2e README if seeding behavior affected
-- [x] Demo (Phase 11), PR, CI, merge
-
-## Acceptance Criteria (from issue)
-- [x] Workflow state stored in MongoDB per user/dataset: current stage, completion flags, key selections (stage_data)
-- [x] State saved at each stage boundary; restored on login/page load
-- [x] Automatic recovery after browser crash/refresh mid-stage
-- [x] Version history of workflow state changes (append log)
-- [x] Endpoints: POST/GET/PUT `/api/v1/workflows/{id}` (+ `/history`)
-- [x] Frontend WorkflowContext reads/writes backend state with localStorage offline fallback
-- [x] Integration tests for save/restore/recovery paths
-
-## Deviations from the CodeRabbit plan
-1. **Model registration via `app/models/registry.py`**, not `init_beanie()` in `main.py` — registry became canonical in issue #160; main.py already consumes `DOCUMENT_MODELS`.
-2. **Wrong-user GET returns 404, not 403** — lookups are scoped by `(user_id, dataset_id)`, so another user's workflow is simply not found; avoids leaking existence. Plan's 403 test becomes a 404 test.
-3. **App-level duplicate check (ConflictError → 409) in addition to the unique index** — unit tests run on mongomock with `skip_indexes=True`, so the index alone can't be relied on in tests.
-4. **History capped at 50 entries** (keep latest) — full-snapshot entries with unbounded growth risk the 16MB Mongo doc limit; cap is one line and satisfies "simple append log".
-5. **`StateHistoryEntry` also snapshots `model_id`/`deployment_id`** so a history entry can fully reconstruct state (plan's recovery test demands full reconstruction but omitted these fields).
-6. **No debounce on auto-save** — stage boundaries are infrequent user actions; plan said "if needed". YAGNI.
-7. **Frontend URL is `${API_URL}/workflows/…`** — `API_URL` constant already contains `/api/v1`.
+## Deviation from original (CodeRabbit) plan
+- Original Phase 1 (fix dialog props `onSave`→`onAdd`, add missing props, metadata helper) is
+  **already implemented** by #166 — dropped.
+- Keeping only CodeRabbit's "Task 2" defensive guard + the test re-enable + verification.


### PR DESCRIPTION
Closes #155.

## Summary
The reported client-side crash on `/datasets/{id}/prepare` was **already resolved on `main`** — #166's TypeScript cleanup fixed the `TransformationConfigDialog` props contract that CodeRabbit's plan blamed, and that dialog never even mounts on initial load (`editingIndex` is `null`). Live browser reproduction against `main` confirms the page renders in both view modes and the edit dialog opens without error.

So the deliverable here is the **acceptance gate**: re-enabling the two `test.fixme`'d `@smoke` tests and getting them (and the rest of the spec) green, plus a small anti-crash hardening that matches the issue's intent.

## Changes
- **Re-enable** the two `@smoke` tests in `e2e/workflows/data-preparation.spec.ts`.
- **Defensive guard** on the edit-dialog render block: only run when `transformations[editingIndex]` exists, so a stale index (delete-while-editing) can't crash the page.
- **Repair the whole data-preparation spec.** Re-enabling the tests surfaced two pre-existing, masked failures:
  - **#87 gating regression** — the backend is now the workflow hydration source of truth, so a localStorage-only seed no longer grants stage access. Added a `seedPreparationWorkflow` helper that seeds the **real backend workflow** (live API, no mocking) with a localStorage fallback, applied to all three `describe` blocks.
  - **Broad locators** that never ran while the page crashed — `toContain('default')` → `toContain('bg-primary')` (the shadcn active variant; the literal "default" never appears in the class string), scoped bare `h1` / `text=/rows/` / `text=/No transformations/`, `.first()` on the link-wrapped Back controls, and fixed an invalid comma `text=` OR.

## Verification
- `chromium-smoke` `@smoke`: **2 passed** ✅
- full `chromium-full` data-preparation spec: **16 passed** ✅
- `tsc --noEmit` clean; `eslint` clean; **313** transformation jest tests pass
- `codex review --base main` (cross-family): no regressions identified
- Live demo evidence captured (page renders, edit dialog opens) — see `tasks/issue-155-demo.md`

## Acceptance criteria
- [x] `/datasets/{id}/prepare` renders (h1 "Prepare Data", view-mode toggles) for a valid dataset
- [x] The two fixme'd smoke tests are re-enabled and pass

## Known limitations
- E2E backend seeding relies on the test harness's `SKIP_AUTH=true` mapping (`Bearer dev-user-default`), consistent with the rest of the suite. It targets LocalStack/local backend only — never real AWS.
- Concurrent multi-device workflow sync remains an accepted beta limitation (deferred with #91), unchanged here.