### PR TITLE
test: make TestTrainingJobListEndpoint order-independent (#198)

### DIFF
--- a/apps/backend/tests/test_api/test_model_training.py
+++ b/apps/backend/tests/test_api/test_model_training.py
@@ -3,6 +3,7 @@ Tests for model training API endpoints
 """
 
 import pytest
+import pytest_asyncio
 from unittest.mock import MagicMock, patch, AsyncMock
 import pandas as pd
 import numpy as np
@@ -955,6 +956,26 @@ async def _insert_job(
 
 
 class TestTrainingJobListEndpoint:
+    """Tests for GET /api/v1/ml/jobs.
+
+    These assert on absolute job counts, so each one needs a clean
+    ``training_jobs`` collection. They don't use ``setup_database`` (they only
+    need the app's lifespan DB from ``async_authorized_client``), and a training
+    test's fire-and-forget background task can leak a job past its own cleanup
+    window. The autouse fixture below clears the collection at the start of each
+    test so the suite is order-independent (issue #198).
+    """
+
+    @pytest_asyncio.fixture(autouse=True)
+    async def _isolate_training_jobs(self, async_authorized_client):
+        from app.models.training_job import TrainingJob
+
+        # Clean slate before the test (drops anything leaked from earlier tests)
+        # and after, so a job created here never bleeds into the next test.
+        await TrainingJob.find().delete()
+        yield
+        await TrainingJob.find().delete()
+
     """Test GET /api/v1/ml/jobs"""
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
Fixes the order-dependent flake in `tests/test_api/test_model_training.py::TestTrainingJobListEndpoint` (issue #198).

The list-jobs tests assert **absolute global** `TrainingJob` counts but don't depend on `setup_database`, so they have no per-test cleanup. When run in the same invocation as `tests/test_model_training/`, a `TrainingJob` created by a training test's fire-and-forget background task (`POST /ml/train`) lands after its cleanup window and survives into these tests → `assert N+1 == N`.

## Change
Add an autouse class fixture (`_isolate_training_jobs`) that clears `training_jobs` before and after each test in the class, giving every test a guaranteed clean slate — robust to this leak and any future one.

This is **Option A** from the #82 review triage. The underlying background-task-vs-cleanup race is deferred (it only manifests through these fragile assertions, which this neutralizes).

## Validation
```
cd apps/backend
PYTHONPATH=. uv run pytest tests/test_model_training/ tests/test_services/test_batch_prediction.py tests/test_api/test_model_training.py -m "not integration and not performance" -W ignore
```
- Previously: `test_list_jobs_{empty,populated,pagination}` FAIL (`4 == 3`)
- Now: all green (158 passed)
- `TestTrainingJobListEndpoint` still passes in isolation; ruff clean

Test-only change; reproduced on `main` (not a feature regression).

Closes #198