### PR TITLE
chore(ci): non-root backend image, trimmed build context, SHA-pinned actions, Dependabot (#176)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,45 @@
+# Dependabot — keep pinned Docker base/tool digests and GitHub Actions SHAs current
+# (issue #176). The deployed image bases (python:3.13-slim, ghcr.io/astral-sh/uv,
+# node:20-alpine) and every workflow `uses:` are pinned by digest/SHA for
+# reproducibility + supply-chain hardening; those pins do not refresh themselves, so
+# Dependabot opens weekly PRs to bump them (and pick up upstream security patches).
+version: 2
+updates:
+  # Backend production image — refreshes `FROM python:3.13-slim@sha256:…` and the
+  # `COPY --from=ghcr.io/astral-sh/uv:0.5.31@sha256:…` tool digest.
+  - package-ecosystem: "docker"
+    directory: "/apps/backend"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(docker)"
+    labels:
+      - "dependencies"
+      - "docker"
+
+  # Frontend production image — refreshes the `node:20-alpine@sha256:…` base digest.
+  - package-ecosystem: "docker"
+    directory: "/apps/frontend"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(docker)"
+    labels:
+      - "dependencies"
+      - "docker"
+
+  # Workflow actions — refreshes the commit-SHA pins (keeps the `# vN` tag comments
+  # accurate). Grouped so all action bumps land in one PR per week.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(ci)"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,8 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.13'
       - name: Install uv
@@ -56,8 +56,8 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.13'
       - name: Install uv
@@ -75,8 +75,8 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.13'
       - name: Install uv
@@ -103,7 +103,7 @@ jobs:
             --cov-report=term-missing \
             -v
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
         with:
           files: apps/backend/coverage.xml
           flags: backend-unit
@@ -139,8 +139,8 @@ jobs:
           --health-timeout 5s
           --health-retries 10
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.13'
       - name: Install uv
@@ -190,7 +190,7 @@ jobs:
           AWS_DEFAULT_REGION: us-east-1
           OPENAI_API_KEY: sk-test-key-for-mocking
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
         with:
           files: apps/backend/coverage.xml
           flags: backend-integration
@@ -209,8 +209,8 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
           cache: 'npm'
@@ -227,8 +227,8 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
           cache: 'npm'
@@ -258,8 +258,8 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
           cache: 'npm'
@@ -273,7 +273,7 @@ jobs:
         env:
           CI: true
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
         with:
           files: apps/frontend/coverage/lcov.info
           flags: frontend-unit
@@ -288,8 +288,8 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.13'
       - name: Install uv

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -26,13 +26,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 1   # you can make this 0 if you want full history/context
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@9dd8b95a392eb34b6f5fb56cf5a64cb735912d4b # v1
         with:
           # Auth for Claude itself (OAuth token from https://console.anthropic.com)
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -32,13 +32,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@9dd8b95a392eb34b6f5fb56cf5a64cb735912d4b # v1
         with:
           # Auth for Claude itself (OAuth token from Anthropic Console)
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,7 +42,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Check deploy secrets are configured
         id: preflight

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -24,10 +24,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
           cache: 'npm'
@@ -66,7 +66,7 @@ jobs:
 
       - name: Upload test results
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: test-results-${{ matrix.project }}-shard-${{ steps.shard.outputs.id }}
           path: apps/frontend/test-results/
@@ -74,7 +74,7 @@ jobs:
 
       - name: Upload Playwright report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: playwright-report-${{ matrix.project }}-shard-${{ steps.shard.outputs.id }}
           path: apps/frontend/playwright-report/

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -23,10 +23,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.11'
 
@@ -95,7 +95,7 @@ jobs:
           OPENAI_API_KEY: sk-test-key-for-mocking
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
         with:
           files: apps/backend/coverage.xml
           flags: backend-integration
@@ -106,7 +106,7 @@ jobs:
 
       - name: Upload coverage artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: integration-coverage
           path: apps/backend/coverage.xml
@@ -114,7 +114,7 @@ jobs:
 
       - name: Upload test results
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: integration-test-results
           path: apps/backend/test-results/

--- a/.github/workflows/perf-tests.yml
+++ b/.github/workflows/perf-tests.yml
@@ -32,17 +32,17 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
           cache: 'npm'
           cache-dependency-path: apps/frontend/package-lock.json
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.13'
 
@@ -144,7 +144,7 @@ jobs:
 
       - name: Upload performance results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: performance-results
           path: |
@@ -155,7 +155,7 @@ jobs:
 
       - name: Upload Playwright report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: perf-test-report
           path: apps/frontend/playwright-report/

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -31,17 +31,17 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
           cache: 'npm'
           cache-dependency-path: apps/frontend/package-lock.json
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.13'
 
@@ -61,7 +61,7 @@ jobs:
       # it. `--with-deps` still runs each time for the apt system libraries
       # (not stored in this cache path), but those are mostly preinstalled.
       - name: Cache Playwright browsers
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ hashFiles('apps/frontend/package-lock.json') }}
@@ -137,7 +137,7 @@ jobs:
 
       - name: Upload test results
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: smoke-test-results
           path: apps/frontend/test-results/
@@ -145,7 +145,7 @@ jobs:
 
       - name: Upload Playwright report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: smoke-test-report
           path: apps/frontend/playwright-report/

--- a/apps/backend/.dockerignore
+++ b/apps/backend/.dockerignore
@@ -20,4 +20,20 @@ test-results/
 .gitignore
 Dockerfile
 .dockerignore
+
+# Non-build inputs — keep the builder's `COPY . .` lean (issue #176). The runtime
+# image already copies only .venv/app/utils, so these never reach the final image;
+# excluding them here trims the builder context + speeds cache-miss COPYs. Never add
+# a build input here: pyproject.toml, uv.lock, app/, utils/, main.py, README.md
+# (referenced by [project].readme — there is no [build-system] section).
 docs/
+claudedocs/
+tests/
+tasks/
+sample_datasets/
+scripts/
+.benchmarks/
+.apm/
+docker-compose.test.yml
+coverage_summary.txt
+test.csv

--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -51,13 +51,26 @@ FROM python:3.13-slim@sha256:c33f0bc4364a6881bed1ec0cc2665e6c53c87a43e774aaeab88
 
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
-    PATH="/app/.venv/bin:$PATH"
+    PATH="/app/.venv/bin:$PATH" \
+    # matplotlib (pulled in by SHAP/visualization) needs a writable cache dir; as a
+    # non-root user it can't write under the root-owned /app home (issue #176). Point
+    # it at a dedicated dir pre-created + chown'd below. Keeps /app read-only and
+    # avoids a per-boot "temporary cache directory" fallback warning.
+    MPLCONFIGDIR=/var/cache/matplotlib
 
 # Runtime-only libraries: curl for the healthcheck, libgomp1 for xgboost/lightgbm.
 RUN apt-get update && apt-get install -y --no-install-recommends \
         curl \
         libgomp1 \
     && rm -rf /var/lib/apt/lists/*
+
+# Run as a non-root user (issue #176), mirroring the frontend image. Debian slim
+# ships groupadd/useradd (not alpine's addgroup/adduser). uid/gid 1001 matches the
+# frontend's convention. The copied venv/app/utils are chown'd to this user below.
+RUN groupadd --system --gid 1001 appuser \
+    && useradd --system --uid 1001 --gid appuser --home-dir /app appuser \
+    && mkdir -p "$MPLCONFIGDIR" \
+    && chown appuser:appuser "$MPLCONFIGDIR"
 
 WORKDIR /app
 
@@ -66,15 +79,19 @@ WORKDIR /app
 # the image: the virtualenv, the `app` package, and the top-level `utils`
 # namespace package (imported by app/api/routes/s3.py). gunicorn runs from
 # WORKDIR /app, so /app is on sys.path and both packages resolve. No compiler
-# toolchain is carried forward.
-COPY --from=builder /app/.venv /app/.venv
-COPY --from=builder /app/app /app/app
-COPY --from=builder /app/utils /app/utils
+# toolchain is carried forward. --chown hands ownership to the non-root appuser.
+COPY --from=builder --chown=appuser:appuser /app/.venv /app/.venv
+COPY --from=builder --chown=appuser:appuser /app/app /app/app
+COPY --from=builder --chown=appuser:appuser /app/utils /app/utils
 
 # Guard the targeted COPY above: fail the build if the runtime image is missing
 # a top-level package the app imports (e.g. a future sibling of app/ + utils/).
-# Import only — no DB/lifespan side effects fire here.
+# Import only — no DB/lifespan side effects fire here. Runs as root pre-switch.
 RUN python -c "import app.main"
+
+# Drop privileges for the running server. gunicorn binds :8000 (>1024 → no root
+# needed) and the curl healthcheck works as any user.
+USER appuser
 
 EXPOSE 8000
 

--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -49,13 +49,14 @@ RUN uv sync --frozen --no-dev
 # Same digest as the builder above (see note there) — keep the two in sync.
 FROM python:3.13-slim@sha256:c33f0bc4364a6881bed1ec0cc2665e6c53c87a43e774aaeab88e6f17af105e4f AS runtime
 
+# MPLCONFIGDIR: matplotlib (pulled in by SHAP/visualization) needs a writable cache
+# dir; as a non-root user it can't write under the root-owned /app home (issue #176).
+# Point it at a dedicated dir pre-created + chown'd below. Keeps /app read-only and
+# avoids a per-boot "temporary cache directory" fallback warning. (Comment kept above
+# the ENV — inline comments inside a `\`-continued instruction are non-standard.)
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
     PATH="/app/.venv/bin:$PATH" \
-    # matplotlib (pulled in by SHAP/visualization) needs a writable cache dir; as a
-    # non-root user it can't write under the root-owned /app home (issue #176). Point
-    # it at a dedicated dir pre-created + chown'd below. Keeps /app read-only and
-    # avoids a per-boot "temporary cache directory" fallback warning.
     MPLCONFIGDIR=/var/cache/matplotlib
 
 # Runtime-only libraries: curl for the healthcheck, libgomp1 for xgboost/lightgbm.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,29 +1,57 @@
-# Issue #176 — CI/Docker hardening follow-ups (mechanical subset)
+# Issue #176 — CI/Docker hardening follow-ups (batch 2)
 
-Branch: `chore/176-ci-docker-hardening`
-Scope confirmed with user: mechanical hardening only. Items 1 (mypy→blocking) and
-7 (broaden integration coverage) stay open as tracked follow-ups; ruff pyupgrade
-(~2,958 findings) deferred — import-sorting only.
+Umbrella issue. Batch 1 (multi-stage backend image, digest pins, Node 20, uv pin, isort)
+shipped in PR #214. This PR implements 4 selected self-contained follow-ups.
 
-## Tasks (PR #214)
-- [x] 2. Backend Dockerfile multi-stage — `builder` keeps build-essential; slim
-      `runtime` copies only `/app` (venv+code) + installs curl, libgomp1.
-- [x] 3. Node 18 → 20 — ci.yml (3), e2e-tests.yml, smoke-tests.yml, perf-tests.yml,
-      frontend Dockerfile (deps/builder/runtime).
-- [x] 4. Pin uv — `ghcr.io/astral-sh/uv:0.5` → `:0.5.31@sha256:7bff3c37…`.
-- [x] 6. Drop `npm ci || npm install` fallback — ci.yml (3), e2e-tests.yml.
-- [x] 5. Ruff `extend-select = ["I"]` + autofix 314 I001; guard app/main.py ordering.
+Branch: `chore/176-ci-docker-hardening-batch2`
+
+## Scope (user-confirmed)
+1. **Backend runtime non-root user**
+2. **Backend `.dockerignore`** (trim builder context)
+3. **Dependabot Docker digest refresh** (+ github-actions to maintain SHA pins)
+4. **Repo-wide GitHub Actions SHA pinning**
+
+Out of scope (large/incremental — stay open on #176): mypy→blocking, ruff pyupgrade,
+broaden integration coverage. CI service-container image digest pinning = documented follow-up.
+
+## Plan
+
+### 1. Backend non-root user (`apps/backend/Dockerfile`, runtime stage)
+- Create non-root system user/group (`appuser`, uid/gid 1001) via `groupadd`/`useradd`
+  (Debian slim, not alpine's addgroup/adduser).
+- `--chown=appuser:appuser` on the three `COPY --from=builder` lines (.venv, app, utils).
+- Keep `python -c "import app.main"` guard (runs as root pre-switch, fine).
+- `USER appuser` before EXPOSE. gunicorn binds :8000 (>1024 → non-root OK); curl healthcheck OK.
+- Mirrors the frontend image's existing non-root pattern.
+
+### 2. Backend `.dockerignore`
+- Add clearly-non-build entries: `tests/`, `tasks/`, `sample_datasets/`, `claudedocs/`,
+  `scripts/`, `.benchmarks/`, `.apm/`, loose artifacts (`coverage_summary.txt`, `test.csv`,
+  `docker-compose.test.yml`).
+- NEVER exclude build inputs: `pyproject.toml`, `uv.lock`, `app/`, `utils/`, `main.py`,
+  `__init__.py`, **`README.md`** (referenced by `[project].readme`; no `[build-system]`).
+- VERIFY with a real `docker build` (the meaningful test for this change).
+
+### 3. `.github/dependabot.yml` (new)
+- `docker` for `apps/backend`, `apps/frontend`, `apps/mcp` (weekly) — refresh `FROM @sha256`
+  + `COPY --from=...@sha256` digest pins.
+- `github-actions` for `/` (weekly) — keep the new SHA pins current.
+
+### 4. GitHub Actions SHA pinning (all 8 workflows)
+Replace `uses: org/action@vN` → `uses: org/action@<sha> # vN`. Resolved SHAs:
+- actions/checkout@v5              -> 93cb6efe18208431cddfb8368fd83d5badbf9bfd
+- actions/upload-artifact@v4       -> ea165f8d65b6e75b540449e92b4886f43607fa02
+- actions/setup-python@v5          -> a26af69be951a213d495a4c3e4e4022e16d87065
+- actions/setup-node@v4            -> 49933ea5288caeca8642d1e84afbd3f7d6820020
+- codecov/codecov-action@v4        -> b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238
+- anthropics/claude-code-action@v1 -> 9dd8b95a392eb34b6f5fb56cf5a64cb735912d4b
+- actions/cache@v4                 -> 0057852bfaa89a56745cba8c7296529d2fc39830
 
 ## Verification
-- [x] `docker build` backend image succeeds; `import app.main` + xgboost/lightgbm
-      in runtime image; gcc absent, curl present.
-- [x] `ruff check .` clean.
-- [x] Service-free pytest suite green (imports intact after isort).
-- [x] Workflow YAML still valid.
-- [x] Cross-family review (codex): no findings. claude-review = infra max-turns (no findings).
-- [x] CI Success green; docs/testing/guide.md synced to Node 20.
+- `docker build apps/backend` succeeds (non-root + .dockerignore); runs `import app.main`.
+- `docker build apps/frontend` still succeeds (unchanged, sanity).
+- actionlint / YAML lint workflows; confirm no bare `@vN` action refs remain.
+- Validate dependabot.yml.
 
-## Deferred (issue stays open)
-- 1. mypy → blocking (~317 findings, incremental typing project)
-- 7. Broaden integration coverage (needs reliable LocalStack/OpenAI)
-- ruff pyupgrade rules (UP*) — 2,958-finding repo-wide churn
+## PR
+- References #176; lists done + still-open items.


### PR DESCRIPTION
Batch 2 of the **#176** CI/Docker hardening follow-ups (batch 1 shipped in PR #214). Implements the four self-contained items confirmed in scope.

## What's in this PR

### 1. Backend runtime non-root user (`apps/backend/Dockerfile`)
- Runs as `appuser` (uid/gid 1001), mirroring the frontend image's existing pattern. Debian-slim → `groupadd`/`useradd`.
- `--chown=appuser:appuser` on the three `COPY --from=builder` lines (`.venv`/`app`/`utils`); `USER appuser` before `EXPOSE`.
- `MPLCONFIGDIR=/var/cache/matplotlib` (pre-created + chown'd) so matplotlib — pulled in by SHAP/visualization — has a writable cache without making `/app` writable. Avoids the per-boot "temporary cache directory" fallback warning the non-root switch would otherwise produce.

### 2. Trimmed backend build context (`apps/backend/.dockerignore`)
- Excludes non-build inputs from the builder's `COPY . .`: `tests/`, `tasks/`, `sample_datasets/`, `scripts/`, `claudedocs/`, `.benchmarks/`, `.apm/`, plus loose artifacts (`docker-compose.test.yml`, `coverage_summary.txt`, `test.csv`).
- **Preserves** all build inputs: `pyproject.toml`, `uv.lock`, `app/`, `utils/`, `main.py`, and `README.md` (referenced by `[project].readme`; there is no `[build-system]` section).

### 3. Dependabot (`.github/dependabot.yml`, new)
- Weekly `docker` updates for `apps/backend` + `apps/frontend` to refresh the pinned `FROM …@sha256` / `COPY --from=…@sha256` base+tool digests (they don't self-refresh → security patches were silently stale).
- Weekly grouped `github-actions` updates to keep the new SHA pins current.

### 4. Repo-wide GitHub Actions SHA pinning (all 8 workflows)
- Every `uses: org/action@vN` → `uses: org/action@<commit-sha> # vN` (44 refs across 7 distinct actions). Supply-chain hardening; the `# vN` comment keeps them readable and Dependabot maintains them.

## Verification
- `docker build apps/backend` succeeds; container runs as `appuser`, `import app.main` OK, `.venv`/`app`/`utils` owned by `appuser`, matplotlib uses `/var/cache/matplotlib` cleanly, trimmed dirs absent from the image.
- Runtime write-paths confirmed safe under non-root: `UploadHandler` writes to `/tmp/uploads`; the `api_documentation` relative-path writes are example-client **string templates**, not executed.
- All workflow + dependabot YAML parse; no bare `@vN` action refs remain.
- Cross-family review (codex `--base main`): no actionable findings.

## Stays open on #176 (too large for one PR)
- mypy → blocking (~317 findings, incremental typing)
- ruff pyupgrade (UP\*) (~2,900 findings)
- Broaden integration coverage in CI

## Known limitation
- CI **service-container** images (mongo/redis/localstack/minio) remain tag-pinned, not digest-pinned — Dependabot's `github-actions` ecosystem doesn't manage service `image:` refs. Tracked as a follow-up on #176.