### PR TITLE
chore(ci): digest-pin CI service-container images (mongo/redis/localstack) (#176)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,6 +133,7 @@ jobs:
       # healthy before any step runs — it is a hard requirement for the
       # redis-gated integration tests. Mapped to 6380 to match TEST_REDIS_URL.
       redis:
+        # Digest-pinned; see the mongodb block above — same manual refresh process.
         image: redis:7-alpine@sha256:6ab0b6e7381779332f97b8ca76193e45b0756f38d4c0dcda72dbb3c32061ab99
         ports:
           - 6380:6379

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,7 +118,10 @@ jobs:
     runs-on: ubuntu-latest
     services:
       mongodb:
-        image: mongo:7.0
+        # Digest-pinned for reproducibility (issue #176). Dependabot's
+        # github-actions ecosystem does NOT manage service `image:` refs, so these
+        # are refreshed manually (or by a future docker-ecosystem entry).
+        image: mongo:7.0@sha256:8ecb514b00bdcc0bde67ef4e6c330385377a9dc68e24ee94e28c07c891647348
         ports:
           - 27017:27017
         options: >-
@@ -130,7 +133,7 @@ jobs:
       # healthy before any step runs — it is a hard requirement for the
       # redis-gated integration tests. Mapped to 6380 to match TEST_REDIS_URL.
       redis:
-        image: redis:7-alpine
+        image: redis:7-alpine@sha256:6ab0b6e7381779332f97b8ca76193e45b0756f38d4c0dcda72dbb3c32061ab99
         ports:
           - 6380:6379
         options: >-

--- a/.github/workflows/perf-tests.yml
+++ b/.github/workflows/perf-tests.yml
@@ -21,7 +21,8 @@ jobs:
 
     services:
       mongodb:
-        image: mongo:7
+        # Digest-pinned (issue #176); unified to the same mongo:7.0 digest as ci.yml.
+        image: mongo:7.0@sha256:8ecb514b00bdcc0bde67ef4e6c330385377a9dc68e24ee94e28c07c891647348
         ports:
           - 27017:27017
         options: >-

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -20,7 +20,8 @@ jobs:
 
     services:
       mongodb:
-        image: mongo:7
+        # Digest-pinned (issue #176); unified to the same mongo:7.0 digest as ci.yml.
+        image: mongo:7.0@sha256:8ecb514b00bdcc0bde67ef4e6c330385377a9dc68e24ee94e28c07c891647348
         ports:
           - 27017:27017
         options: >-

--- a/apps/backend/docker-compose.test.yml
+++ b/apps/backend/docker-compose.test.yml
@@ -17,7 +17,9 @@ services:
   # Note: Running without authentication for local testing only
   # DO NOT use this configuration in production
   redis-test:
-    image: redis:7-alpine
+    # Digest-pinned for reproducible test infra (issue #176). Refresh alongside the
+    # workflow service-image pins when bumping.
+    image: redis:7-alpine@sha256:6ab0b6e7381779332f97b8ca76193e45b0756f38d4c0dcda72dbb3c32061ab99
     container_name: narrative-redis-test
     ports:
       - "6380:6379"  # Different port to avoid conflicts with dev Redis
@@ -36,7 +38,7 @@ services:
   # Note: LocalStack uses fake AWS credentials for local testing only
   # These credentials never touch real AWS services
   localstack:
-    image: localstack/localstack:3.0.2
+    image: localstack/localstack:3.0.2@sha256:e606c4421419030b12d63a59f1211f57f5b0fbf7e9ce769e6250ee62ff4f9293
     container_name: narrative-localstack-test
     ports:
       - "4566:4566"  # LocalStack edge port

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,29 @@
 # Lessons
 
+## 2026-06-17 — issue #176 (CI/Docker hardening, batch 2 / PR #215)
+
+- **Making a Python container non-root breaks `$HOME`-caching libs.** After
+  `USER appuser`, matplotlib (pulled in via SHAP/visualization) couldn't write
+  its cache under the root-owned `/app` home and fell back to `/tmp` with a
+  per-boot warning. Fix: set `MPLCONFIGDIR` to a dir **pre-created + `chown`'d**
+  to the user (just exporting `MPLCONFIGDIR=/tmp/matplotlib` wasn't enough —
+  matplotlib's writability check failed on the not-yet-existing dir). Keeps
+  `/app` read-only. Watch for the same with joblib/numba/fontconfig if they warn.
+- **Inline `#` comments inside a `\`-continued `ENV`/`RUN` are non-standard.**
+  Current BuildKit strips them (the build passed), but the Dockerfile spec
+  doesn't guarantee it and older daemons / custom frontends may choke. Put the
+  comment **above** the instruction. Caught by claude-review; cheap pre-merge fix.
+- **Verify non-root doesn't break runtime file writes.** codex's review probe
+  grepped for `open(...,'w')`/`to_csv` — turned out safe here (`UploadHandler` →
+  `/tmp/uploads`; `api_documentation` writes were example-client **string
+  templates**, not executed), but the check is the right reflex when dropping
+  privileges.
+- **SHA-pin actions + Dependabot together.** Pin `uses: org/action@vN` →
+  `@<40-hex-sha> # vN` (resolve via `gh api repos/<org>/<action>/commits/<tag>`),
+  then add a Dependabot `github-actions` (grouped) + `docker` config so the pins
+  refresh. The CI run on the PR itself validates the pins (jobs spawning = the
+  pinned checkout/setup resolved).
+
 ## 2026-06-08 — issue #75 (core AutoML pipeline)
 
 - **Trust the code, not the issue's "Current State".** The ticket (and its

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,6 +1,18 @@
 # Lessons
 
-## 2026-06-17 — issue #176 (CI/Docker hardening, batch 2 / PR #215)
+## 2026-06-17 — issue #176 (CI/Docker hardening, batch 3 / PR #222)
+
+- **Pin service-container images by multi-arch digest, not tag.** Resolve the
+  manifest-list digest with `docker buildx imagetools inspect <img:tag>` (the
+  `Digest:` line) → pin as `img:tag@sha256:…`; this preserves multi-arch unlike a
+  per-platform digest. GitHub Actions `services:` `image:` and docker-compose
+  `image:` both accept it. **Dependabot's `github-actions` ecosystem does NOT
+  manage service `image:` refs** — those pins are manual (the `docker` ecosystem
+  covers Dockerfiles/compose, not workflow service blocks).
+- The CI run on the pinning PR itself is the functional test — the integration
+  job spins up the pinned mongo/redis, so green = the digests are valid + healthy.
+
+## 2026-06-17 — issue #176 (CI/Docker hardening, batch 2 / PR #215; recorded here)
 
 - **Making a Python container non-root breaks `$HOME`-caching libs.** After
   `USER appuser`, matplotlib (pulled in via SHAP/visualization) couldn't write


### PR DESCRIPTION
Completes the supply-chain pin coverage from #176: the deployed image bases were digest-pinned in #214 (python/uv/node), and this pins the **CI service-container images** too. Part of the #176 epic (the small in-progress item; the larger tracks are now sub-issues #219/#220/#221).

## Changes
| File | Image | Pin |
|------|-------|-----|
| `ci.yml` | `mongo:7.0` (mongodb service) | `@sha256:8ecb…7348` |
| `ci.yml` | `redis:7-alpine` (redis service) | `@sha256:6ab0…ab99` |
| `smoke-tests.yml` | `mongo` (was `:7`) | unified → `mongo:7.0@sha256:8ecb…7348` |
| `perf-tests.yml` | `mongo` (was `:7`) | unified → `mongo:7.0@sha256:8ecb…7348` |
| `docker-compose.test.yml` | `redis:7-alpine` | `@sha256:6ab0…ab99` |
| `docker-compose.test.yml` | `localstack/localstack:3.0.2` | `@sha256:e606…9293` |

Digests are the multi-arch manifest-list digests (resolved via `docker buildx imagetools inspect`), so arch coverage is preserved. `mongo:7` in smoke/perf was unified to the same `mongo:7.0` digest as `ci.yml` for consistency.

## Why manual (not Dependabot)
Dependabot's `github-actions` ecosystem (added in #215) does **not** manage service-container `image:` refs, so these pins are maintained manually for now. Noted inline.

## Verification
- All workflow + compose YAML parse.
- All three pinned digests `docker pull` successfully.
- `docker compose -f apps/backend/docker-compose.test.yml up -d` → redis **healthy**, localstack **running**, both using the digest-pinned refs; clean teardown.

## Out of scope
- `docker-compose.staging.yml`'s `redis:7-alpine` (deploy/runtime path, not CI) — tracked on #176.

Closes the service-container-pinning checklist item on the #176 epic.