### PR TITLE
chore(deploy): digest-pin staging redis + Dependabot root docker entry (#176)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,6 +28,18 @@ updates:
       - "dependencies"
       - "docker"
 
+  # Staging compose — refreshes the `redis:7-alpine@sha256:…` digest pinned in the
+  # repo-root `docker-compose.staging.yml` (deploy path, not CI).
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(docker)"
+    labels:
+      - "dependencies"
+      - "docker"
+
   # Workflow actions — refreshes the commit-SHA pins (keeps the `# vN` tag comments
   # accurate). Grouped so all action bumps land in one PR per week.
   - package-ecosystem: "github-actions"

--- a/apps/backend/REDIS_CACHE.md
+++ b/apps/backend/REDIS_CACHE.md
@@ -92,7 +92,7 @@ CACHE_DEFAULT_TTL=3600            # Default TTL in seconds
 Redis service added to `docker-compose.yml`:
 ```yaml
 redis:
-  image: redis:7.2-alpine
+  image: redis:7-alpine@sha256:6ab0b6e7381779332f97b8ca76193e45b0756f38d4c0dcda72dbb3c32061ab99  # digest-pinned (issue #176)
   ports:
     - "6379:6379"
   command: redis-server --appendonly yes

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -114,7 +114,7 @@ services:
 
   # Redis Cache
   redis:
-    image: redis:7-alpine
+    image: redis:7-alpine@sha256:6ab0b6e7381779332f97b8ca76193e45b0756f38d4c0dcda72dbb3c32061ab99
     container_name: narrative-staging-redis
     restart: unless-stopped
     ports:


### PR DESCRIPTION
## Summary
Closes the last small follow-up tracked directly against the #176 CI/Docker hardening epic: the **staging `redis:7-alpine`** image was the only unpinned service image left in the repo (deploy path, not CI).

## Changes
- **`docker-compose.staging.yml`** — pin `redis:7-alpine` → `redis:7-alpine@sha256:6ab0b6e…` (same multi-arch digest CI already uses in `ci.yml` and `apps/backend/docker-compose.test.yml`, for consistency).
- **`.github/dependabot.yml`** — add a `/`-rooted `docker` ecosystem entry so the staging compose digest is refreshed weekly (the existing `/apps/backend` + `/apps/frontend` entries don't cover the repo-root compose).
- **`apps/backend/REDIS_CACHE.md`** — refresh the `redis:7.2-alpine` doc example to the pinned form.

## Verification
- All `image:` refs in `docker-compose.staging.yml` are now digest-pinned (redis is the only service image; Mongo is external Atlas in staging).
- Digest matches `ci.yml`, `docker-compose.test.yml`, and the doc example.
- `dependabot.yml` and `docker-compose.staging.yml` parse as valid YAML.

## Scope / Known limitations
- This is the **small** epic follow-up only. The three large sub-issues remain open and tracked separately: #219 (mypy → blocking), #220 (ruff pyupgrade UP*), #221 (broaden CI integration coverage).
- Per the epic, #176 closes once #219–#221 and this staging-redis pin are all done — so this PR does **not** close #176.

Refs #176

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Configured automated Docker image updates for the staging environment
  * Updated Docker image pinning for the staging deployment

<!-- end of auto-generated comment: release notes by coderabbit.ai -->