### PR TITLE
chore(ci): Dependabot ignore python major bumps on backend image (#176)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,14 @@ updates:
     labels:
       - "dependencies"
       - "docker"
+    ignore:
+      # Python major bumps need the scientific stack (numba via shap, etc.) to
+      # support the new interpreter first — 3.14 breaks `uv sync` because
+      # numba 0.62.1 caps at <3.14 (PR #216). Re-enable by removing this once
+      # numba/llvmlite ship 3.14 wheels and uv.lock is relocked. Digest +
+      # minor/patch refreshes still flow.
+      - dependency-name: "python"
+        update-types: ["version-update:semver-major"]
 
   # Frontend production image — refreshes the `node:20-alpine@sha256:…` base digest.
   - package-ecosystem: "docker"


### PR DESCRIPTION
## Summary
Stops Dependabot from re-opening the unmergeable Python **major** bump (PR #216) on the backend image.

## Why
PR #216 bumped `python:3.13-slim` → `3.14-slim` and **passed CI**, but CI never builds the backend Docker image — it runs pytest on the runner's 3.13. A local `docker build` of `apps/backend` on 3.14 fails:

```
RuntimeError: Cannot install on Python version 3.14.6; only versions >=3.10,<3.14 are supported.
help: numba (v0.62.1) was included because shap (v0.52.0) depends on numba
```

`numba 0.62.1` (locked, transitive via `shap`) has no 3.14 support, so `uv sync --frozen` fails in the builder stage. Fixing it would require re-locking the entire scientific stack (numba → llvmlite → scipy/numpy) — out of scope for a base-image bump.

## Change
Add an `ignore` for python `version-update:semver-major` on the `/apps/backend` docker entry. Digest + minor/patch refreshes still flow. Remove the ignore once numba/llvmlite ship 3.14 wheels and `uv.lock` is relocked.

Refs #176. Documents why #216 is being closed.