### PR TITLE
test(e2e): migrate trainModel tests off un-trainable sample.csv (#195)

### DIFF
--- a/apps/frontend/e2e/helpers/binaryClassificationData.ts
+++ b/apps/frontend/e2e/helpers/binaryClassificationData.ts
@@ -1,0 +1,66 @@
+/**
+ * Shared test data for e2e specs that train on the trainable
+ * `binary-classification-small.csv` dataset (#195). The 6-row `sample.csv`
+ * makes AutoML detect problem type "unknown" and fail, so any test that trains
+ * a real model must use this dataset + the `churned` target.
+ *
+ * The 9 feature columns (target `churned` excluded) mirror the dataset header;
+ * if that header changes, update these payloads to match.
+ */
+
+/** Relative path passed to the `uploadTestDataset` fixture. */
+export const BINARY_CLASS_DATASET = 'ai-test-datasets/binary-classification-small.csv';
+
+/** Target column for `trainModel`. */
+export const BINARY_CLASS_TARGET = 'churned';
+
+export interface BinaryClassRow {
+  age: number;
+  tenure: number;
+  monthly_charges: number;
+  contract_type: string;
+  has_internet: boolean;
+  has_phone: boolean;
+  payment_method: string;
+  total_charges: number;
+  support_calls: number;
+}
+
+/** One valid feature record the fitted pipeline can transform. */
+export const BINARY_CLASS_ROW: BinaryClassRow = {
+  age: 35,
+  tenure: 12,
+  monthly_charges: 65.5,
+  contract_type: 'Month-to-month',
+  has_internet: true,
+  has_phone: true,
+  payment_method: 'Electronic Check',
+  total_charges: 800.0,
+  support_calls: 2,
+};
+
+const CONTRACT_TYPES = ['Month-to-month', 'One year', 'Two year'];
+const PAYMENT_METHODS = ['Electronic Check', 'Credit Card', 'Bank Transfer', 'Mailed Check'];
+
+/**
+ * Generate `n` varied-but-valid feature rows for batch-style prediction.
+ * Values stay within the dataset's observed ranges so the feature engineer
+ * accepts every categorical value.
+ */
+export function makeBinaryClassRows(n: number): BinaryClassRow[] {
+  return Array.from({ length: n }, (_, i) => {
+    const tenure = 1 + (i % 72); // 1–72
+    const monthly = 20 + (i % 81); // 20–100
+    return {
+      age: 20 + (i % 41), // 20–60
+      tenure,
+      monthly_charges: monthly,
+      contract_type: CONTRACT_TYPES[i % CONTRACT_TYPES.length],
+      has_internet: i % 2 === 0,
+      has_phone: i % 3 !== 0,
+      payment_method: PAYMENT_METHODS[i % PAYMENT_METHODS.length],
+      total_charges: Number((tenure * monthly).toFixed(2)),
+      support_calls: i % 11, // 0–10
+    };
+  });
+}

--- a/apps/frontend/e2e/helpers/mlApi.ts
+++ b/apps/frontend/e2e/helpers/mlApi.ts
@@ -1,0 +1,10 @@
+/**
+ * Shared backend base URL + auth header for e2e specs that call the
+ * `/api/v1/ml` API directly (Next.js does not proxy `/api/v1`, and the
+ * SKIP_AUTH backend still requires an Authorization header for HTTPBearer).
+ *
+ * The token matches the `trainModel`/`uploadTestDataset` fixtures so all calls
+ * resolve to the same SKIP_AUTH user.
+ */
+export const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000/api/v1';
+export const ML_AUTH = { Authorization: 'Bearer e2e-test-token' };

--- a/apps/frontend/e2e/helpers/seedWorkflow.ts
+++ b/apps/frontend/e2e/helpers/seedWorkflow.ts
@@ -16,6 +16,10 @@ export async function seedPredictionWorkflow(
   modelId: string
 ): Promise<void> {
   const apiBase = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000/api/v1';
+  // The `dev-user-default` token differs from the fixtures' `e2e-test-token`,
+  // but under SKIP_AUTH both resolve to the same default user — so the seeded
+  // workflow is owned by the user the page loads as. (Same equivalence noted in
+  // data-preparation.spec.ts.)
   const headers = {
     Authorization: 'Bearer dev-user-default',
     'Content-Type': 'application/json',

--- a/apps/frontend/e2e/helpers/seedWorkflow.ts
+++ b/apps/frontend/e2e/helpers/seedWorkflow.ts
@@ -1,0 +1,65 @@
+import type { Page, APIRequestContext } from '@playwright/test';
+
+/**
+ * Seed the backend workflow (the source of truth since #87) up to a completed
+ * MODEL_EVALUATION with the trained model id, so the prediction-gated `/predict`
+ * page is reachable instead of redirecting to `/upload`.
+ *
+ * The `trainModel` fixture only hits `/ml/train` (it does not persist workflow
+ * state), so any test that navigates a stage-gated UI page after it must seed
+ * the workflow first. Mirrors the inline helper proven in predict.spec.ts.
+ */
+export async function seedPredictionWorkflow(
+  page: Page,
+  request: APIRequestContext,
+  datasetId: string,
+  modelId: string
+): Promise<void> {
+  const apiBase = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000/api/v1';
+  const headers = {
+    Authorization: 'Bearer dev-user-default',
+    'Content-Type': 'application/json',
+  };
+  const completedStages = [
+    'data_loading',
+    'data_profiling',
+    'data_preparation',
+    'feature_engineering',
+    'model_training',
+    'model_evaluation',
+  ];
+  const workflow = {
+    current_stage: 'prediction',
+    completed_stages: completedStages,
+    stage_data: {},
+    model_id: modelId,
+  };
+
+  const put = await request.put(`${apiBase}/workflows/${datasetId}`, { headers, data: workflow });
+  if (put.status() === 404) {
+    const post = await request.post(`${apiBase}/workflows/${datasetId}`, { headers, data: workflow });
+    if (!post.ok()) {
+      throw new Error(`seedPredictionWorkflow POST failed (${post.status()}): ${await post.text()}`);
+    }
+  } else if (!put.ok()) {
+    throw new Error(`seedPredictionWorkflow PUT failed (${put.status()}): ${await put.text()}`);
+  }
+
+  // Mirror into localStorage so the context hydrates before the backend fetch.
+  await page.addInitScript(
+    ({ id, model, stages }) => {
+      localStorage.setItem(
+        'workflowState',
+        JSON.stringify({
+          currentStage: 'prediction',
+          completedStages: stages,
+          stageData: {},
+          datasetId: id,
+          modelId: model,
+          lastUpdated: new Date().toISOString(),
+        })
+      );
+    },
+    { id: datasetId, model: modelId, stages: completedStages }
+  );
+}

--- a/apps/frontend/e2e/workflows/error-scenarios.spec.ts
+++ b/apps/frontend/e2e/workflows/error-scenarios.spec.ts
@@ -17,7 +17,11 @@ import { test, expect } from '../fixtures';
 import { UploadPage } from '../pages/UploadPage';
 import { TransformPage } from '../pages/TransformPage';
 import { TrainPage } from '../pages/TrainPage';
-import { PredictPage } from '../pages/PredictPage';
+import {
+  BINARY_CLASS_DATASET,
+  BINARY_CLASS_TARGET,
+} from '../helpers/binaryClassificationData';
+import { seedPredictionWorkflow } from '../helpers/seedWorkflow';
 import { join } from 'path';
 
 test.describe('Network and API Error Handling', () => {
@@ -168,25 +172,31 @@ test.describe('Validation and Data Error Scenarios', () => {
     }
   });
 
-  test('should prevent prediction with missing feature values', async ({ authenticatedPage, uploadTestDataset, trainModel }) => {
-    const datasetId = await uploadTestDataset();
-    const modelId = await trainModel(datasetId, 'purchased');
+  test('should prevent prediction with missing feature values', async ({
+    authenticatedPage,
+    request,
+    uploadTestDataset,
+    trainModel,
+  }) => {
+    test.setTimeout(120000); // real AutoML training runs well past the 30s default
+    const datasetId = await uploadTestDataset(BINARY_CLASS_DATASET);
+    const modelId = await trainModel(datasetId, BINARY_CLASS_TARGET);
 
-    await authenticatedPage.goto(`/models/${modelId}/predict`);
+    // /predict is stage-gated (#87/#88): seed the workflow to the prediction
+    // stage so the page renders the form instead of redirecting to /upload.
+    await seedPredictionWorkflow(authenticatedPage, request, datasetId, modelId);
 
-    const predictPage = new PredictPage(authenticatedPage);
+    await authenticatedPage.goto(`/predict/${datasetId}`);
 
-    // Try to predict without filling all required fields
-    const predictButton = authenticatedPage.locator('button:has-text(/predict|submit/i)');
+    // The prediction form must render (not redirect away).
+    await expect(authenticatedPage).toHaveURL(/\/predict\//, { timeout: 10000 });
 
-    if (await predictButton.isVisible({ timeout: 5000 })) {
-      await predictButton.click();
-
-      // Should show validation error for missing fields
-      await expect(
-        authenticatedPage.locator('text=/required|fill.*field|missing.*value/i')
-      ).toBeVisible({ timeout: 5000 });
-    }
+    // With required feature values unfilled the form is invalid, so the
+    // Make Prediction button is disabled — the client-side guard (#82) that
+    // prevents predicting with missing values.
+    const predictButton = authenticatedPage.getByTestId('make-prediction');
+    await expect(predictButton).toBeVisible({ timeout: 10000 });
+    await expect(predictButton).toBeDisabled();
   });
 
   test('should validate transformation prerequisites', async ({ authenticatedPage, uploadTestDataset }) => {

--- a/apps/frontend/e2e/workflows/model-config.spec.ts
+++ b/apps/frontend/e2e/workflows/model-config.spec.ts
@@ -25,11 +25,7 @@ import {
   BINARY_CLASS_DATASET,
   BINARY_CLASS_TARGET,
 } from '../helpers/binaryClassificationData';
-
-// Direct backend base + auth: Next.js does not proxy /api/v1, and the SKIP_AUTH
-// backend still requires an Authorization header for HTTPBearer.
-const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000/api/v1';
-const ML_AUTH = { Authorization: 'Bearer e2e-test-token' };
+import { API_BASE, ML_AUTH } from '../helpers/mlApi';
 
 test.describe('Model Config Workflow', () => {
   let datasetId: string;

--- a/apps/frontend/e2e/workflows/model-config.spec.ts
+++ b/apps/frontend/e2e/workflows/model-config.spec.ts
@@ -21,6 +21,15 @@
 
 import { test, expect } from '../fixtures';
 import { ModelConfigPage } from '../pages/ModelConfigPage';
+import {
+  BINARY_CLASS_DATASET,
+  BINARY_CLASS_TARGET,
+} from '../helpers/binaryClassificationData';
+
+// Direct backend base + auth: Next.js does not proxy /api/v1, and the SKIP_AUTH
+// backend still requires an Authorization header for HTTPBearer.
+const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000/api/v1';
+const ML_AUTH = { Authorization: 'Bearer e2e-test-token' };
 
 test.describe('Model Config Workflow', () => {
   let datasetId: string;
@@ -250,7 +259,12 @@ test.describe('Model Config Workflow', () => {
     }
   });
 
-  test('should compare multiple models', async ({ authenticatedPage, trainModel }) => {
+  // #195 / follow-up #234 [P4.12]: the model-comparison UI lives on the stage-gated
+  // /evaluate Compare tab (#79), not the model list — so this test's
+  // `if (compareButton.isVisible()) … else log` path never asserts. Making it
+  // real needs the same /evaluate workflow-seeding as the descoped render tests.
+  // Deferred to [P4.12].
+  test.fixme('should compare multiple models', async ({ authenticatedPage, trainModel }) => {
     const modelPage = new ModelConfigPage(authenticatedPage);
 
     // Train first model
@@ -698,43 +712,36 @@ test.describe('Model Config API Integration', () => {
     }
   });
 
-  test('should validate training metrics structure', async ({ request, trainModel }) => {
-    // Train model
-    const modelId = await trainModel(datasetId, 'purchased');
+  test('should validate training metrics structure', async ({ request, uploadTestDataset, trainModel }) => {
+    test.setTimeout(120000); // real AutoML training runs well past the 30s default
+    // #195: the shared beforeEach uploads the un-trainable sample.csv; override
+    // with a trainable dataset in-test so AutoML actually fits a model.
+    const trainableDatasetId = await uploadTestDataset(BINARY_CLASS_DATASET);
+    const modelId = await trainModel(trainableDatasetId, BINARY_CLASS_TARGET);
 
     try {
-      // Fetch model metrics via API
-      const response = await request.get(`/api/v1/models/${modelId}`);
+      // Metrics live on the model document at GET /api/v1/ml/{id} (there is no
+      // /models/{id} or training_metrics field — that was the stale contract).
+      const response = await request.get(`${API_BASE}/ml/${modelId}`, { headers: ML_AUTH });
+      expect(response.ok()).toBeTruthy();
 
-      if (response.ok()) {
-        const model = await response.json();
+      const model = await response.json();
+      expect(model).toHaveProperty('metrics');
 
-        // Validate training_metrics field exists
-        expect(model).toHaveProperty('training_metrics');
+      const metrics = model.metrics;
+      expect(metrics).toBeTruthy();
+      expect(typeof metrics).toBe('object');
 
-        const metrics = model.training_metrics;
-
-        // Validate metrics structure
-        expect(metrics).toBeTruthy();
-        expect(typeof metrics).toBe('object');
-
-        // Verify at least one metric is present
-        const metricKeys = Object.keys(metrics);
-        expect(metricKeys.length).toBeGreaterThan(0);
-
-        // Verify metric values are numbers
-        for (const key of metricKeys) {
-          if (typeof metrics[key] === 'number') {
-            expect(metrics[key]).toBeGreaterThanOrEqual(0);
-          }
+      // At least one metric is present and numeric metrics are non-negative.
+      const metricKeys = Object.keys(metrics);
+      expect(metricKeys.length).toBeGreaterThan(0);
+      for (const key of metricKeys) {
+        if (typeof metrics[key] === 'number') {
+          expect(metrics[key]).toBeGreaterThanOrEqual(0);
         }
       }
-
-      // Clean up
-      await request.delete(`/api/v1/models/${modelId}`).catch(() => {});
-    } catch (error) {
-      await request.delete(`/api/v1/models/${modelId}`).catch(() => {});
-      throw error;
+    } finally {
+      await request.delete(`${API_BASE}/ml/${modelId}`, { headers: ML_AUTH }).catch(() => {});
     }
   });
 });

--- a/apps/frontend/e2e/workflows/performance.spec.ts
+++ b/apps/frontend/e2e/workflows/performance.spec.ts
@@ -21,12 +21,8 @@ import {
   BINARY_CLASS_ROW,
   makeBinaryClassRows,
 } from '../helpers/binaryClassificationData';
+import { API_BASE, ML_AUTH } from '../helpers/mlApi';
 import { join } from 'path';
-
-// Direct backend base + auth header: Next.js does not proxy /api/v1, and the
-// SKIP_AUTH backend still requires an Authorization header for HTTPBearer.
-const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000/api/v1';
-const ML_AUTH = { Authorization: 'Bearer e2e-test-token' };
 
 let perfMonitor: PerformanceMonitor;
 
@@ -274,24 +270,30 @@ test.describe('Performance - API Response Times', () => {
     // /predict-batch surface — the array call is the batch path.
     const batchData = makeBinaryClassRows(100);
 
-    const metric = await perfMonitor.measureApiCall(
-      'Batch Prediction API',
-      async () => {
-        const response = await request.post(`${API_BASE}/ml/${modelId}/predict`, {
-          headers: ML_AUTH,
-          data: { data: batchData },
-          timeout: 5000,
-        });
-        expect(response.ok()).toBeTruthy();
-        const body = await response.json();
-        expect(Array.isArray(body.predictions)).toBeTruthy();
-        expect(body.predictions.length).toBe(100);
-      },
-      'Batch Prediction (100 rows)',
-      5000
-    );
+    try {
+      const metric = await perfMonitor.measureApiCall(
+        'Batch Prediction API',
+        async () => {
+          // No request-level timeout: the 5000ms budget is asserted on the
+          // recorded metric below, so a slow call yields a clean budget failure
+          // (test.setTimeout is the hard backstop).
+          const response = await request.post(`${API_BASE}/ml/${modelId}/predict`, {
+            headers: ML_AUTH,
+            data: { data: batchData },
+          });
+          expect(response.ok()).toBeTruthy();
+          const body = await response.json();
+          expect(Array.isArray(body.predictions)).toBeTruthy();
+          expect(body.predictions.length).toBe(100);
+        },
+        'Batch Prediction (100 rows)',
+        5000
+      );
 
-    expect(metric.value).toBeLessThanOrEqual(5000);
+      expect(metric.value).toBeLessThanOrEqual(5000);
+    } finally {
+      await request.delete(`${API_BASE}/ml/${modelId}`, { headers: ML_AUTH }).catch(() => {});
+    }
   });
 
   test('should compare versions (10k rows) within 10s', async ({
@@ -374,19 +376,23 @@ test.describe('Performance - Database Query Performance', () => {
     const datasetId = await uploadTestDataset(BINARY_CLASS_DATASET);
     const modelId = await trainModel(datasetId, BINARY_CLASS_TARGET);
 
-    const metric = await perfMonitor.measureApiCall(
-      'Model Metrics Query',
-      async () => {
-        const response = await request.get(`${API_BASE}/ml/${modelId}`, { headers: ML_AUTH });
-        expect(response.ok()).toBeTruthy();
-        const body = await response.json();
-        expect(body).toHaveProperty('metrics');
-      },
-      'Model Metrics Retrieval',
-      500
-    );
+    try {
+      const metric = await perfMonitor.measureApiCall(
+        'Model Metrics Query',
+        async () => {
+          const response = await request.get(`${API_BASE}/ml/${modelId}`, { headers: ML_AUTH });
+          expect(response.ok()).toBeTruthy();
+          const body = await response.json();
+          expect(body).toHaveProperty('metrics');
+        },
+        'Model Metrics Retrieval',
+        500
+      );
 
-    expect(metric.value).toBeLessThanOrEqual(500);
+      expect(metric.value).toBeLessThanOrEqual(500);
+    } finally {
+      await request.delete(`${API_BASE}/ml/${modelId}`, { headers: ML_AUTH }).catch(() => {});
+    }
   });
 
   test('should fetch version history (20 versions) within 2s', async ({
@@ -443,7 +449,8 @@ test.describe('Performance - Frontend Rendering', () => {
     trainModel,
   }) => {
     const datasetId = await uploadTestDataset(BINARY_CLASS_DATASET);
-    const modelId = await trainModel(datasetId, BINARY_CLASS_TARGET);
+    // [P4.12] will seed the workflow with this model id so /evaluate renders.
+    await trainModel(datasetId, BINARY_CLASS_TARGET);
 
     await authenticatedPage.goto(`/evaluate/${datasetId}`);
 
@@ -456,7 +463,6 @@ test.describe('Performance - Frontend Rendering', () => {
     );
 
     expect(metric.value).toBeLessThanOrEqual(2000);
-    void modelId;
   });
 
   // #195 / follow-up #234 [P4.12]: same /evaluate stage-gating as the confusion
@@ -467,7 +473,8 @@ test.describe('Performance - Frontend Rendering', () => {
     trainModel,
   }) => {
     const datasetId = await uploadTestDataset(BINARY_CLASS_DATASET);
-    const modelId = await trainModel(datasetId, BINARY_CLASS_TARGET);
+    // [P4.12] will seed the workflow with this model id so /evaluate renders.
+    await trainModel(datasetId, BINARY_CLASS_TARGET);
 
     await authenticatedPage.goto(`/evaluate/${datasetId}`);
 
@@ -480,7 +487,6 @@ test.describe('Performance - Frontend Rendering', () => {
     );
 
     expect(metric.value).toBeLessThanOrEqual(2000);
-    void modelId;
   });
 
   test('should validate form (20 fields) within 100ms', async ({ authenticatedPage }) => {
@@ -554,24 +560,28 @@ test.describe('Performance - Concurrent Load @concurrency', () => {
     const datasetId = await uploadTestDataset(BINARY_CLASS_DATASET);
     const modelId = await trainModel(datasetId, BINARY_CLASS_TARGET);
 
-    const predictionOperations = Array.from({ length: 10 }, () => async () => {
-      const response = await request.post(`${API_BASE}/ml/${modelId}/predict`, {
-        headers: ML_AUTH,
-        data: { data: [BINARY_CLASS_ROW] },
+    try {
+      const predictionOperations = Array.from({ length: 10 }, () => async () => {
+        const response = await request.post(`${API_BASE}/ml/${modelId}/predict`, {
+          headers: ML_AUTH,
+          data: { data: [BINARY_CLASS_ROW] },
+        });
+        expect(response.ok()).toBeTruthy();
+        const body = await response.json();
+        expect(body.predictions.length).toBe(1);
       });
-      expect(response.ok()).toBeTruthy();
-      const body = await response.json();
-      expect(body.predictions.length).toBe(1);
-    });
 
-    const metric = await perfMonitor.measureConcurrentOperations(
-      'Concurrent Predictions',
-      predictionOperations,
-      '10 Concurrent Predictions',
-      1000
-    );
+      const metric = await perfMonitor.measureConcurrentOperations(
+        'Concurrent Predictions',
+        predictionOperations,
+        '10 Concurrent Predictions',
+        1000
+      );
 
-    expect(metric.value).toBeLessThanOrEqual(1000);
+      expect(metric.value).toBeLessThanOrEqual(1000);
+    } finally {
+      await request.delete(`${API_BASE}/ml/${modelId}`, { headers: ML_AUTH }).catch(() => {});
+    }
   });
 });
 

--- a/apps/frontend/e2e/workflows/performance.spec.ts
+++ b/apps/frontend/e2e/workflows/performance.spec.ts
@@ -15,7 +15,18 @@
 import { test, expect } from '../fixtures';
 import { PerformanceMonitor } from '../helpers';
 import { UploadPage } from '../pages/UploadPage';
+import {
+  BINARY_CLASS_DATASET,
+  BINARY_CLASS_TARGET,
+  BINARY_CLASS_ROW,
+  makeBinaryClassRows,
+} from '../helpers/binaryClassificationData';
 import { join } from 'path';
+
+// Direct backend base + auth header: Next.js does not proxy /api/v1, and the
+// SKIP_AUTH backend still requires an Authorization header for HTTPBearer.
+const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000/api/v1';
+const ML_AUTH = { Authorization: 'Bearer e2e-test-token' };
 
 let perfMonitor: PerformanceMonitor;
 
@@ -246,34 +257,40 @@ test.describe('Performance - API Response Times', () => {
     expect(metric.value).toBeLessThanOrEqual(SINGLE_PREDICTION_BUDGET_MS);
   });
 
-  test('should complete batch prediction (100 rows) within 5s', async ({
+  // #195: real array-predict of 100 rows. Timing is a non-blocking @perf SLO
+  // (5s budget over the ~hundreds-of-ms call observed locally); the functional
+  // assertion (100 predictions returned) is what actually matters here.
+  test('should complete batch prediction (100 rows) within 5s @perf', async ({
     request,
     uploadTestDataset,
     trainModel,
   }) => {
-    const datasetId = await uploadTestDataset();
-    const modelId = await trainModel(datasetId, 'purchased');
+    test.setTimeout(120000); // real AutoML training runs well past the 30s default
+    const datasetId = await uploadTestDataset(BINARY_CLASS_DATASET);
+    const modelId = await trainModel(datasetId, BINARY_CLASS_TARGET);
 
-    // Create 100 prediction rows
-    const batchData = Array.from({ length: 100 }, (_, i) => ({
-      age: 25 + i,
-      income: 50000 + i * 1000,
-    }));
+    // 100 valid feature rows. The real ML predict endpoint lives under /api/v1/ml
+    // and accepts a list of records (PredictRequest.data); there is no
+    // /predict-batch surface — the array call is the batch path.
+    const batchData = makeBinaryClassRows(100);
 
     const metric = await perfMonitor.measureApiCall(
       'Batch Prediction API',
       async () => {
-        const response = await request.post(`/api/v1/models/${modelId}/predict-batch`, {
-          data: { features: batchData },
+        const response = await request.post(`${API_BASE}/ml/${modelId}/predict`, {
+          headers: ML_AUTH,
+          data: { data: batchData },
           timeout: 5000,
         });
         expect(response.ok()).toBeTruthy();
+        const body = await response.json();
+        expect(Array.isArray(body.predictions)).toBeTruthy();
+        expect(body.predictions.length).toBe(100);
       },
       'Batch Prediction (100 rows)',
       5000
     );
 
-    expect(metric.passed).toBeTruthy();
     expect(metric.value).toBeLessThanOrEqual(5000);
   });
 
@@ -346,25 +363,29 @@ test.describe('Performance - Database Query Performance', () => {
     expect(metric.value).toBeLessThanOrEqual(1000);
   });
 
-  test('should retrieve model metrics within 500ms', async ({
+  // #195: metrics live on the model document at GET /api/v1/ml/{id} (there is no
+  // /models/{id}/metrics route). Timing is a non-blocking @perf SLO.
+  test('should retrieve model metrics within 500ms @perf', async ({
     request,
     uploadTestDataset,
     trainModel,
   }) => {
-    const datasetId = await uploadTestDataset();
-    const modelId = await trainModel(datasetId, 'purchased');
+    test.setTimeout(120000); // real AutoML training runs well past the 30s default
+    const datasetId = await uploadTestDataset(BINARY_CLASS_DATASET);
+    const modelId = await trainModel(datasetId, BINARY_CLASS_TARGET);
 
     const metric = await perfMonitor.measureApiCall(
       'Model Metrics Query',
       async () => {
-        const response = await request.get(`/api/v1/models/${modelId}/metrics`);
+        const response = await request.get(`${API_BASE}/ml/${modelId}`, { headers: ML_AUTH });
         expect(response.ok()).toBeTruthy();
+        const body = await response.json();
+        expect(body).toHaveProperty('metrics');
       },
       'Model Metrics Retrieval',
       500
     );
 
-    expect(metric.passed).toBeTruthy();
     expect(metric.value).toBeLessThanOrEqual(500);
   });
 
@@ -410,15 +431,21 @@ test.describe('Performance - Frontend Rendering', () => {
     expect(metric.value).toBeLessThanOrEqual(1000);
   });
 
-  test('should render confusion matrix chart within 2s', async ({
+  // #195 / follow-up #234 [P4.12]: these charts render only on the stage-gated
+  // /evaluate/[datasetId] page (not /models/{id}), which requires the
+  // WorkflowContext to carry state.modelId — only set by full UI-workflow
+  // training, not the trainModel API fixture. Reaching it needs workflow-seeding
+  // for the evaluation stage (the trickier evaluate-gating case the
+  // single-prediction/predict pattern doesn't cover). Deferred to [P4.12].
+  test.fixme('should render confusion matrix chart within 2s', async ({
     authenticatedPage,
     uploadTestDataset,
     trainModel,
   }) => {
-    const datasetId = await uploadTestDataset();
-    const modelId = await trainModel(datasetId, 'purchased');
+    const datasetId = await uploadTestDataset(BINARY_CLASS_DATASET);
+    const modelId = await trainModel(datasetId, BINARY_CLASS_TARGET);
 
-    await authenticatedPage.goto(`/models/${modelId}`);
+    await authenticatedPage.goto(`/evaluate/${datasetId}`);
 
     const metric = await perfMonitor.measureRenderTime(
       authenticatedPage,
@@ -429,17 +456,20 @@ test.describe('Performance - Frontend Rendering', () => {
     );
 
     expect(metric.value).toBeLessThanOrEqual(2000);
+    void modelId;
   });
 
-  test('should render ROC curve chart within 2s', async ({
+  // #195 / follow-up #234 [P4.12]: same /evaluate stage-gating as the confusion
+  // matrix test above.
+  test.fixme('should render ROC curve chart within 2s', async ({
     authenticatedPage,
     uploadTestDataset,
     trainModel,
   }) => {
-    const datasetId = await uploadTestDataset();
-    const modelId = await trainModel(datasetId, 'purchased');
+    const datasetId = await uploadTestDataset(BINARY_CLASS_DATASET);
+    const modelId = await trainModel(datasetId, BINARY_CLASS_TARGET);
 
-    await authenticatedPage.goto(`/models/${modelId}`);
+    await authenticatedPage.goto(`/evaluate/${datasetId}`);
 
     const metric = await perfMonitor.measureRenderTime(
       authenticatedPage,
@@ -450,6 +480,7 @@ test.describe('Performance - Frontend Rendering', () => {
     );
 
     expect(metric.value).toBeLessThanOrEqual(2000);
+    void modelId;
   });
 
   test('should validate form (20 fields) within 100ms', async ({ authenticatedPage }) => {
@@ -509,32 +540,38 @@ test.describe('Performance - Concurrent Load @concurrency', () => {
     expect(metric.value).toBeLessThanOrEqual(10000);
   });
 
-  test('should handle 10 concurrent predictions within 200ms average', async ({
+  // #195: real concurrent inference against /api/v1/ml/{id}/predict. The old
+  // 200ms budget was set against a mock; real cold-model inference needs more
+  // headroom, so this is a non-blocking @perf SLO of 1000ms/call (matching the
+  // single-prediction SLO). The functional assertion (every call returns a
+  // prediction) is the real check.
+  test('should handle 10 concurrent predictions within 1s average @perf', async ({
     request,
     uploadTestDataset,
     trainModel,
   }) => {
-    const datasetId = await uploadTestDataset();
-    const modelId = await trainModel(datasetId, 'purchased');
+    test.setTimeout(120000); // real AutoML training runs well past the 30s default
+    const datasetId = await uploadTestDataset(BINARY_CLASS_DATASET);
+    const modelId = await trainModel(datasetId, BINARY_CLASS_TARGET);
 
     const predictionOperations = Array.from({ length: 10 }, () => async () => {
-      const response = await request.post(`/api/v1/models/${modelId}/predict`, {
-        data: {
-          features: { age: 30, income: 60000 },
-        },
+      const response = await request.post(`${API_BASE}/ml/${modelId}/predict`, {
+        headers: ML_AUTH,
+        data: { data: [BINARY_CLASS_ROW] },
       });
       expect(response.ok()).toBeTruthy();
+      const body = await response.json();
+      expect(body.predictions.length).toBe(1);
     });
 
     const metric = await perfMonitor.measureConcurrentOperations(
       'Concurrent Predictions',
       predictionOperations,
       '10 Concurrent Predictions',
-      200
+      1000
     );
 
-    expect(metric.passed).toBeTruthy();
-    expect(metric.value).toBeLessThanOrEqual(200);
+    expect(metric.value).toBeLessThanOrEqual(1000);
   });
 });
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,21 +1,45 @@
-# Issue #226 — Burn down backend mypy baseline
+# Issue #195 — Migrate trainModel-based e2e tests off un-trainable sample.csv
 
-213 errors / 56 files in `apps/backend/mypy-baseline.txt`. CI tolerates baselined errors, fails on new ones. Done-condition: baseline empty → deletable, gate becomes plain `mypy app/`.
+Test-only PR. 8 manual `chromium-full` tests train on the 6-row `sample.csv`
+(`purchased`) which AutoML can't fit; migrate to `binary-classification-small.csv`
+(`churned`, 200 rows — the #157 light-training subset) and fix broken API
+contracts. Not in the CI gate, so no merge-risk; demo = run them green on the live stack.
 
-## Key insight
-Errors cluster — far fewer than 213 distinct edits:
-- `ab_testing.py`: one `metrics: dict[str, Any]` annotation clears ~10 (dict-value narrowing, not a logic bug).
-- `datasets.py`: None-guards after `find_one`/`update_dataset` clear ~28 union-attr (real 500→404 fix).
-- `mcp_integration.py`: 3 fields `str/int = None` → `| None` (always filled in `__post_init__`).
+## In-repo exemplar (replicate this)
+`performance.spec.ts` single-prediction test (already migrated in #157):
+- `uploadTestDataset('ai-test-datasets/binary-classification-small.csv')` + `trainModel(id,'churned')`
+- `const apiBase = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000/api/v1'`
+- `POST ${apiBase}/ml/${modelId}/predict` with `{ data: [ {9 cols} ] }`, header `Authorization: Bearer e2e-test-token`
+- asserts `body.predictions` (array)
+9 feature cols: age, tenure, monthly_charges, contract_type, has_internet, has_phone, payment_method, total_charges, support_calls.
 
-## Clusters (by code)
-- P1 correctness: datasets union-attr (28) + arg-type (6); ab_testing (14); mcp_integration (3)
-- Zero-risk mechanical: var-annotated (34, 16 files); annotation-unchecked notes (10)
-- Medium: arg-type (rest), assignment (25), dict-item (12), operator, call-arg, index, return-value, list-item, misc, attr-defined
+## Shared helper (new)
+`e2e/helpers/binaryClassificationData.ts`: `BINARY_CLASS_ROW` (one valid 9-col obj) + `makeBinaryClassRows(n)` generator. Refactor the exemplar test's inline payload to use it (DRY).
 
-## Done
-Baseline burned to zero and deleted; CI gate is now a plain `uv run mypy app/`
-(the `mypy-baseline` tool was removed). `uv run mypy app/` → Success, 152 files.
+## Per-test changes
+**performance.spec.ts (5):**
+- batch (255): dataset+churned; **broken** `POST /api/v1/models/{id}/predict-batch` + `{features:batchData}` → `${apiBase}/ml/{id}/predict` + `{data: makeBinaryClassRows(100)}` + auth; assert `body.predictions.length===100`.
+- metrics (355): dataset+churned; **broken** `GET /api/v1/models/{id}/metrics` → `${apiBase}/ml/{id}` + auth; assert `body.metrics`.
+- confusion (419) + ROC (440): **DESCOPED** → `test.fixme` + follow-up issue **[P4.12]**. Evaluate page is stage-gated (needs WorkflowContext `state.modelId`, only set by full UI-workflow training, not the trainModel API fixture; evaluate.spec hedges with soft guards). Out of scope for this PR.
+- concurrent (518): dataset+churned; `POST /api/v1/models/{id}/predict` (wrong prefix) + `{features:{age,income}}` → `${apiBase}/ml/{id}/predict` + `{data:[BINARY_CLASS_ROW]}` + auth.
 
-## Verify
-Full backend suite stays green (the None-guards change error semantics 500→404).
+**error-scenarios.spec.ts (1):** `:172/:173` dataset+churned. Pure client-side form-validation test (clicks predict unfilled) — no payload change. Remove any vacuous guard so the validation error is asserted.
+
+**model-config.spec.ts:** `:701` metrics → in-test binary-class upload + churned + `GET ${apiBase}/ml/{id}` asserting `metrics` (clean API). `:253` compare → **DESCOPED** to [P4.12]: its compare UI lives on the stage-gated `/evaluate` Compare tab (#79), same gating class as the render tests; vacuous `if(visible)else log` today.
+
+## DESCOPED to follow-up [P4.12] (all /evaluate-stage-gated UI)
+confusion render, ROC render, compare → `test.fixme` + a [P4.12] issue for the workflow-seeding/evaluate-gating work.
+
+## Final scope THIS PR = 5 tests
+4 clean API (perf batch/metrics/concurrent, model-config metrics) + 1 seeded-UI (error-scenarios:171 predict, reuse predict.spec's `seedPredictionWorkflow` pattern → assert make-prediction button **disabled** when fields empty).
+
+## Cross-cutting
+- Remove vacuous `if (response.ok())` / `if (visible)` guards so tests assert (the issue's whole point).
+- Perf timing budgets were set vs vacuous behavior; against real inference some are unrealistic (esp. 200ms/10-concurrent). → relax to realistic SLOs + `@perf` (non-blocking), per #157.
+- Keep all tests **manual chromium-full** (do NOT promote to @smoke) — real training starves 2-core CI (#157). Document.
+
+## Verify (demo)
+Run migrated specs green on full live stack (backend+Mongo+MinIO+frontend, seeded e2e): `npx playwright test --project=chromium-full performance.spec.ts model-config.spec.ts error-scenarios.spec.ts`. Show before(red/vacuous)→after(green, real assertions).
+
+## Out of scope (file separately if hit)
+Backend bugs surfaced by now-real assertions → own issues (keep this test-only).


### PR DESCRIPTION
Closes #195. Follow-up filed as #234 ([P4.12]) for the descoped tests.

## Problem
Eight manual `chromium-full` tests trained on the 6-row `sample.csv` (`purchased`), which AutoML can't fit (`problem type "unknown"` → divide error). Post-#156 they failed loudly at `trainModel`; before that they passed **vacuously** behind `if (response.ok())` / `if (visible)` guards. Several also spoke API contracts the backend never had (`/api/v1/models/{id}/predict-batch`, `{features:…}` payloads, `/models/{id}/metrics`).

## What changed (5 tests migrated + verified)
New helpers:
- `e2e/helpers/binaryClassificationData.ts` — the trainable dataset/target constants, a valid 9-column feature row, and an `n`-row generator.
- `e2e/helpers/seedWorkflow.ts` — seeds the #87 backend workflow so stage-gated pages render (reuses predict.spec's proven pattern).

| Test | Fix | Real assertion |
|---|---|---|
| perf: batch prediction (100 rows) | `POST /ml/{id}/predict` array + auth + `{data:[…]}` (no `/predict-batch`) | 100 predictions returned |
| perf: model metrics | `GET /ml/{id}` + auth | `metrics` present |
| perf: concurrent predictions | `POST /ml/{id}/predict` + auth | each call returns 1 prediction |
| model-config: training metrics structure | `GET /ml/{id}` asserting `metrics` (was non-existent `/models/{id}` + `training_metrics`); in-test trainable dataset | metrics object, numeric ≥ 0 |
| error-scenarios: prevent prediction w/ missing values | seed workflow → `/predict/{datasetId}` → assert **Make Prediction button disabled** (was a vacuous click at a non-existent `/models/{id}/predict`) | button disabled |

All vacuous guards removed so the tests actually assert. Timing budgets were set against mock behavior; relaxed to realistic SLOs and tagged `@perf` (non-blocking). Each training test gets `test.setTimeout(120000)` (real AutoML exceeds the 30s default).

## Demo (outcome evidence)
Ran the 5 migrated tests on `chromium-full` against the **live stack** (backend + Mongo + LocalStack S3 + frontend, real AutoML training):
```
Running 5 tests using 1 worker
  5 passed (56.7s)
```
Before: 4 failed / vacuous; after: all green with real behavior assertions.

## Descoped → #234 [P4.12] (`test.fixme`)
The confusion-matrix, ROC, and model-comparison tests depend on the **stage-gated `/evaluate` page**, which renders only when the WorkflowContext carries `state.modelId` — set by full UI-workflow training, not the `trainModel` API fixture (the existing `evaluate.spec` only reaches it via UI training, with soft guards). Deferred to keep this PR atomic and green.

## Known limitations
- Manual `chromium-full` only — **not** promoted to `@smoke` (real training starves 2-core CI; #157). Not in the PR CI gate; verified locally on the live stack.
- On a constrained machine, run training-heavy specs with limited workers (verified with `--workers=1`); the per-test 120s timeout is the durable fix.