### PR TITLE
test(e2e): cover /evaluate-gated render + compare tests (#234)

### DIFF
--- a/apps/frontend/app/evaluate/page.tsx
+++ b/apps/frontend/app/evaluate/page.tsx
@@ -465,7 +465,7 @@ export default function EvaluatePage() {
           {showCurvesTab && (
             <TabsContent value="curves" className="space-y-8 mt-4">
               {evaluation.roc_curve && (
-                <div>
+                <div data-testid="roc-curve">
                   <h3 className="font-semibold text-lg mb-2">ROC Curve</h3>
                   <ROCCurveChart data={evaluation.roc_curve} />
                 </div>

--- a/apps/frontend/components/ConfusionMatrixChart.tsx
+++ b/apps/frontend/components/ConfusionMatrixChart.tsx
@@ -88,7 +88,7 @@ export function ConfusionMatrixChart({ data, onCellClick }: ConfusionMatrixChart
     selected !== null ? data.matrix[selected.row][selected.col] : 0
 
   return (
-    <div className="w-full">
+    <div className="w-full" data-testid="confusion-matrix">
       <div ref={containerRef} className="w-full overflow-x-auto">
         <svg
           width="100%"

--- a/apps/frontend/e2e/helpers/seedWorkflow.ts
+++ b/apps/frontend/e2e/helpers/seedWorkflow.ts
@@ -1,19 +1,21 @@
 import type { Page, APIRequestContext } from '@playwright/test';
 
 /**
- * Seed the backend workflow (the source of truth since #87) up to a completed
- * MODEL_EVALUATION with the trained model id, so the prediction-gated `/predict`
- * page is reachable instead of redirecting to `/upload`.
+ * Seed the backend workflow (the source of truth since #87) for a model trained
+ * via the `trainModel` fixture, so a stage-gated UI page is reachable instead of
+ * redirecting to `/upload`.
  *
  * The `trainModel` fixture only hits `/ml/train` (it does not persist workflow
- * state), so any test that navigates a stage-gated UI page after it must seed
- * the workflow first. Mirrors the inline helper proven in predict.spec.ts.
+ * state), so any test that navigates a stage-gated page after it must seed the
+ * workflow first. Mirrors the inline helper proven in predict.spec.ts.
  */
-export async function seedPredictionWorkflow(
+async function seedWorkflow(
   page: Page,
   request: APIRequestContext,
   datasetId: string,
-  modelId: string
+  modelId: string,
+  currentStage: string,
+  completedStages: string[]
 ): Promise<void> {
   const apiBase = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000/api/v1';
   // The `dev-user-default` token differs from the fixtures' `e2e-test-token`,
@@ -24,16 +26,8 @@ export async function seedPredictionWorkflow(
     Authorization: 'Bearer dev-user-default',
     'Content-Type': 'application/json',
   };
-  const completedStages = [
-    'data_loading',
-    'data_profiling',
-    'data_preparation',
-    'feature_engineering',
-    'model_training',
-    'model_evaluation',
-  ];
   const workflow = {
-    current_stage: 'prediction',
+    current_stage: currentStage,
     completed_stages: completedStages,
     stage_data: {},
     model_id: modelId,
@@ -43,19 +37,19 @@ export async function seedPredictionWorkflow(
   if (put.status() === 404) {
     const post = await request.post(`${apiBase}/workflows/${datasetId}`, { headers, data: workflow });
     if (!post.ok()) {
-      throw new Error(`seedPredictionWorkflow POST failed (${post.status()}): ${await post.text()}`);
+      throw new Error(`seedWorkflow POST failed (${post.status()}): ${await post.text()}`);
     }
   } else if (!put.ok()) {
-    throw new Error(`seedPredictionWorkflow PUT failed (${put.status()}): ${await put.text()}`);
+    throw new Error(`seedWorkflow PUT failed (${put.status()}): ${await put.text()}`);
   }
 
   // Mirror into localStorage so the context hydrates before the backend fetch.
   await page.addInitScript(
-    ({ id, model, stages }) => {
+    ({ id, model, stage, stages }) => {
       localStorage.setItem(
         'workflowState',
         JSON.stringify({
-          currentStage: 'prediction',
+          currentStage: stage,
           completedStages: stages,
           stageData: {},
           datasetId: id,
@@ -64,6 +58,47 @@ export async function seedPredictionWorkflow(
         })
       );
     },
-    { id: datasetId, model: modelId, stages: completedStages }
+    { id: datasetId, model: modelId, stage: currentStage, stages: completedStages }
   );
+}
+
+/**
+ * Seed up to a completed MODEL_EVALUATION so the prediction-gated `/predict`
+ * page is reachable.
+ */
+export async function seedPredictionWorkflow(
+  page: Page,
+  request: APIRequestContext,
+  datasetId: string,
+  modelId: string
+): Promise<void> {
+  await seedWorkflow(page, request, datasetId, modelId, 'prediction', [
+    'data_loading',
+    'data_profiling',
+    'data_preparation',
+    'feature_engineering',
+    'model_training',
+    'model_evaluation',
+  ]);
+}
+
+/**
+ * Seed the workflow at the MODEL_EVALUATION stage (#234) so the stage-gated
+ * `/evaluate/[datasetId]` dashboard renders for a model trained via the API
+ * fixture. The evaluate page gates on MODEL_TRAINING being complete and the
+ * context carrying `state.modelId` — both satisfied here.
+ */
+export async function seedEvaluationWorkflow(
+  page: Page,
+  request: APIRequestContext,
+  datasetId: string,
+  modelId: string
+): Promise<void> {
+  await seedWorkflow(page, request, datasetId, modelId, 'model_evaluation', [
+    'data_loading',
+    'data_profiling',
+    'data_preparation',
+    'feature_engineering',
+    'model_training',
+  ]);
 }

--- a/apps/frontend/e2e/workflows/model-config.spec.ts
+++ b/apps/frontend/e2e/workflows/model-config.spec.ts
@@ -21,10 +21,12 @@
 
 import { test, expect } from '../fixtures';
 import { ModelConfigPage } from '../pages/ModelConfigPage';
+import { EvaluatePage } from '../pages/EvaluatePage';
 import {
   BINARY_CLASS_DATASET,
   BINARY_CLASS_TARGET,
 } from '../helpers/binaryClassificationData';
+import { seedEvaluationWorkflow } from '../helpers/seedWorkflow';
 import { API_BASE, ML_AUTH } from '../helpers/mlApi';
 
 test.describe('Model Config Workflow', () => {
@@ -255,64 +257,58 @@ test.describe('Model Config Workflow', () => {
     }
   });
 
-  // #195 / follow-up #234 [P4.12]: the model-comparison UI lives on the stage-gated
-  // /evaluate Compare tab (#79), not the model list — so this test's
-  // `if (compareButton.isVisible()) … else log` path never asserts. Making it
-  // real needs the same /evaluate workflow-seeding as the descoped render tests.
-  // Deferred to [P4.12].
-  test.fixme('should compare multiple models', async ({ authenticatedPage, trainModel }) => {
-    const modelPage = new ModelConfigPage(authenticatedPage);
-
-    // Train first model
-    const modelId1 = await trainModel(datasetId, 'purchased');
-
-    // Train second model with different algorithm
-    await modelPage.gotoTraining(datasetId);
-    await modelPage.selectTargetColumn('purchased');
-    await modelPage.selectAlgorithm('logistic_regression');
-    await modelPage.startTraining();
-    await modelPage.waitForTrainingComplete();
-
-    const modelId2 = await modelPage.getModelId();
+  // #234 [P4.12]: the model-comparison UI lives on the stage-gated /evaluate
+  // Compare tab (#79). The shared beforeEach uploads the un-trainable sample.csv,
+  // so this test uploads its own binary-classification dataset, trains two real
+  // models on it, seeds the evaluation workflow so /evaluate renders, then
+  // exercises the real Compare tab + ModelComparisonTable. Manual chromium-full
+  // only (two real trainings); not promoted to @smoke (#157).
+  test('should compare multiple models', async ({
+    authenticatedPage,
+    uploadTestDataset,
+    trainModel,
+    cleanupModel,
+    cleanupDataset,
+  }) => {
+    test.slow();
+    const compareDatasetId = await uploadTestDataset(BINARY_CLASS_DATASET);
+    const modelId1 = await trainModel(compareDatasetId, BINARY_CLASS_TARGET);
+    const modelId2 = await trainModel(compareDatasetId, BINARY_CLASS_TARGET);
 
     try {
-      // Navigate to model list or comparison page
-      await modelPage.gotoModelList();
+      await seedEvaluationWorkflow(
+        authenticatedPage,
+        authenticatedPage.request,
+        compareDatasetId,
+        modelId1
+      );
 
-      // Compare models
-      const compareButton = authenticatedPage.locator('button:has-text("Compare"), [data-testid="compare-models"]');
+      const evaluatePage = new EvaluatePage(authenticatedPage);
+      await authenticatedPage.goto(`/evaluate/${compareDatasetId}`);
+      await evaluatePage.waitForDashboard();
+      await evaluatePage.switchToTab('Compare');
 
-      if (await compareButton.isVisible({ timeout: 5000 })) {
-        await compareButton.click();
+      // Select both trained models and run the comparison.
+      await authenticatedPage.locator(`#compare-${modelId1}`).check();
+      await authenticatedPage.locator(`#compare-${modelId2}`).check();
+      await evaluatePage.runComparison();
 
-        // Select models to compare
-        await authenticatedPage.locator(`input[value="${modelId1}"], [data-model="${modelId1}"]`).check();
-        await authenticatedPage.locator(`input[value="${modelId2}"], [data-model="${modelId2}"]`).check();
-
-        // Confirm comparison
-        await authenticatedPage.locator('button:has-text("Compare"), [data-testid="confirm-compare"]').click();
-
-        // Verify comparison view shows both models
-        await expect(
-          authenticatedPage.locator('text=/Comparison|Model Comparison/i')
-        ).toBeVisible({ timeout: 5000 });
-
-        // Verify both model IDs or names are shown
-        await expect(authenticatedPage.locator(`text=${modelId1.substring(0, 8)}`)).toBeVisible({ timeout: 5000 });
-      } else {
-        console.log('Model comparison feature not yet implemented');
-      }
-
-      // Clean up second model
-      await authenticatedPage.request.delete(`/api/v1/models/${modelId2}`).catch(() => {});
-      await authenticatedPage.request.delete(`/api/v1/models/${modelId1}`).catch(() => {});
-    } catch (error) {
-      await authenticatedPage.request.delete(`/api/v1/models/${modelId2}`).catch(() => {});
-      await authenticatedPage.request.delete(`/api/v1/models/${modelId1}`).catch(() => {});
-      throw error;
+      // ModelComparisonTable renders a cell per (metric × model); assert both
+      // models have cells and that the best-per-metric highlighting ran.
+      await expect(
+        authenticatedPage.locator(`[data-testid$="-${modelId1}"]`).first()
+      ).toBeVisible({ timeout: 15000 });
+      await expect(
+        authenticatedPage.locator(`[data-testid$="-${modelId2}"]`).first()
+      ).toBeVisible();
+      await expect(
+        authenticatedPage.locator('[data-best="true"]').first()
+      ).toBeVisible();
+    } finally {
+      await cleanupModel(modelId1);
+      await cleanupModel(modelId2);
+      await cleanupDataset(compareDatasetId);
     }
-
-    modelId = modelId1;
   });
 
   test('should support model versioning', async ({ authenticatedPage }) => {

--- a/apps/frontend/e2e/workflows/performance.spec.ts
+++ b/apps/frontend/e2e/workflows/performance.spec.ts
@@ -449,31 +449,38 @@ test.describe('Performance - Frontend Rendering', () => {
     authenticatedPage,
     uploadTestDataset,
     trainModel,
+    cleanupModel,
+    cleanupDataset,
   }) => {
     test.slow();
     const datasetId = await uploadTestDataset(BINARY_CLASS_DATASET);
     const modelId = await trainModel(datasetId, BINARY_CLASS_TARGET);
-    await seedEvaluationWorkflow(
-      authenticatedPage,
-      authenticatedPage.request,
-      datasetId,
-      modelId
-    );
+    try {
+      await seedEvaluationWorkflow(
+        authenticatedPage,
+        authenticatedPage.request,
+        datasetId,
+        modelId
+      );
 
-    const evaluatePage = new EvaluatePage(authenticatedPage);
-    await authenticatedPage.goto(`/evaluate/${datasetId}`);
-    await evaluatePage.waitForDashboard();
-    await evaluatePage.switchToTab('Confusion Matrix');
+      const evaluatePage = new EvaluatePage(authenticatedPage);
+      await authenticatedPage.goto(`/evaluate/${datasetId}`);
+      await evaluatePage.waitForDashboard();
+      await evaluatePage.switchToTab('Confusion Matrix');
 
-    const metric = await perfMonitor.measureRenderTime(
-      authenticatedPage,
-      'Confusion Matrix Chart',
-      '[data-testid="confusion-matrix"]',
-      'Confusion Matrix Chart',
-      2000
-    );
+      const metric = await perfMonitor.measureRenderTime(
+        authenticatedPage,
+        'Confusion Matrix Chart',
+        '[data-testid="confusion-matrix"]',
+        'Confusion Matrix Chart',
+        2000
+      );
 
-    expect(metric.value).toBeLessThanOrEqual(2000);
+      expect(metric.value).toBeLessThanOrEqual(2000);
+    } finally {
+      await cleanupModel(modelId);
+      await cleanupDataset(datasetId);
+    }
   });
 
   // #234 [P4.12]: same /evaluate stage-gating as the confusion matrix test above.
@@ -481,31 +488,38 @@ test.describe('Performance - Frontend Rendering', () => {
     authenticatedPage,
     uploadTestDataset,
     trainModel,
+    cleanupModel,
+    cleanupDataset,
   }) => {
     test.slow();
     const datasetId = await uploadTestDataset(BINARY_CLASS_DATASET);
     const modelId = await trainModel(datasetId, BINARY_CLASS_TARGET);
-    await seedEvaluationWorkflow(
-      authenticatedPage,
-      authenticatedPage.request,
-      datasetId,
-      modelId
-    );
+    try {
+      await seedEvaluationWorkflow(
+        authenticatedPage,
+        authenticatedPage.request,
+        datasetId,
+        modelId
+      );
 
-    const evaluatePage = new EvaluatePage(authenticatedPage);
-    await authenticatedPage.goto(`/evaluate/${datasetId}`);
-    await evaluatePage.waitForDashboard();
-    await evaluatePage.switchToTab('Curves');
+      const evaluatePage = new EvaluatePage(authenticatedPage);
+      await authenticatedPage.goto(`/evaluate/${datasetId}`);
+      await evaluatePage.waitForDashboard();
+      await evaluatePage.switchToTab('Curves');
 
-    const metric = await perfMonitor.measureRenderTime(
-      authenticatedPage,
-      'ROC Curve Chart',
-      '[data-testid="roc-curve"]',
-      'ROC Curve Chart',
-      2000
-    );
+      const metric = await perfMonitor.measureRenderTime(
+        authenticatedPage,
+        'ROC Curve Chart',
+        '[data-testid="roc-curve"]',
+        'ROC Curve Chart',
+        2000
+      );
 
-    expect(metric.value).toBeLessThanOrEqual(2000);
+      expect(metric.value).toBeLessThanOrEqual(2000);
+    } finally {
+      await cleanupModel(modelId);
+      await cleanupDataset(datasetId);
+    }
   });
 
   test('should validate form (20 fields) within 100ms', async ({ authenticatedPage }) => {

--- a/apps/frontend/e2e/workflows/performance.spec.ts
+++ b/apps/frontend/e2e/workflows/performance.spec.ts
@@ -15,6 +15,8 @@
 import { test, expect } from '../fixtures';
 import { PerformanceMonitor } from '../helpers';
 import { UploadPage } from '../pages/UploadPage';
+import { EvaluatePage } from '../pages/EvaluatePage';
+import { seedEvaluationWorkflow } from '../helpers/seedWorkflow';
 import {
   BINARY_CLASS_DATASET,
   BINARY_CLASS_TARGET,
@@ -437,27 +439,36 @@ test.describe('Performance - Frontend Rendering', () => {
     expect(metric.value).toBeLessThanOrEqual(1000);
   });
 
-  // #195 / follow-up #234 [P4.12]: these charts render only on the stage-gated
+  // #234 [P4.12]: these charts render only on the stage-gated
   // /evaluate/[datasetId] page (not /models/{id}), which requires the
   // WorkflowContext to carry state.modelId — only set by full UI-workflow
-  // training, not the trainModel API fixture. Reaching it needs workflow-seeding
-  // for the evaluation stage (the trickier evaluate-gating case the
-  // single-prediction/predict pattern doesn't cover). Deferred to [P4.12].
-  test.fixme('should render confusion matrix chart within 2s', async ({
+  // training, not the trainModel API fixture. seedEvaluationWorkflow primes the
+  // backend + localStorage workflow state so /evaluate renders for an
+  // API-trained model. Manual @perf (real training); not in the @smoke gate.
+  test('should render confusion matrix chart within 2s @perf', async ({
     authenticatedPage,
     uploadTestDataset,
     trainModel,
   }) => {
+    test.slow();
     const datasetId = await uploadTestDataset(BINARY_CLASS_DATASET);
-    // [P4.12] will seed the workflow with this model id so /evaluate renders.
-    await trainModel(datasetId, BINARY_CLASS_TARGET);
+    const modelId = await trainModel(datasetId, BINARY_CLASS_TARGET);
+    await seedEvaluationWorkflow(
+      authenticatedPage,
+      authenticatedPage.request,
+      datasetId,
+      modelId
+    );
 
+    const evaluatePage = new EvaluatePage(authenticatedPage);
     await authenticatedPage.goto(`/evaluate/${datasetId}`);
+    await evaluatePage.waitForDashboard();
+    await evaluatePage.switchToTab('Confusion Matrix');
 
     const metric = await perfMonitor.measureRenderTime(
       authenticatedPage,
       'Confusion Matrix Chart',
-      '[data-testid="confusion-matrix"], canvas, svg',
+      '[data-testid="confusion-matrix"]',
       'Confusion Matrix Chart',
       2000
     );
@@ -465,23 +476,31 @@ test.describe('Performance - Frontend Rendering', () => {
     expect(metric.value).toBeLessThanOrEqual(2000);
   });
 
-  // #195 / follow-up #234 [P4.12]: same /evaluate stage-gating as the confusion
-  // matrix test above.
-  test.fixme('should render ROC curve chart within 2s', async ({
+  // #234 [P4.12]: same /evaluate stage-gating as the confusion matrix test above.
+  test('should render ROC curve chart within 2s @perf', async ({
     authenticatedPage,
     uploadTestDataset,
     trainModel,
   }) => {
+    test.slow();
     const datasetId = await uploadTestDataset(BINARY_CLASS_DATASET);
-    // [P4.12] will seed the workflow with this model id so /evaluate renders.
-    await trainModel(datasetId, BINARY_CLASS_TARGET);
+    const modelId = await trainModel(datasetId, BINARY_CLASS_TARGET);
+    await seedEvaluationWorkflow(
+      authenticatedPage,
+      authenticatedPage.request,
+      datasetId,
+      modelId
+    );
 
+    const evaluatePage = new EvaluatePage(authenticatedPage);
     await authenticatedPage.goto(`/evaluate/${datasetId}`);
+    await evaluatePage.waitForDashboard();
+    await evaluatePage.switchToTab('Curves');
 
     const metric = await perfMonitor.measureRenderTime(
       authenticatedPage,
       'ROC Curve Chart',
-      '[data-testid="roc-curve"], canvas, svg',
+      '[data-testid="roc-curve"]',
       'ROC Curve Chart',
       2000
     );


### PR DESCRIPTION
## Summary
Closes #234 (P4.12). Un-fixmes the 3 e2e tests deferred from #195 that depend on the stage-gated `/evaluate` page.

**Note:** The CodeRabbit plan on the issue was stale — it assumed #195's helpers (`seedWorkflow.ts`, `binaryClassificationData.ts`, `EvaluatePage.ts`) didn't exist. They're all on `main`, so this reuses them rather than recreating them.

## Changes
- **`e2e/helpers/seedWorkflow.ts`** — add `seedEvaluationWorkflow` (sibling to `seedPredictionWorkflow`, `current_stage=model_evaluation`) so an API-trained model satisfies `/evaluate` gating (`MODEL_TRAINING` complete + `state.modelId`). Shared internal extracted; `seedPredictionWorkflow` signature unchanged.
- **`components/ConfusionMatrixChart.tsx`** + **`app/evaluate/page.tsx`** — add `data-testid="confusion-matrix"` / `data-testid="roc-curve"` so the `@perf` selectors target the real chart, not a header icon `<svg>`.
- **`performance.spec.ts`** — the 2 render tests seed the workflow, open the Confusion Matrix / Curves tab on `/evaluate`, and measure the real chart. Kept `@perf` + 2000ms; `test.slow()`.
- **`model-config.spec.ts`** — the compare test trains two real models on the binary dataset, opens the `/evaluate` Compare tab, selects both, and asserts `ModelComparisonTable` renders cells for both models + a best-per-metric highlight (`data-best="true"`). Removes the vacuous `if-visible/else-log` path.

## Verification
Ran on `chromium-full` against the live stack (backend SKIP_AUTH + Mongo + LocalStack S3):
- ✅ Confusion matrix renders on `/evaluate` (**23ms**)
- ✅ ROC curve renders on `/evaluate`
- ✅ Real 2-model comparison table renders with `data-best` highlighting

`npm run type-check` clean; eslint 0 errors on changed files.

## Known limitations
- Manual `chromium-full` only — **not** promoted to `@smoke` (three real trainings starve 2-core CI, see #157). The `@perf` job is non-blocking (`continue-on-error`).
- The two render tests train in `beforeEach`/body; running all three training-heavy tests at the default 3-worker parallelism can flake in the **shared `authenticatedPage` fixture's** `waitForLoadState('networkidle', 10s)` on `/dashboard` under concurrent-training contention (pre-existing fixture behaviour, not in this change's test bodies). Both render tests pass green serially; the compare test passed in the parallel run.