### PR TITLE
feat(quality): data quality scoring system (#102)

### DIFF
--- a/apps/backend/app/api/routes/data_processing.py
+++ b/apps/backend/app/api/routes/data_processing.py
@@ -13,7 +13,10 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from app.auth.nextauth_auth import get_current_user_id
 from app.models.user_data import UserData
+from app.schemas.quality import QualityReportResponse
 from app.services.data_processing.data_processor import DataProcessor
+from app.services.data_processing.quality_assessment import ActionableRecommendation
+from app.services.quality_gate_service import evaluate_gates, overall_score
 from app.services.s3_service import s3_service
 from app.utils.json_encoder import NumpyJSONEncoder, convert_numpy_types
 from app.utils.s3 import parse_s3_url
@@ -227,6 +230,53 @@ async def get_quality_report(
         "filename": user_data.original_filename,
         "quality_report": user_data.quality_report
     }
+
+
+@router.get("/{file_id}/quality-report", response_model=QualityReportResponse)
+async def get_quality_report_consolidated(
+    file_id: str = Path(..., description="File ID"),
+    current_user_id: str = Depends(get_current_user_id)
+):
+    """Consolidated quality report: 0-100 score, components, actionable
+    recommendations, and soft quality gates (issue #102, AC4/AC5).
+
+    Built from the cached quality report. Pre-#102 caches degrade to ``partial=true``
+    (gates derived from legacy dimension scores). Quality trend has its own endpoint
+    (GET /api/v1/datasets/{dataset_id}/quality-trend). Never 500s on stale caches.
+    """
+    user_data = await UserData.find_one(
+        UserData.id == file_id,
+        UserData.user_id == current_user_id
+    )
+    if not user_data:
+        raise HTTPException(status_code=404, detail="File not found")
+    if not user_data.is_processed or not user_data.quality_report:
+        raise HTTPException(status_code=400, detail="File not processed yet")
+
+    report = user_data.quality_report
+    # Pre-#102 cached reports lack the 0-100 score / actionable recs.
+    partial = "score_0_100" not in report
+
+    gates = evaluate_gates(report)
+    actionable = [
+        ActionableRecommendation(**rec)
+        for rec in report.get("actionable_recommendations", [])
+    ]
+
+    return QualityReportResponse(
+        file_id=str(user_data.id),
+        filename=user_data.original_filename,
+        score_0_100=overall_score(report),
+        component_scores={
+            str(k): float(v) for k, v in (report.get("component_scores") or {}).items()
+        },
+        recommendations=report.get("recommendations", []),
+        actionable_recommendations=actionable,
+        gates=gates,
+        critical_issue_count=len(report.get("critical_issues", [])),
+        warning_count=len(report.get("warnings", [])),
+        partial=partial,
+    )
 
 
 @router.get("/{file_id}/preview")

--- a/apps/backend/app/api/routes/versions.py
+++ b/apps/backend/app/api/routes/versions.py
@@ -16,6 +16,8 @@ from app.schemas.version import (
     DatasetVersionCreate,
     DatasetVersionResponse,
     LineageResponse,
+    QualityTrendPoint,
+    QualityTrendResponse,
     VersionComparisonRequest,
     VersionComparisonResponse,
     VersionListResponse,
@@ -78,6 +80,53 @@ async def list_dataset_versions(
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Error listing versions: {str(e)}"
+        )
+
+
+@router.get("/datasets/{dataset_id}/quality-trend", response_model=QualityTrendResponse)
+async def get_quality_trend(
+    dataset_id: str,
+    current_user_id: str = Depends(get_current_user_id)
+):
+    """
+    Quality score trend across a dataset's versions (issue #102, AC3).
+
+    Returns per-transformation 0-100 quality scores plus aggregate metrics.
+    Empty trend when the dataset has no transformation history. Never 500s.
+    """
+    # Ownership check — 404 for unknown or foreign datasets.
+    dataset = await DatasetMetadata.find_one({"dataset_id": dataset_id})
+    if not dataset or dataset.user_id != current_user_id:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Dataset {dataset_id} not found"
+        )
+
+    try:
+        raw_points = await versioning_service.get_quality_trend(dataset_id)
+        points = [QualityTrendPoint(**p) for p in raw_points]
+
+        scores = [
+            s for p in points for s in (p.score_before, p.score_after) if s is not None
+        ]
+        overall_improvement = None
+        first_before = next((p.score_before for p in points if p.score_before is not None), None)
+        last_after = next((p.score_after for p in reversed(points) if p.score_after is not None), None)
+        if first_before is not None and last_after is not None:
+            overall_improvement = round(last_after - first_before, 1)
+
+        return QualityTrendResponse(
+            dataset_id=dataset_id,
+            points=points,
+            overall_improvement=overall_improvement,
+            best_score=max(scores) if scores else None,
+            worst_score=min(scores) if scores else None,
+        )
+    except Exception as e:
+        logger.error(f"Error building quality trend for dataset {dataset_id}: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Error building quality trend: {str(e)}"
         )
 
 

--- a/apps/backend/app/models/version.py
+++ b/apps/backend/app/models/version.py
@@ -30,8 +30,14 @@ class TransformationStep(BaseModel):
     @field_validator('step_type')
     @classmethod
     def validate_step_type(cls, v: str) -> str:
-        """Validate step_type is one of known transformation types."""
-        allowed_types = {
+        """Validate step_type is a known transformation type.
+
+        Accepts any canonical TransformationType value (the real transformation flow
+        records these) plus the legacy aliases. Imported lazily to avoid a model cycle.
+        """
+        from app.models.transformation import TransformationType
+
+        allowed_types = {t.value for t in TransformationType} | {
             'drop_missing', 'impute', 'encode', 'scale', 'normalize',
             'feature_engineering', 'outlier_removal', 'custom'
         }

--- a/apps/backend/app/schemas/quality.py
+++ b/apps/backend/app/schemas/quality.py
@@ -1,0 +1,40 @@
+"""Schemas for the data quality scoring system (issue #102).
+
+Mirrored by the frontend in apps/frontend/lib/types/quality.ts — change both together.
+"""
+
+from pydantic import BaseModel, Field
+
+from app.services.data_processing.quality_assessment import ActionableRecommendation
+
+
+class QualityGateResult(BaseModel):
+    """Result of evaluating one soft quality gate (issue #102, AC4)."""
+
+    gate_name: str
+    passed: bool
+    actual_score: float = Field(..., description="0-100 overall score evaluated")
+    required_score: float = Field(..., description="0-100 minimum overall score")
+    failing_dimensions: list[str] = Field(
+        default_factory=list, description="Dimensions below their threshold"
+    )
+    is_blocking: bool = Field(
+        False, description="Soft gates never block workflow progression"
+    )
+
+
+class QualityReportResponse(BaseModel):
+    """Consolidated quality report for a dataset (issue #102, AC5)."""
+
+    file_id: str
+    filename: str | None = None
+    score_0_100: float
+    component_scores: dict[str, float] = Field(default_factory=dict)
+    recommendations: list[str] = Field(default_factory=list)
+    actionable_recommendations: list[ActionableRecommendation] = Field(default_factory=list)
+    gates: list[QualityGateResult] = Field(default_factory=list)
+    critical_issue_count: int = 0
+    warning_count: int = 0
+    partial: bool = Field(
+        False, description="True when computed from a pre-#102 cached report"
+    )

--- a/apps/backend/app/schemas/version.py
+++ b/apps/backend/app/schemas/version.py
@@ -152,3 +152,26 @@ class VersionPinRequest(BaseModel):
     """Request model for pinning/unpinning a version."""
 
     pinned: bool = Field(..., description="Whether to pin or unpin the version")
+
+
+class QualityTrendPoint(BaseModel):
+    """One transformation step in a dataset's quality trend (issue #102, AC3)."""
+
+    version_number: int | None = Field(None, description="Resulting version number")
+    created_at: datetime
+    score_before: float | None = Field(None, description="0-100 quality score before")
+    score_after: float | None = Field(None, description="0-100 quality score after")
+    improvement: float | None = Field(None, description="score_after - score_before")
+    transformation: str = Field(..., description="Transformation(s) applied")
+
+
+class QualityTrendResponse(BaseModel):
+    """Quality trend across a dataset's versions (issue #102, AC3)."""
+
+    dataset_id: str
+    points: list[QualityTrendPoint]
+    overall_improvement: float | None = Field(
+        None, description="score_after of last point minus score_before of first point"
+    )
+    best_score: float | None = None
+    worst_score: float | None = None

--- a/apps/backend/app/services/data_processing/quality_assessment.py
+++ b/apps/backend/app/services/data_processing/quality_assessment.py
@@ -10,6 +10,8 @@ import numpy as np
 import pandas as pd
 from pydantic import BaseModel, ConfigDict, Field
 
+from app.models.transformation import TransformationType
+
 
 class QualityDimension(str, Enum):
     """Data quality dimensions"""
@@ -19,6 +21,52 @@ class QualityDimension(str, Enum):
     VALIDITY = "validity"
     UNIQUENESS = "uniqueness"
     TIMELINESS = "timeliness"
+
+
+# The five ML-readiness dimensions combined into the headline 0-100 score (issue #102).
+# Timeliness is excluded — it is a hardcoded placeholder, not a measured signal.
+SCORE_DIMENSIONS = (
+    QualityDimension.COMPLETENESS,
+    QualityDimension.VALIDITY,
+    QualityDimension.CONSISTENCY,
+    QualityDimension.UNIQUENESS,
+    QualityDimension.ACCURACY,
+)
+
+
+def _recommended_transformation(issue: "QualityIssue") -> TransformationType | None:
+    """Map a quality issue to the transformation that fixes it (issue #102, AC2).
+
+    Returns the canonical TransformationType so recommendations stay tied to the
+    real transformation tooling. None when no automated fix applies.
+    """
+    desc = issue.description.lower()
+    if issue.dimension == QualityDimension.COMPLETENESS:
+        return TransformationType.FILL_MISSING
+    if issue.dimension == QualityDimension.UNIQUENESS:
+        return TransformationType.REMOVE_DUPLICATES
+    if issue.dimension == QualityDimension.VALIDITY:
+        if "outlier" in desc:
+            return TransformationType.OUTLIER_REMOVAL
+        return TransformationType.STANDARDIZE_FORMAT
+    if issue.dimension == QualityDimension.CONSISTENCY:
+        if "casing" in desc:
+            return TransformationType.FIX_CASING
+        if "non-numeric" in desc:
+            return TransformationType.TO_NUMERIC
+        if "date" in desc:
+            return TransformationType.TO_DATETIME
+        return TransformationType.STANDARDIZE_FORMAT
+    return None
+
+
+class ActionableRecommendation(BaseModel):
+    """A quality recommendation tied to a concrete transformation (issue #102, AC2)."""
+    dimension: QualityDimension
+    description: str
+    transformation_type: str  # canonical TransformationType value
+    affected_columns: list[str] = Field(default_factory=list)
+    severity: str  # "low", "medium", "high"
 
 
 class QualityIssue(BaseModel):
@@ -56,11 +104,14 @@ class QualityReport(BaseModel):
     )
     
     overall_quality_score: float
+    score_0_100: float = 0.0  # 0-100 ML-readiness score over SCORE_DIMENSIONS (issue #102)
     dimension_scores: dict[QualityDimension, float]
+    component_scores: dict[QualityDimension, float] = Field(default_factory=dict)  # 0-100 per dim
     column_scores: list[ColumnQualityScore]
     critical_issues: list[QualityIssue]
     warnings: list[QualityIssue]
     recommendations: list[str]
+    actionable_recommendations: list[ActionableRecommendation] = Field(default_factory=list)
     row_count: int
     column_count: int
     assessed_at: datetime = Field(default_factory=datetime.utcnow)
@@ -121,14 +172,27 @@ class QualityAssessmentService:
         
         # Generate recommendations
         recommendations = self._generate_recommendations(all_issues, column_types)
-        
+        actionable_recommendations = self._generate_actionable_recommendations(all_issues)
+
+        # 0-100 ML-readiness score + per-dimension component scores (issue #102, AC1)
+        component_scores = {
+            dim: round(dimension_scores.get(dim, 0.0) * 100, 1) for dim in SCORE_DIMENSIONS
+        }
+        if component_scores:
+            score_0_100 = round(float(np.mean(list(component_scores.values()))), 1)
+        else:
+            score_0_100 = 0.0
+
         return QualityReport(
             overall_quality_score=float(overall_score),
+            score_0_100=score_0_100,
             dimension_scores=dimension_scores,
+            component_scores=component_scores,
             column_scores=column_scores,
             critical_issues=critical_issues,
             warnings=warnings,
             recommendations=recommendations,
+            actionable_recommendations=actionable_recommendations,
             row_count=len(df),
             column_count=len(df.columns)
         )
@@ -468,6 +532,49 @@ class QualityAssessmentService:
                 f"⚠️ {overall_critical} critical issues found. Prioritize data cleaning before analysis."
             )
         
+        return recommendations
+
+    def _generate_actionable_recommendations(
+        self, issues: list[QualityIssue]
+    ) -> list[ActionableRecommendation]:
+        """Map quality issues to concrete transformations (issue #102, AC2).
+
+        Groups issues by (dimension, transformation) so the frontend can offer a
+        single "apply fix" action per transformation across all affected columns.
+        """
+        severity_rank = {"low": 0, "medium": 1, "high": 2}
+        grouped: dict[tuple[QualityDimension, str], dict[str, Any]] = {}
+
+        for issue in issues:
+            transform = _recommended_transformation(issue)
+            if transform is None:
+                continue
+            key = (issue.dimension, transform.value)
+            entry = grouped.setdefault(
+                key,
+                {"columns": [], "severity": "low", "recommendation": issue.recommendation},
+            )
+            if issue.column and issue.column not in entry["columns"]:
+                entry["columns"].append(issue.column)
+            if severity_rank[issue.severity] > severity_rank[entry["severity"]]:
+                entry["severity"] = issue.severity
+
+        recommendations = []
+        for (dimension, transform_value), entry in grouped.items():
+            cols = entry["columns"]
+            scope = ", ".join(cols) if cols else "the dataset"
+            recommendations.append(
+                ActionableRecommendation(
+                    dimension=dimension,
+                    description=f"Apply '{transform_value}' to {scope}: {entry['recommendation']}",
+                    transformation_type=transform_value,
+                    affected_columns=cols,
+                    severity=entry["severity"],
+                )
+            )
+
+        # Highest-severity first so the dashboard surfaces the most impactful fixes.
+        recommendations.sort(key=lambda r: severity_rank[r.severity], reverse=True)
         return recommendations
 
     def _get_severity(self, affected_percentage: float) -> str:

--- a/apps/backend/app/services/quality_gate_service.py
+++ b/apps/backend/app/services/quality_gate_service.py
@@ -1,0 +1,66 @@
+"""Soft quality gates for workflow progression (issue #102, AC4).
+
+Stateless evaluator with sensible default thresholds. Gates are advisory only —
+``is_blocking`` is always False so they warn but never block a user. No DB model,
+no CRUD: thresholds live here as constants.
+"""
+
+from typing import Any
+
+from app.schemas.quality import QualityGateResult
+from app.services.data_processing.quality_assessment import SCORE_DIMENSIONS
+
+# name -> (min overall 0-100, {dimension: min 0-100})
+DEFAULT_GATES: dict[str, tuple[float, dict[str, float]]] = {
+    "ML Training Ready": (70.0, {"completeness": 80.0, "validity": 70.0}),
+}
+
+
+def _component_scores(report: dict[str, Any]) -> dict[str, float]:
+    """Extract per-dimension 0-100 scores, tolerating pre-#102 cached reports."""
+    components = report.get("component_scores")
+    if components:
+        return {str(k): float(v) for k, v in components.items()}
+    # Backward compat: derive from 0-1 dimension_scores.
+    dim_scores = report.get("dimension_scores") or {}
+    return {
+        dim.value: round(float(dim_scores.get(dim.value, 0.0)) * 100, 1)
+        for dim in SCORE_DIMENSIONS
+        if dim.value in dim_scores
+    }
+
+
+def overall_score(report: dict[str, Any]) -> float:
+    """0-100 overall score, tolerating pre-#102 cached reports."""
+    if report.get("score_0_100") is not None:
+        return float(report["score_0_100"])
+    components = _component_scores(report)
+    if components:
+        return round(sum(components.values()) / len(components), 1)
+    # Last resort: the legacy 0-1 overall score.
+    return round(float(report.get("overall_quality_score", 0.0)) * 100, 1)
+
+
+def evaluate_gates(report: dict[str, Any]) -> list[QualityGateResult]:
+    """Evaluate all default soft gates against a quality report dict."""
+    overall = overall_score(report)
+    components = _component_scores(report)
+
+    results: list[QualityGateResult] = []
+    for name, (min_overall, min_dims) in DEFAULT_GATES.items():
+        failing = [
+            dim for dim, threshold in min_dims.items()
+            if components.get(dim, 0.0) < threshold
+        ]
+        passed = overall >= min_overall and not failing
+        results.append(
+            QualityGateResult(
+                gate_name=name,
+                passed=passed,
+                actual_score=overall,
+                required_score=min_overall,
+                failing_dimensions=failing,
+                is_blocking=False,
+            )
+        )
+    return results

--- a/apps/backend/app/services/transformation_service.py
+++ b/apps/backend/app/services/transformation_service.py
@@ -494,7 +494,8 @@ class TransformationService(BaseService[TransformationConfig]):
                         "parameters": parameters,
                         "affected_columns": affected_columns,
                         "rows_affected": result.affected_rows,
-                        "execution_time": execution_time_ms
+                        # TransformationStep.execution_time is documented in seconds.
+                        "execution_time": execution_time_ms / 1000
                     }
                 ]
 

--- a/apps/backend/app/services/transformation_service.py
+++ b/apps/backend/app/services/transformation_service.py
@@ -6,8 +6,11 @@ TransformationConfig model, delegating actual transformation execution to
 the existing TransformationEngine.
 """
 
+import logging
 from datetime import UTC
 from typing import Any
+
+import pandas as pd
 
 from app.models.transformation import (
     TransformationConfig,
@@ -15,11 +18,14 @@ from app.models.transformation import (
     TransformationValidation,
 )
 from app.services.base_service import BaseService
+from app.services.data_processing.quality_assessment import QualityAssessmentService
 from app.services.exceptions import NotFoundError, OperationError
 from app.services.transformation_engine.transformation_engine import (
     TransformationEngine,
     TransformationType,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class TransformationService(BaseService[TransformationConfig]):
@@ -31,6 +37,39 @@ class TransformationService(BaseService[TransformationConfig]):
     def __init__(self):
         """Initialize service with transformation engine."""
         self.engine = TransformationEngine()
+        self.quality_service = QualityAssessmentService()
+
+    @staticmethod
+    def _infer_column_types(df: pd.DataFrame) -> dict[str, str]:
+        """Coarse pandas-dtype -> quality-assessment type map (issue #102).
+
+        Enough for trend scoring; specialised email/phone detection isn't needed here.
+        """
+        types: dict[str, str] = {}
+        for col in df.columns:
+            dtype = df[col].dtype
+            if pd.api.types.is_integer_dtype(dtype):
+                types[col] = "integer"
+            elif pd.api.types.is_float_dtype(dtype):
+                types[col] = "float"
+            elif pd.api.types.is_datetime64_any_dtype(dtype):
+                types[col] = "datetime"
+            elif pd.api.types.is_bool_dtype(dtype):
+                types[col] = "boolean"
+            else:
+                types[col] = "string"
+        return types
+
+    async def _assess_quality_dict(self, df: pd.DataFrame) -> dict[str, Any] | None:
+        """Best-effort quality report as a JSON-native dict, or None on failure."""
+        try:
+            report = await self.quality_service.assess_quality(
+                df, self._infer_column_types(df)
+            )
+            return report.model_dump(mode="json")
+        except Exception as exc:  # never break the transformation on a quality error
+            logger.warning(f"Quality assessment skipped during versioning: {exc}")
+            return None
 
     def _get_id_field(self) -> str:
         """
@@ -357,8 +396,6 @@ class TransformationService(BaseService[TransformationConfig]):
         import time
         from datetime import datetime
 
-        import pandas as pd
-
         from app.models.dataset import DatasetMetadata
         from app.services.redis_cache import cache_service
         from app.services.transformation_engine.data_utils import (
@@ -443,16 +480,28 @@ class TransformationService(BaseService[TransformationConfig]):
                 dataset.num_columns = len(transformed_df.columns)
                 dataset.columns = transformed_df.columns.tolist()
 
-                # Build transformation steps for lineage
+                # Build transformation steps for lineage.
+                # Use the TransformationStep schema field names (step_type/affected_columns/
+                # rows_affected); the previous dict used transformation_type/column/columns,
+                # which raised a ValidationError that aborted every versioned transform.
+                affected_columns = [
+                    c for c in (parameters.get("column"), *(parameters.get("columns") or []))
+                    if c
+                ]
                 transformation_steps = [
                     {
-                        "transformation_type": transformation_type,
-                        "column": parameters.get("column"),
-                        "columns": parameters.get("columns"),
+                        "step_type": transformation_type,
                         "parameters": parameters,
+                        "affected_columns": affected_columns,
+                        "rows_affected": result.affected_rows,
                         "execution_time": execution_time_ms
                     }
                 ]
+
+                # Quality trend tracking (issue #102, AC3): assess before/after,
+                # best-effort — a quality failure must never break the transformation.
+                quality_before = await self._assess_quality_dict(df)
+                quality_after = await self._assess_quality_dict(transformed_df)
 
                 # Create version with lineage
                 version, lineage = await versioning_service.create_transformation_version(
@@ -462,7 +511,9 @@ class TransformationService(BaseService[TransformationConfig]):
                     dataset_metadata=dataset,
                     user_id=user_id,
                     description=f"Applied {transformation_type} transformation",
-                    transformation_config_id=config_id
+                    transformation_config_id=config_id,
+                    quality_before=quality_before,
+                    quality_after=quality_after
                 )
                 version_id = version.version_id
 

--- a/apps/backend/app/services/versioning_service.py
+++ b/apps/backend/app/services/versioning_service.py
@@ -132,7 +132,9 @@ class VersioningService(BaseService[DatasetVersion]):
         dataset_metadata: DatasetMetadata,
         user_id: str,
         description: str | None = None,
-        transformation_config_id: str | None = None
+        transformation_config_id: str | None = None,
+        quality_before: dict[str, Any] | None = None,
+        quality_after: dict[str, Any] | None = None
     ) -> tuple[DatasetVersion, TransformationLineage]:
         """
         Create new version after transformation application.
@@ -145,6 +147,8 @@ class VersioningService(BaseService[DatasetVersion]):
             user_id: User performing transformation
             description: Optional version description
             transformation_config_id: Optional reference to full config
+            quality_before: Optional quality report (dict) of the parent data
+            quality_after: Optional quality report (dict) of the transformed data
 
         Returns:
             Tuple of (new_version, lineage)
@@ -187,7 +191,9 @@ class VersioningService(BaseService[DatasetVersion]):
                 transformation_steps=transformation_steps,
                 dataset_metadata=dataset_metadata,
                 user_id=user_id,
-                transformation_config_id=transformation_config_id
+                transformation_config_id=transformation_config_id,
+                quality_before=quality_before,
+                quality_after=quality_after
             )
             return existing_version, lineage
 
@@ -251,7 +257,9 @@ class VersioningService(BaseService[DatasetVersion]):
             transformation_steps=transformation_steps,
             dataset_metadata=dataset_metadata,
             user_id=user_id,
-            transformation_config_id=transformation_config_id
+            transformation_config_id=transformation_config_id,
+            quality_before=quality_before,
+            quality_after=quality_after
         )
 
         # Link lineage to version
@@ -267,7 +275,9 @@ class VersioningService(BaseService[DatasetVersion]):
         transformation_steps: list[dict[str, Any]],
         dataset_metadata: DatasetMetadata,
         user_id: str,
-        transformation_config_id: str | None = None
+        transformation_config_id: str | None = None,
+        quality_before: dict[str, Any] | None = None,
+        quality_after: dict[str, Any] | None = None
     ) -> TransformationLineage:
         """Create transformation lineage record."""
         lineage_id = str(uuid.uuid4())
@@ -277,6 +287,14 @@ class VersioningService(BaseService[DatasetVersion]):
 
         # Calculate total execution time
         total_time = sum(step.execution_time or 0 for step in steps)
+
+        # Quality trend (issue #102, AC3): improvement is the 0-100 score delta.
+        quality_improvement: float | None = None
+        if quality_before and quality_after:
+            before_score = quality_before.get("score_0_100")
+            after_score = quality_after.get("score_0_100")
+            if before_score is not None and after_score is not None:
+                quality_improvement = round(float(after_score) - float(before_score), 1)
 
         lineage = TransformationLineage(
             lineage_id=lineage_id,
@@ -290,7 +308,10 @@ class VersioningService(BaseService[DatasetVersion]):
             rows_before=parent_version.num_rows,
             rows_after=child_version.num_rows,
             columns_before=parent_version.num_columns,
-            columns_after=child_version.num_columns
+            columns_after=child_version.num_columns,
+            quality_before=quality_before,
+            quality_after=quality_after,
+            quality_improvement=quality_improvement
         )
 
         lineage.mark_completed()
@@ -425,6 +446,39 @@ class VersioningService(BaseService[DatasetVersion]):
         versions = await query.sort("-version_number").skip(skip).limit(limit).to_list()
         logger.info(f"Listed {len(versions)} versions for dataset {dataset_id}")
         return versions
+
+    async def get_quality_trend(self, dataset_id: str) -> list[dict[str, Any]]:
+        """Quality score trend across a dataset's versions (issue #102, AC3).
+
+        Reads transformation lineage records (oldest first) and projects each one's
+        before/after 0-100 quality scores. Never raises — returns [] when there is
+        no lineage / no quality data.
+        """
+        lineages = await TransformationLineage.find(
+            TransformationLineage.dataset_id == dataset_id
+        ).sort("+created_at").to_list()
+
+        versions = await DatasetVersion.find(
+            DatasetVersion.dataset_id == dataset_id
+        ).to_list()
+        version_number = {v.version_id: v.version_number for v in versions}
+
+        points: list[dict[str, Any]] = []
+        for lineage in lineages:
+            before = (lineage.quality_before or {}).get("score_0_100")
+            after = (lineage.quality_after or {}).get("score_0_100")
+            transforms = ", ".join(
+                step.step_type for step in lineage.transformation_steps
+            ) or "transformation"
+            points.append({
+                "version_number": version_number.get(lineage.child_version_id),
+                "created_at": lineage.created_at,
+                "score_before": before,
+                "score_after": after,
+                "improvement": lineage.quality_improvement,
+                "transformation": transforms,
+            })
+        return points
 
     async def get_lineage_chain(self, version_id: str) -> list[TransformationLineage]:
         """

--- a/apps/backend/tests/test_api/test_data_processing.py
+++ b/apps/backend/tests/test_api/test_data_processing.py
@@ -226,6 +226,66 @@ class TestDataProcessingAPI:
             assert len(data["quality_report"]["recommendations"]) == 1
     
     @pytest.mark.asyncio
+    async def test_quality_report_consolidated_full(self, async_authorized_client, setup_database):
+        """Consolidated report exposes 0-100 score, components, gates (issue #102)."""
+        quality_data = {
+            "overall_quality_score": 0.86,
+            "score_0_100": 86.0,
+            "dimension_scores": {"completeness": 0.9, "validity": 0.8},
+            "component_scores": {
+                "completeness": 90.0, "validity": 80.0, "consistency": 95.0,
+                "uniqueness": 100.0, "accuracy": 80.0,
+            },
+            "recommendations": ["Fix missing values"],
+            "actionable_recommendations": [{
+                "dimension": "completeness", "description": "Apply 'fill_missing' to age",
+                "transformation_type": "fill_missing", "affected_columns": ["age"],
+                "severity": "high",
+            }],
+            "critical_issues": [{"x": 1}],
+            "warnings": [],
+        }
+        mock_user_data = create_mock_user_data(quality_report=quality_data, is_processed=True)
+        with patch('app.models.user_data.UserData.find_one', new_callable=AsyncMock) as mock_find:
+            mock_find.return_value = mock_user_data
+            response = await async_authorized_client.get("/api/v1/data/test-file-123/quality-report")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["score_0_100"] == 86.0
+        assert data["partial"] is False
+        assert data["component_scores"]["completeness"] == 90.0
+        assert data["actionable_recommendations"][0]["transformation_type"] == "fill_missing"
+        assert len(data["gates"]) >= 1
+        assert data["gates"][0]["is_blocking"] is False
+        assert data["gates"][0]["passed"] is True
+        assert data["critical_issue_count"] == 1
+
+    @pytest.mark.asyncio
+    async def test_quality_report_consolidated_partial_pre_102(self, async_authorized_client, setup_database):
+        """Pre-#102 cached report (no score_0_100) degrades to partial, never 500."""
+        quality_data = {
+            "overall_quality_score": 0.6,
+            "dimension_scores": {
+                "completeness": 0.5, "validity": 0.7, "consistency": 0.9,
+                "uniqueness": 1.0, "accuracy": 0.7,
+            },
+            "recommendations": [],
+        }
+        mock_user_data = create_mock_user_data(quality_report=quality_data, is_processed=True)
+        with patch('app.models.user_data.UserData.find_one', new_callable=AsyncMock) as mock_find:
+            mock_find.return_value = mock_user_data
+            response = await async_authorized_client.get("/api/v1/data/test-file-123/quality-report")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["partial"] is True
+        assert data["score_0_100"] > 0  # derived from legacy 0-1 dimension scores
+        # completeness 50 < 80 threshold -> gate fails
+        assert data["gates"][0]["passed"] is False
+        assert "completeness" in data["gates"][0]["failing_dimensions"]
+
+    @pytest.mark.asyncio
     async def test_get_data_preview_success(self, async_authorized_client, setup_database, sample_dataframe):
         """Test getting data preview"""
         mock_user_data = create_mock_user_data(is_processed=True)

--- a/apps/backend/tests/test_api/test_versions.py
+++ b/apps/backend/tests/test_api/test_versions.py
@@ -113,6 +113,75 @@ class TestVersionsAPI:
         )
         return version
 
+    # Test GET /datasets/{id}/quality-trend (issue #102, AC3)
+    @pytest.mark.asyncio
+    async def test_quality_trend_with_lineage(
+        self,
+        async_authorized_client: AsyncClient,
+        base_version: DatasetVersion,
+        sample_dataset_metadata: DatasetMetadata,
+        mock_user_id: str,
+        mock_s3_client,
+    ):
+        """Trend endpoint projects per-version 0-100 quality scores."""
+        steps = [{
+            "step_type": "fill_missing", "parameters": {}, "affected_columns": ["value"],
+            "rows_affected": 0, "execution_time": 0.1
+        }]
+        sample_dataset_metadata.num_rows = 102
+        await versioning_service.create_transformation_version(
+            parent_version_id=base_version.version_id,
+            transformed_content=b"id,value,category\n1,10.5,A\n2,20.3,B\n3,5,C",
+            transformation_steps=steps,
+            dataset_metadata=sample_dataset_metadata,
+            user_id=mock_user_id,
+            description="Filled missing",
+            quality_before={"score_0_100": 60.0},
+            quality_after={"score_0_100": 80.0},
+        )
+
+        response = await async_authorized_client.get(
+            f"/api/v1/datasets/{base_version.dataset_id}/quality-trend"
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["dataset_id"] == base_version.dataset_id
+        assert len(data["points"]) == 1
+        point = data["points"][0]
+        assert point["score_before"] == 60.0
+        assert point["score_after"] == 80.0
+        assert point["improvement"] == 20.0
+        assert "fill_missing" in point["transformation"]
+        assert data["overall_improvement"] == 20.0
+        assert data["best_score"] == 80.0
+        assert data["worst_score"] == 60.0
+
+    @pytest.mark.asyncio
+    async def test_quality_trend_empty_when_no_transformations(
+        self,
+        async_authorized_client: AsyncClient,
+        base_version: DatasetVersion,
+    ):
+        """A dataset with only a base version has an empty trend, not a 500."""
+        response = await async_authorized_client.get(
+            f"/api/v1/datasets/{base_version.dataset_id}/quality-trend"
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["points"] == []
+        assert data["overall_improvement"] is None
+
+    @pytest.mark.asyncio
+    async def test_quality_trend_unknown_dataset_404(
+        self,
+        async_authorized_client: AsyncClient,
+    ):
+        """Unknown/foreign dataset -> 404."""
+        response = await async_authorized_client.get(
+            f"/api/v1/datasets/{uuid.uuid4()}/quality-trend"
+        )
+        assert response.status_code == 404
+
     # Test GET /datasets/{id}/versions - List all versions
     @pytest.mark.asyncio
     async def test_list_versions_success(

--- a/apps/backend/tests/test_processing/test_quality_assessment.py
+++ b/apps/backend/tests/test_processing/test_quality_assessment.py
@@ -277,6 +277,51 @@ class TestQualityAssessment:
         assert report.row_count == 0
         assert report.column_count == 0
 
+    async def test_score_0_100_and_component_scores(self, quality_service, perfect_dataframe):
+        """0-100 score and per-dimension component scores are populated (issue #102, AC1)."""
+        column_types = {
+            'id': 'integer', 'name': 'string', 'email': 'email',
+            'age': 'integer', 'created_at': 'datetime'
+        }
+        report = await quality_service.assess_quality(perfect_dataframe, column_types)
+
+        # Headline score is on a 0-100 scale and tracks the 0-1 overall score.
+        assert 0.0 <= report.score_0_100 <= 100.0
+        assert report.score_0_100 > 90.0  # perfect data
+
+        # Component scores cover exactly the 5 AC dimensions, each 0-100.
+        from app.services.data_processing.quality_assessment import SCORE_DIMENSIONS
+        assert set(report.component_scores.keys()) == set(SCORE_DIMENSIONS)
+        assert all(0.0 <= v <= 100.0 for v in report.component_scores.values())
+        assert QualityDimension.TIMELINESS not in report.component_scores
+
+    async def test_score_0_100_empty_dataframe(self, quality_service):
+        """Empty dataframe yields a 0 score, not an error (issue #102)."""
+        report = await quality_service.assess_quality(pd.DataFrame(), {})
+        assert report.score_0_100 == 0.0
+        assert report.component_scores == {} or all(v == 0.0 for v in report.component_scores.values())
+
+    async def test_actionable_recommendations(self, quality_service, problematic_dataframe):
+        """Issues map to concrete transformations (issue #102, AC2)."""
+        from app.models.transformation import TransformationType
+
+        column_types = {
+            'id': 'integer', 'name': 'string', 'email': 'email',
+            'age': 'integer', 'phone': 'phone', 'created_at': 'datetime'
+        }
+        report = await quality_service.assess_quality(problematic_dataframe, column_types)
+
+        assert len(report.actionable_recommendations) > 0
+        valid_types = {t.value for t in TransformationType}
+        for rec in report.actionable_recommendations:
+            assert rec.transformation_type in valid_types
+            assert rec.severity in {"low", "medium", "high"}
+
+        # Missing values -> fill_missing; duplicate IDs -> remove_duplicates
+        rec_types = {r.transformation_type for r in report.actionable_recommendations}
+        assert TransformationType.FILL_MISSING.value in rec_types
+        assert TransformationType.REMOVE_DUPLICATES.value in rec_types
+
     async def test_mixed_quality_summary(self, quality_service, problematic_dataframe):
         """Test quality summary statistics"""
         column_types = {

--- a/apps/backend/tests/test_services/test_quality_gate_service.py
+++ b/apps/backend/tests/test_services/test_quality_gate_service.py
@@ -1,0 +1,66 @@
+"""Tests for soft quality gates (issue #102, AC4)."""
+
+from app.services.quality_gate_service import (
+    DEFAULT_GATES,
+    evaluate_gates,
+    overall_score,
+)
+
+
+def _report(score=85.0, completeness=90.0, validity=80.0):
+    return {
+        "score_0_100": score,
+        "component_scores": {
+            "completeness": completeness,
+            "validity": validity,
+            "consistency": 95.0,
+            "uniqueness": 100.0,
+            "accuracy": 80.0,
+        },
+        "critical_issues": [],
+        "warnings": [],
+    }
+
+
+class TestQualityGates:
+    def test_gate_passes_for_high_quality(self):
+        results = evaluate_gates(_report())
+        assert len(results) == len(DEFAULT_GATES)
+        gate = results[0]
+        assert gate.passed is True
+        assert gate.failing_dimensions == []
+        assert gate.is_blocking is False  # soft gate, always
+
+    def test_gate_fails_on_low_overall(self):
+        gate = evaluate_gates(_report(score=50.0))[0]
+        assert gate.passed is False
+        assert gate.actual_score == 50.0
+        assert gate.required_score == 70.0
+
+    def test_gate_reports_failing_dimensions(self):
+        gate = evaluate_gates(_report(completeness=60.0))[0]
+        assert gate.passed is False
+        assert "completeness" in gate.failing_dimensions
+
+    def test_gates_are_never_blocking(self):
+        for gate in evaluate_gates(_report(score=10.0, completeness=10.0)):
+            assert gate.is_blocking is False
+
+    def test_backward_compat_pre_102_report(self):
+        """Pre-#102 report (no score_0_100/component_scores) derives from 0-1 dims."""
+        legacy = {
+            "overall_quality_score": 0.9,
+            "dimension_scores": {
+                "completeness": 0.9,
+                "validity": 0.8,
+                "consistency": 0.95,
+                "uniqueness": 1.0,
+                "accuracy": 0.8,
+            },
+        }
+        assert overall_score(legacy) > 0  # derived, not zero
+        gate = evaluate_gates(legacy)[0]
+        assert gate.passed is True
+
+    def test_overall_score_last_resort_legacy_scalar(self):
+        assert overall_score({"overall_quality_score": 0.75}) == 75.0

--- a/apps/backend/tests/test_services/test_transformation_service.py
+++ b/apps/backend/tests/test_services/test_transformation_service.py
@@ -425,3 +425,29 @@ class TestApplyTransformationVersioning:
                 assert "transformation_config_id" in call_args.kwargs
                 # Verify config_id starts with expected prefix (actual ID includes timestamp)
                 assert call_args.kwargs["transformation_config_id"].startswith("config_ds1_")
+
+
+@pytest.mark.unit
+class TestQualityAssessmentHelpers:
+    """Quality helpers used for version trend tracking (issue #102, AC3)."""
+
+    def test_infer_column_types(self, transformation_service, sample_dataframe):
+        types = transformation_service._infer_column_types(sample_dataframe)
+        assert types["id"] == "integer"
+        assert types["age"] == "float"  # has a NaN -> float dtype
+        assert types["department"] == "string"
+
+    @pytest.mark.asyncio
+    async def test_assess_quality_dict_returns_json_native(self, transformation_service, sample_dataframe):
+        result = await transformation_service._assess_quality_dict(sample_dataframe)
+        assert result is not None
+        assert "score_0_100" in result
+        assert isinstance(result["score_0_100"], (int, float))
+        # enum dict keys are serialised to plain strings (mode="json")
+        assert all(isinstance(k, str) for k in result["component_scores"])
+
+    @pytest.mark.asyncio
+    async def test_assess_quality_dict_never_raises(self, transformation_service):
+        # A column-less frame must not blow up the version path; returns a dict or None.
+        result = await transformation_service._assess_quality_dict(pd.DataFrame())
+        assert result is None or "score_0_100" in result

--- a/apps/backend/tests/test_services/test_versioning_service.py
+++ b/apps/backend/tests/test_services/test_versioning_service.py
@@ -130,6 +130,66 @@ class TestVersionCreation:
                 )
 
     @pytest.mark.asyncio
+    async def test_create_lineage_populates_quality_improvement(self, versioning_service, mock_dataset_metadata):
+        """_create_lineage records the 0-100 quality delta (issue #102, AC3)."""
+        captured = {}
+
+        def capture(**kwargs):
+            captured.update(kwargs)
+            obj = MagicMock()
+            obj.mark_completed = Mock()
+            obj.insert = AsyncMock()
+            obj.lineage_id = kwargs["lineage_id"]
+            return obj
+
+        parent = MagicMock(version_id="v1", dataset_id="ds1", num_rows=100, num_columns=5)
+        child = MagicMock(version_id="v2", num_rows=90, num_columns=5)
+
+        with patch('app.services.versioning_service.TransformationLineage', side_effect=capture):
+            await versioning_service._create_lineage(
+                parent_version=parent,
+                child_version=child,
+                transformation_steps=[],
+                dataset_metadata=mock_dataset_metadata,
+                user_id="user1",
+                quality_before={"score_0_100": 60.0},
+                quality_after={"score_0_100": 82.5},
+            )
+
+        assert captured["quality_before"] == {"score_0_100": 60.0}
+        assert captured["quality_after"] == {"score_0_100": 82.5}
+        assert captured["quality_improvement"] == 22.5
+
+    @pytest.mark.asyncio
+    async def test_create_lineage_quality_none_when_unavailable(self, versioning_service, mock_dataset_metadata):
+        """No quality dicts -> quality_improvement stays None (backward compat)."""
+        captured = {}
+
+        def capture(**kwargs):
+            captured.update(kwargs)
+            obj = MagicMock()
+            obj.mark_completed = Mock()
+            obj.insert = AsyncMock()
+            obj.lineage_id = kwargs["lineage_id"]
+            return obj
+
+        parent = MagicMock(version_id="v1", dataset_id="ds1", num_rows=100, num_columns=5)
+        child = MagicMock(version_id="v2", num_rows=100, num_columns=5)
+
+        with patch('app.services.versioning_service.TransformationLineage', side_effect=capture):
+            await versioning_service._create_lineage(
+                parent_version=parent,
+                child_version=child,
+                transformation_steps=[],
+                dataset_metadata=mock_dataset_metadata,
+                user_id="user1",
+            )
+
+        assert captured["quality_before"] is None
+        assert captured["quality_after"] is None
+        assert captured["quality_improvement"] is None
+
+    @pytest.mark.asyncio
     async def test_create_transformation_version_parent_not_found(self, versioning_service, mock_dataset_metadata):
         """Test error when parent version not found raises NotFoundError."""
         with patch('app.services.versioning_service.DatasetVersion') as MockDatasetVersion:

--- a/apps/frontend/__tests__/components/QualityDashboard.test.tsx
+++ b/apps/frontend/__tests__/components/QualityDashboard.test.tsx
@@ -1,0 +1,109 @@
+import React from 'react'
+import { render, screen, waitFor } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import { QualityDashboard } from '@/components/quality/QualityDashboard'
+import { QualityService } from '@/lib/services/quality'
+import type { QualityReportResponse, QualityTrendResponse } from '@/lib/types/quality'
+
+jest.mock('@/lib/services/quality', () => ({
+  QualityService: {
+    getQualityReport: jest.fn(),
+    getQualityTrend: jest.fn(),
+  },
+}))
+
+// LineChart pulls in recharts — stub it so the test stays a unit test.
+jest.mock('@/components/LineChart', () => ({
+  LineChart: () => <div data-testid="line-chart" />,
+}))
+
+const mockService = QualityService as jest.Mocked<typeof QualityService>
+
+function makeReport(overrides: Partial<QualityReportResponse> = {}): QualityReportResponse {
+  return {
+    file_id: 'file-1',
+    filename: 'data.csv',
+    score_0_100: 86.5,
+    component_scores: { completeness: 90, validity: 80, consistency: 95, uniqueness: 100, accuracy: 80 },
+    recommendations: ['Fix missing values'],
+    actionable_recommendations: [
+      {
+        dimension: 'completeness',
+        description: "Apply 'fill_missing' to age",
+        transformation_type: 'fill_missing',
+        affected_columns: ['age'],
+        severity: 'high',
+      },
+    ],
+    gates: [
+      {
+        gate_name: 'ML Training Ready',
+        passed: true,
+        actual_score: 86.5,
+        required_score: 70,
+        failing_dimensions: [],
+        is_blocking: false,
+      },
+    ],
+    critical_issue_count: 1,
+    warning_count: 2,
+    partial: false,
+    ...overrides,
+  }
+}
+
+function makeTrend(): QualityTrendResponse {
+  return {
+    dataset_id: 'ds-1',
+    points: [
+      { version_number: 2, created_at: '2026-01-01T00:00:00Z', score_before: 60, score_after: 80, improvement: 20, transformation: 'fill_missing' },
+    ],
+    overall_improvement: 20,
+    best_score: 80,
+    worst_score: 60,
+  }
+}
+
+describe('QualityDashboard', () => {
+  beforeEach(() => jest.clearAllMocks())
+
+  it('renders the 0-100 score, gates, components and recommendations', async () => {
+    mockService.getQualityReport.mockResolvedValue(makeReport())
+    mockService.getQualityTrend.mockResolvedValue({ ...makeTrend(), points: [] })
+
+    render(<QualityDashboard fileId="file-1" datasetId="ds-1" />)
+
+    await waitFor(() => expect(screen.getByTestId('quality-dashboard')).toBeInTheDocument())
+    expect(screen.getByTestId('quality-score')).toHaveTextContent('86.5')
+    expect(screen.getByText('ML Training Ready')).toBeInTheDocument()
+    expect(screen.getByTestId('component-completeness')).toBeInTheDocument()
+    expect(screen.getByText("Apply 'fill_missing' to age")).toBeInTheDocument()
+    expect(screen.getByText('fill_missing')).toBeInTheDocument()
+  })
+
+  it('renders the trend chart only when trend points exist', async () => {
+    mockService.getQualityReport.mockResolvedValue(makeReport())
+    mockService.getQualityTrend.mockResolvedValue(makeTrend())
+
+    render(<QualityDashboard fileId="file-1" datasetId="ds-1" />)
+
+    await waitFor(() => expect(screen.getByTestId('line-chart')).toBeInTheDocument())
+  })
+
+  it('shows an error state when the report fails to load', async () => {
+    mockService.getQualityReport.mockRejectedValue(new Error('boom'))
+
+    render(<QualityDashboard fileId="file-1" />)
+
+    await waitFor(() => expect(screen.getByTestId('quality-dashboard-error')).toBeInTheDocument())
+  })
+
+  it('does not fetch the trend when no datasetId is provided', async () => {
+    mockService.getQualityReport.mockResolvedValue(makeReport())
+
+    render(<QualityDashboard fileId="file-1" />)
+
+    await waitFor(() => expect(screen.getByTestId('quality-dashboard')).toBeInTheDocument())
+    expect(mockService.getQualityTrend).not.toHaveBeenCalled()
+  })
+})

--- a/apps/frontend/app/explore/[id]/page.tsx
+++ b/apps/frontend/app/explore/[id]/page.tsx
@@ -18,6 +18,7 @@ import { DataPreviewTable } from '@/components/DataPreviewTable'
 import { SchemaViewer } from '@/components/SchemaViewer'
 import { StatisticsDashboard } from '@/components/StatisticsDashboard'
 import { QualityReportCard } from '@/components/QualityReportCard'
+import { QualityDashboard } from '@/components/quality/QualityDashboard'
 import { AIInsightsPanel } from '@/components/AIInsightsPanel'
 import { InteractiveVisualizationDashboard } from '@/components/InteractiveVisualizationDashboard'
 import type { DatasetSchema, DatasetStatistics, DatasetQualityReport } from '@/lib/types/api'
@@ -474,7 +475,8 @@ export default function DatasetAnalysisPage() {
             )}
           </TabsContent>
 
-          <TabsContent value="quality">
+          <TabsContent value="quality" className="space-y-4">
+            {dataset.id && <QualityDashboard fileId={dataset.id} datasetId={dataset.id} />}
             {dataset.quality_report ? (
               <QualityReportCard report={dataset.quality_report} />
             ) : (

--- a/apps/frontend/components/quality/QualityDashboard.tsx
+++ b/apps/frontend/components/quality/QualityDashboard.tsx
@@ -1,0 +1,211 @@
+'use client'
+
+import React, { useEffect, useState } from 'react'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Progress } from '@/components/ui/progress'
+import { Badge } from '@/components/ui/badge'
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
+import { CheckCircle2, AlertCircle, XCircle, Wrench, TrendingUp } from 'lucide-react'
+import { LineChart } from '@/components/LineChart'
+import { QualityService } from '@/lib/services/quality'
+import type {
+  QualityReportResponse,
+  QualityTrendResponse,
+} from '@/lib/types/quality'
+
+interface QualityDashboardProps {
+  /** UserData file id — drives the consolidated report endpoint. */
+  fileId: string
+  /** DatasetMetadata id — drives the trend endpoint (best-effort). */
+  datasetId?: string
+}
+
+function scoreLabel(score: number): { label: string; color: string } {
+  if (score >= 90) return { label: 'Excellent', color: 'text-green-600' }
+  if (score >= 70) return { label: 'Good', color: 'text-green-600' }
+  if (score >= 50) return { label: 'Fair', color: 'text-yellow-600' }
+  return { label: 'Poor', color: 'text-red-600' }
+}
+
+const severityColor: Record<string, string> = {
+  high: 'bg-red-100 text-red-800',
+  medium: 'bg-yellow-100 text-yellow-800',
+  low: 'bg-blue-100 text-blue-800',
+}
+
+export function QualityDashboard({ fileId, datasetId }: QualityDashboardProps) {
+  const [report, setReport] = useState<QualityReportResponse | null>(null)
+  const [trend, setTrend] = useState<QualityTrendResponse | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    setError(null)
+
+    QualityService.getQualityReport(fileId)
+      .then((r) => {
+        if (!cancelled) setReport(r)
+      })
+      .catch((e) => {
+        if (!cancelled) setError(e instanceof Error ? e.message : 'Failed to load quality report')
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+
+    // Trend is best-effort — a dataset without versions just hides the chart.
+    if (datasetId) {
+      QualityService.getQualityTrend(datasetId)
+        .then((t) => {
+          if (!cancelled) setTrend(t)
+        })
+        .catch(() => {
+          /* no trend available — ignore */
+        })
+    }
+
+    return () => {
+      cancelled = true
+    }
+  }, [fileId, datasetId])
+
+  if (loading) {
+    return <div data-testid="quality-dashboard-loading" className="text-sm text-muted-foreground">Loading quality report…</div>
+  }
+
+  if (error || !report) {
+    return (
+      <Alert variant="destructive" data-testid="quality-dashboard-error">
+        <XCircle className="h-4 w-4" />
+        <AlertTitle>Quality report unavailable</AlertTitle>
+        <AlertDescription>{error || 'No quality data for this dataset yet.'}</AlertDescription>
+      </Alert>
+    )
+  }
+
+  const { label, color } = scoreLabel(report.score_0_100)
+  const trendPoints = trend?.points ?? []
+
+  return (
+    <div className="space-y-4" data-testid="quality-dashboard">
+      {/* Overall 0-100 score */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center justify-between">
+            ML-Readiness Score
+            <span className={`text-3xl font-bold ${color}`} data-testid="quality-score">
+              {report.score_0_100.toFixed(1)}
+            </span>
+          </CardTitle>
+          <CardDescription>
+            <span className={color}>{label}</span> · {report.critical_issue_count} critical, {report.warning_count} warnings
+            {report.partial && ' · partial (legacy report)'}
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Progress value={report.score_0_100} className="h-2" />
+        </CardContent>
+      </Card>
+
+      {/* Quality gates */}
+      {report.gates.length > 0 && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Quality Gates</CardTitle>
+            <CardDescription>Advisory only — gates never block your workflow.</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            {report.gates.map((gate) => (
+              <div key={gate.gate_name} className="flex items-center justify-between" data-testid="quality-gate">
+                <div className="flex items-center gap-2">
+                  {gate.passed ? (
+                    <CheckCircle2 className="h-4 w-4 text-green-600" />
+                  ) : (
+                    <AlertCircle className="h-4 w-4 text-yellow-600" />
+                  )}
+                  <span className="text-sm font-medium">{gate.gate_name}</span>
+                </div>
+                <div className="text-sm text-muted-foreground">
+                  {gate.passed ? 'Passed' : `Needs ${gate.required_score} (now ${gate.actual_score.toFixed(0)})`}
+                  {gate.failing_dimensions.length > 0 && ` · ${gate.failing_dimensions.join(', ')}`}
+                </div>
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Component scores */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Component Scores</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          {Object.entries(report.component_scores).map(([dim, value]) => (
+            <div key={dim} data-testid={`component-${dim}`}>
+              <div className="mb-1 flex justify-between text-sm">
+                <span className="capitalize">{dim}</span>
+                <span>{value.toFixed(1)}</span>
+              </div>
+              <Progress value={value} className="h-1.5" />
+            </div>
+          ))}
+        </CardContent>
+      </Card>
+
+      {/* Actionable recommendations */}
+      {report.actionable_recommendations.length > 0 && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2 text-base">
+              <Wrench className="h-4 w-4" /> Recommended Fixes
+            </CardTitle>
+            <CardDescription>Each maps to a transformation you can apply.</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            {report.actionable_recommendations.map((rec, i) => (
+              <div key={i} className="flex items-start justify-between gap-3 rounded border p-2" data-testid="recommendation">
+                <div className="text-sm">{rec.description}</div>
+                <div className="flex shrink-0 items-center gap-2">
+                  <Badge className={severityColor[rec.severity] || ''}>{rec.severity}</Badge>
+                  <Badge variant="outline">{rec.transformation_type}</Badge>
+                </div>
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Quality trend across versions */}
+      {trendPoints.length > 0 && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2 text-base">
+              <TrendingUp className="h-4 w-4" /> Quality Trend
+            </CardTitle>
+            <CardDescription>
+              Score after each transformation
+              {trend?.overall_improvement != null && ` · ${trend.overall_improvement > 0 ? '+' : ''}${trend.overall_improvement} overall`}
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <LineChart
+              height={280}
+              data={{
+                data: trendPoints.map((p, i) => ({
+                  x: p.version_number != null ? `v${p.version_number}` : `step ${i + 1}`,
+                  score: p.score_after ?? 0,
+                })),
+                lines: [{ dataKey: 'score', label: 'Quality Score', color: '#82ca9d' }],
+                xLabel: 'Version',
+                yLabel: 'Score (0-100)',
+              }}
+            />
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  )
+}

--- a/apps/frontend/components/quality/QualityDashboard.tsx
+++ b/apps/frontend/components/quality/QualityDashboard.tsx
@@ -43,6 +43,7 @@ export function QualityDashboard({ fileId, datasetId }: QualityDashboardProps) {
     let cancelled = false
     setLoading(true)
     setError(null)
+    setTrend(null)  // avoid rendering the previous dataset's trend during a new load
 
     QualityService.getQualityReport(fileId)
       .then((r) => {
@@ -86,7 +87,8 @@ export function QualityDashboard({ fileId, datasetId }: QualityDashboardProps) {
   }
 
   const { label, color } = scoreLabel(report.score_0_100)
-  const trendPoints = trend?.points ?? []
+  // Only plot points with a real post-transformation score (the field is nullable).
+  const trendPoints = (trend?.points ?? []).filter((p) => p.score_after != null)
 
   return (
     <div className="space-y-4" data-testid="quality-dashboard">
@@ -196,7 +198,7 @@ export function QualityDashboard({ fileId, datasetId }: QualityDashboardProps) {
               data={{
                 data: trendPoints.map((p, i) => ({
                   x: p.version_number != null ? `v${p.version_number}` : `step ${i + 1}`,
-                  score: p.score_after ?? 0,
+                  score: p.score_after as number,
                 })),
                 lines: [{ dataKey: 'score', label: 'Quality Score', color: '#82ca9d' }],
                 xLabel: 'Version',

--- a/apps/frontend/lib/services/quality.ts
+++ b/apps/frontend/lib/services/quality.ts
@@ -1,0 +1,47 @@
+/**
+ * Quality scoring API client (issue #102).
+ */
+
+import { getAuthToken } from '@/lib/auth-helpers'
+import type {
+  QualityReportResponse,
+  QualityTrendResponse,
+} from '@/lib/types/quality'
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000/api/v1'
+
+async function authHeaders(): Promise<HeadersInit> {
+  const token = await getAuthToken()
+  return {
+    'Content-Type': 'application/json',
+    ...(token && { Authorization: `Bearer ${token}` }),
+  }
+}
+
+export const QualityService = {
+  /** Consolidated quality report (score, components, recommendations, gates). */
+  async getQualityReport(fileId: string): Promise<QualityReportResponse> {
+    const response = await fetch(
+      `${API_BASE_URL}/data/${encodeURIComponent(fileId)}/quality-report`,
+      { headers: await authHeaders() }
+    )
+    if (!response.ok) {
+      const error = await response.json().catch(() => ({ detail: 'Request failed' }))
+      throw new Error(error.detail || 'Failed to load quality report')
+    }
+    return response.json()
+  },
+
+  /** Quality trend across dataset versions. Returns empty points when none exist. */
+  async getQualityTrend(datasetId: string): Promise<QualityTrendResponse> {
+    const response = await fetch(
+      `${API_BASE_URL}/datasets/${encodeURIComponent(datasetId)}/quality-trend`,
+      { headers: await authHeaders() }
+    )
+    if (!response.ok) {
+      const error = await response.json().catch(() => ({ detail: 'Request failed' }))
+      throw new Error(error.detail || 'Failed to load quality trend')
+    }
+    return response.json()
+  },
+}

--- a/apps/frontend/lib/types/quality.ts
+++ b/apps/frontend/lib/types/quality.ts
@@ -1,0 +1,53 @@
+/**
+ * Data quality scoring system types (issue #102).
+ *
+ * Mirrors backend schemas in apps/backend/app/schemas/quality.py and
+ * apps/backend/app/schemas/version.py — change both together.
+ */
+
+export interface ActionableRecommendation {
+  dimension: string
+  description: string
+  transformation_type: string
+  affected_columns: string[]
+  severity: 'low' | 'medium' | 'high'
+}
+
+export interface QualityGateResult {
+  gate_name: string
+  passed: boolean
+  actual_score: number
+  required_score: number
+  failing_dimensions: string[]
+  is_blocking: boolean
+}
+
+export interface QualityReportResponse {
+  file_id: string
+  filename: string | null
+  score_0_100: number
+  component_scores: Record<string, number>
+  recommendations: string[]
+  actionable_recommendations: ActionableRecommendation[]
+  gates: QualityGateResult[]
+  critical_issue_count: number
+  warning_count: number
+  partial: boolean
+}
+
+export interface QualityTrendPoint {
+  version_number: number | null
+  created_at: string
+  score_before: number | null
+  score_after: number | null
+  improvement: number | null
+  transformation: string
+}
+
+export interface QualityTrendResponse {
+  dataset_id: string
+  points: QualityTrendPoint[]
+  overall_improvement: number | null
+  best_score: number | null
+  worst_score: number | null
+}

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,40 +1,107 @@
-# Issue #101 — Quick / Comprehensive Training Modes
+# Issue #102 — Data quality scoring system (P5.10, post-beta V2)
 
-## What already exists (Traycer plan is stale — do NOT rebuild)
-- Per-algorithm progress, current_stage, elapsed/estimated-remaining time, polling UI, logs, cancel — all shipped in #76.
-- Hyperparameter tuning (`enable_tuning`/`tuning_config`, bayesian + budgets, optuna early-stop pruner) — shipped in #77.
-- `progress_callback`/`event_callback`/`cancel_check`, `max_models`, candidate model catalog — exist in `AutoMLEngine`.
-- `training_config` dict passthrough on `TrainModelRequest` (no schema change needed — modes ride in it, like #77 did with tuning).
+**Lean adaptation.** The CodeRabbit plan was heavily over-scoped (new `QualityGate`
+Beanie model + CRUD + presets, a `QualityReportGenerator` with PDF export, a separate
+`ActionableRecommendation` model + a *new* `ISSUE_TO_TRANSFORMATION_MAP` that duplicates
+the existing `FixSuggestionEngine`, configurable per-request dimension weights, 6 new
+frontend components + a new page + new API client/hooks). This plan builds **on the real
+surfaces** that already exist and cuts the gold-plating.
 
-## Real gaps (AC ↔ work)
-1. AC1/AC2: mode → engine config mapping (quick: 3 algos, no tuning, 300s; comprehensive: 10+ algos, tuning, 1800s).
-2. AC2 "10+ algorithms": catalog tops out at ~7. Add ~4 always-on sklearn algos (ExtraTrees, AdaBoost, DecisionTree, GaussianNB / Lasso+ElasticNet) → comprehensive lists 10+.
-3. AC4: `time_limit` is accepted by the engine but **never enforced**, and the route never passes it. Add wall-clock enforcement + early-stop-on-good-score in the candidate loop.
-4. AC3: dataset-based recommendation (small endpoint + heuristic) + frontend mode selector with trade-off copy.
-5. AC5: time-remaining progress — already done (#76). No work.
+## Ground truth (verified in code)
+- `QualityAssessmentService.assess_quality()` already computes 0-1 dimension scores for
+  completeness / consistency / validity / uniqueness (accuracy = validity placeholder,
+  timeliness = 1.0 placeholder) and text `recommendations`. Returns `QualityReport`.
+- `GET /api/v1/data/{file_id}/quality` returns the cached `UserData.quality_report`.
+- `TransformationLineage` (`app/models/version.py`) already has
+  `quality_before/quality_after/quality_improvement` fields — **declared but never
+  populated** (dead). `DatasetVersion` is real and created on transformation.
+- `transformation_service.py` (~L406) has BOTH `df` (before) and `transformed_df` (after)
+  in hand at the exact call to `versioning_service.create_transformation_version()`.
+- `TransformationType` enum (`app/models/transformation.py`) is the canonical transform list.
+- Frontend already has `QualityReportCard.tsx` (rendered in `/explore/[id]` Quality tab),
+  a `LineChart.tsx` Recharts wrapper, and quality types in `lib/types/api.ts`.
 
-## Plan (lean)
+## Acceptance criteria
+- [x] AC1: Overall quality score (0-100) combining completeness, validity, consistency,
+      uniqueness, accuracy — `score_0_100` + `component_scores` on `QualityReport`
+- [x] AC2: Quality improvement recommendations tied to existing transformation tooling —
+      `actionable_recommendations` mapping issues → canonical `TransformationType`
+- [x] AC3: Quality trend tracking across dataset versions — lineage `quality_*` populated +
+      `GET /datasets/{id}/quality-trend`
+- [x] AC4: Optional quality gates for workflow progression — `quality_gate_service` (soft)
+- [x] AC5: Quality report generation + frontend dashboard —
+      `GET /data/{id}/quality-report` + `QualityDashboard` on the explore Quality tab
 
-### Backend
-- **New** `app/services/model_training/training_mode.py` (pure): `TrainingMode` enum; `resolve_mode_config(mode, overrides)` -> engine kwargs (max_models, time_limit, enable_tuning, tuning_strategy, early_stop_score) with explicit overrides winning; `recommend_mode(n_rows, n_features)` -> {mode, reason}.
-- **Edit** `automl_engine.py`:
-  - `__init__`: add `early_stop_score: float | None = None`.
-  - Candidate loop: enforce `time_limit` (break after >=1 model when elapsed >= budget) and early-stop when `cv_score >= early_stop_score`. Record `early_stopped`/`stop_reason`/`algorithms_evaluated`.
-  - `_get_candidate_models`: append ~4 always-on algos so full catalog >=10. Quick (first 3) unaffected.
-  - `AutoMLResult`: add `training_mode`, `early_stopped=False`, `stop_reason=None`, `algorithms_evaluated=None`.
-- **Edit** `model_training.py` train route: resolve `training_config["training_mode"]` via `resolve_mode_config` (absent -> today's behaviour unchanged), pass `time_limit` + `early_stop_score` to engine, stash mode/stop_reason in `training_config` (persisted on MLModel — **no new MLModel field**, avoids mock-fixture gotcha). New `GET /ml/datasets/{dataset_id}/mode-recommendation` (owner-scoped, 404 foreign).
+## Bug fixed in passing (blocked AC3)
+- `TransformationStep(**step)` in `_create_lineage` received `transformation_type`-keyed dicts
+  (wrong field name) and the `step_type` validator only allowed 8 of the 39 `TransformationType`
+  values → `ValidationError` (a `ValueError`) swallowed into an `OperationError`, so **every
+  transform on a dataset with a base version failed**. Fixed: correct dict field names in
+  `transformation_service` + validator now accepts all `TransformationType` values.
 
-### Frontend
-- **Edit** `lib/services/model.ts`: add `training_mode?` to `training_config` type; add `getModeRecommendation`.
-- **New** `components/TrainingModeSelector.tsx`: two cards (Quick/Comprehensive) + trade-off copy + recommendation banner.
-- **Edit** `app/model/page.tsx`: render selector, fetch recommendation on load, send `training_config.training_mode`.
+## Plan
 
-### Tests (TDD)
-- BE: `test_training_mode.py`; extend automl engine test (time-budget break, early-stop, new algos count >=10); route test (mode wiring + recommendation endpoint 200/404-foreign).
-- FE: `TrainingModeSelector.test.tsx`; extend `model.test.ts` (getModeRecommendation); model page mode wiring.
+### Step 1 — 0-100 score + component scores + actionable recommendations (AC1, AC2)
+`app/services/data_processing/quality_assessment.py`
+- Add `score_0_100: float` and `component_scores: dict[str, float]` (0-100, the 5 AC
+  dimensions; exclude the timeliness placeholder) to `QualityReport`, computed equal-weight
+  from existing `dimension_scores`. **No configurable weights** (not in AC; equal weight is
+  the existing behaviour — keeps backward-compat, no query param).
+- Add an `actionable_recommendations: list[ActionableRecommendation]` field: small struct
+  `{dimension, description, transformation_type, affected_columns, severity}` mapping each
+  quality dimension's issues to a canonical `TransformationType` (completeness→`fill_missing`,
+  consistency-casing→`fix_casing`, consistency-numeric→`to_numeric`,
+  consistency-date→`to_datetime`, validity-outlier→`outlier_removal`,
+  uniqueness→`remove_duplicates`). Reuse existing per-issue `affected columns`. Keep the
+  existing text `recommendations` unchanged (backward-compat).
+- Tests: extend `tests/test_processing/test_quality_assessment.py`.
 
-## Explicitly NOT doing (vs Traycer)
-- No `dataset_profiler.py`, no `training_constants.py`, no new MLModel DB fields, no new MLModel migration.
-- No new `GET /ml/train/{id}/progress` endpoint, no Redis progress cache (status endpoint + polling already exist).
-- No `RecommendationBanner.tsx`/`TrainingProgressDialog.tsx`/rework of `ModelTrainingButton.tsx` (unused).
-- No top-level `TrainModelRequest.training_mode` schema field (rides in training_config).
+### Step 2 — Populate quality lineage during transformation (AC3)
+`app/services/versioning_service.py` + `app/services/transformation_service.py`
+- Add optional `quality_before: dict | None`, `quality_after: dict | None` params to
+  `create_transformation_version()` and `_create_lineage()`; when present, set
+  `lineage.quality_before/after` and `quality_improvement = after.score_0_100 -
+  before.score_0_100`. Never fail the transform on a quality error (best-effort).
+- In `transformation_service.py` compute quality on `df` and `transformed_df` (derive a
+  simple column-type map from dtypes) and pass both in.
+- Tests: `tests/test_services/` lineage-quality population (real flow).
+
+### Step 3 — Quality trend endpoint (AC3)
+`app/api/routes/versions.py`
+- `GET /api/v1/datasets/{dataset_id}/quality-trend` (owner-scoped, 404 unknown/foreign):
+  read lineage records for the dataset ordered by version, return per-version
+  `{version_number, created_at, score_before, score_after, improvement, transformation}`
+  plus overall improvement since v1. Empty/no-versions → empty trend (never 500).
+- Tests: `tests/test_api/`.
+
+### Step 4 — Soft quality gates + report endpoint (AC4, AC5 backend)
+- `app/services/quality_gate_service.py` (stateless, no DB model): `evaluate(report)` with
+  default thresholds (ML-ready: overall ≥70, completeness ≥80, validity ≥70) → list of
+  `{gate_name, passed, actual_score, required_score, failing_dimensions, is_blocking:false}`.
+  **No `QualityGate` Beanie model, no CRUD, no presets persistence** — soft/advisory only.
+- `GET /api/v1/data/{file_id}/quality-report` aggregates: `score_0_100`, component scores,
+  actionable recommendations, gate results, and trend (if the dataset has versions). JSON
+  only — **no PDF** (not in AC; defer).
+- Tests: `tests/test_services/` + `tests/test_api/`.
+
+### Step 5 — Frontend quality dashboard (AC5 frontend) — IN SCOPE (user chose lean dashboard)
+`lib/services/quality.ts` (typed client for the report + trend endpoints) +
+a dashboard surface reusing the existing `QualityReportCard` with a 0-100 gauge, the
+existing `LineChart` for the trend, an actionable-recommendations list, and gate status.
+Mirror types in `lib/types/`. Component tests under `__tests__/`.
+
+## Deviations from CodeRabbit plan (why)
+- Drop configurable dimension weights / `weights` query param — not in AC, equal weight is
+  current behaviour. (YAGNI)
+- Drop the new `ActionableRecommendation` *model file* + `ISSUE_TO_TRANSFORMATION_MAP`
+  constant — fold a tiny dimension→`TransformationType` map into the service; reuse the
+  canonical enum instead of duplicating the existing `FixSuggestionEngine` mapping.
+- Drop `QualityGate` Beanie model + `QualityGateService` CRUD + presets — soft gates are a
+  stateless evaluator with default thresholds.
+- Drop PDF export from report generation — JSON only (not in AC).
+- Drop base-version quality backfill / new `initial_quality` field — trend's first
+  `quality_before` already captures the base-version quality.
+
+## Test commands
+- Backend: `cd apps/backend && uv run pytest tests/test_processing/test_quality_assessment.py tests/test_services/ tests/test_api/ -k quality -v`
+- Frontend: `cd apps/frontend && npm test` + `npm run type-check`


### PR DESCRIPTION
Closes #102.

## Summary
Adds a unified **data quality scoring system** built lean on the existing
`QualityAssessmentService`, `TransformationLineage`, and versions surfaces —
not the over-scoped CodeRabbit plan (no new `QualityGate` Beanie model + CRUD,
no `ActionableRecommendation` model duplicating the existing `FixSuggestionEngine`,
no PDF export, no configurable per-request weights).

## Acceptance criteria
- **AC1 — 0-100 score:** `QualityReport` gains `score_0_100` + per-dimension
  `component_scores` (equal-weight over completeness/validity/consistency/uniqueness/accuracy;
  timeliness excluded as a hardcoded placeholder).
- **AC2 — recommendations tied to transformations:** `actionable_recommendations`
  map each quality issue to a canonical `TransformationType`
  (completeness→`fill_missing`, casing→`fix_casing`, duplicates→`remove_duplicates`, …).
- **AC3 — quality trend across versions:** the previously-dead
  `TransformationLineage.quality_before/after/improvement` fields are now populated
  during transformation (best-effort, never breaks a transform), exposed via
  `GET /api/v1/datasets/{dataset_id}/quality-trend`.
- **AC4 — optional quality gates:** stateless `quality_gate_service.evaluate_gates`
  with default thresholds (ML Training Ready: overall ≥70, completeness ≥80, validity ≥70);
  **soft/advisory — `is_blocking` is always false**, never blocks workflow progression.
- **AC5 — report + dashboard:** `GET /api/v1/data/{file_id}/quality-report` aggregates
  score + components + recommendations + gates; `QualityDashboard` renders the score
  gauge, gates, component bars, recommendations, and a version trend chart on the
  explore page **Quality** tab.

## Bug fixed in passing (blocked AC3)
`_create_lineage` built `TransformationStep(**step)` from `transformation_type`-keyed
dicts (wrong field name), and the `step_type` validator only allowed 8 of the 39
`TransformationType` values. The resulting `ValidationError` (a `ValueError`) was
swallowed into an `OperationError`, so **every transform on a dataset that had a base
version failed**. Fixed by using the correct `TransformationStep` field names in
`transformation_service` and accepting all `TransformationType` values in the validator.

## Tests
- Backend: extended `test_quality_assessment`, new `test_quality_gate_service`,
  extended `test_versioning_service` / `test_transformation_service` / `test_version`,
  new trend + report API tests (`test_versions`, `test_data_processing`) — 108 passing
  across touched files; full-app `ruff` + `mypy` clean.
- Frontend: new `QualityDashboard.test.tsx` (4) + existing `QualityReportCard`,
  explore page test green; `type-check` + `eslint` clean.

## Known limitations
- `score_0_100` uses **equal weights** (configurable weights deferred — not in the AC).
- Quality `accuracy` remains the existing **validity placeholder**; `timeliness` stays a
  hardcoded placeholder and is excluded from the score.
- The report endpoint is keyed on the **UserData file id** and the trend on the
  **DatasetMetadata dataset id**; the dashboard fetches the trend best-effort and hides
  the chart when none exists.
- Report endpoint is **JSON only** (no PDF export).
- Quality computed in the **engineered/loaded space** via a coarse dtype→type map at
  version time (no email/phone specialisation in the trend path).
- Pre-#102 cached reports degrade to `partial=true` (gates derived from legacy 0-1
  dimension scores).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a quality dashboard showing overall quality score, component scores, recommendations, advisory gate results, and a quality trend over time.
  * Introduced endpoints for viewing a file’s quality report and a dataset’s quality trend.
* **Bug Fixes**
  * Improved handling of older quality reports so they still display correctly.
  * Updated transformation history tracking to include before/after quality scores and clearer step details.
* **Tests**
  * Expanded backend and frontend test coverage for quality reports, trend data, and dashboard rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->