### PR TITLE
[P0.1] fix(auth): mint backend-verifiable JWT for API calls (#251)

### DIFF
--- a/apps/backend/tests/test_auth/test_nextauth.py
+++ b/apps/backend/tests/test_auth/test_nextauth.py
@@ -76,6 +76,18 @@ async def test_malformed_token_rejected(mock_env_vars):
 
 
 @pytest.mark.asyncio
+async def test_legacy_nextauth_prefix_token_rejected(mock_env_vars):
+    """The old placeholder credential `nextauth-<user_id>` is not a JWT and
+    must be rejected with 401 under SKIP_AUTH=false (issue #251 AC: it can never
+    be used to impersonate a user)."""
+    with pytest.raises(HTTPException) as exc_info:
+        await get_current_user_id(bearer("nextauth-other_user"))
+
+    assert exc_info.value.status_code == 401
+    assert "Invalid token" in str(exc_info.value.detail)
+
+
+@pytest.mark.asyncio
 async def test_wrong_signature_rejected(mock_env_vars):
     """A JWT signed with a different secret is rejected with 401."""
     token = make_token({"sub": SAMPLE_USER_ID}, secret="some-other-secret")

--- a/apps/frontend/__tests__/lib/api-token.test.ts
+++ b/apps/frontend/__tests__/lib/api-token.test.ts
@@ -1,0 +1,53 @@
+/**
+ * @jest-environment node
+ *
+ * mintApiToken must produce a standard HS256 JWT that the FastAPI backend
+ * (jose.jwt.decode with NEXTAUTH_SECRET, reading `sub`) accepts. We verify the
+ * signature independently with node:crypto (the backend re-does the same HMAC
+ * check), proving the token is genuinely signed, not just well-shaped.
+ */
+import { createHmac } from 'node:crypto';
+import { mintApiToken } from '@/lib/api-token';
+
+const SECRET = 'test-secret-for-api-token';
+
+function verify(token: string, secret: string): Record<string, unknown> {
+  const [header, payload, sig] = token.split('.');
+  const expected = createHmac('sha256', secret).update(`${header}.${payload}`).digest('base64url');
+  if (sig !== expected) {
+    throw new Error('signature mismatch');
+  }
+  return JSON.parse(Buffer.from(payload, 'base64url').toString('utf8'));
+}
+
+describe('mintApiToken', () => {
+  const orig = process.env.NEXTAUTH_SECRET;
+  beforeEach(() => {
+    process.env.NEXTAUTH_SECRET = SECRET;
+  });
+  afterAll(() => {
+    process.env.NEXTAUTH_SECRET = orig;
+  });
+
+  it('produces a 3-part HS256 JWT with the userId as sub and a future expiry', () => {
+    const token = mintApiToken('user_123');
+
+    expect(token.split('.')).toHaveLength(3);
+    const header = JSON.parse(Buffer.from(token.split('.')[0], 'base64url').toString('utf8'));
+    expect(header).toEqual({ alg: 'HS256', typ: 'JWT' });
+
+    const claims = verify(token, SECRET);
+    expect(claims.sub).toBe('user_123');
+    expect(claims.exp as number).toBeGreaterThan(Math.floor(Date.now() / 1000));
+  });
+
+  it('fails verification with the wrong secret (the signature is real)', () => {
+    const token = mintApiToken('user_123');
+    expect(() => verify(token, 'wrong-secret')).toThrow('signature mismatch');
+  });
+
+  it('throws when NEXTAUTH_SECRET is not set', () => {
+    delete process.env.NEXTAUTH_SECRET;
+    expect(() => mintApiToken('user_123')).toThrow(/NEXTAUTH_SECRET/);
+  });
+});

--- a/apps/frontend/__tests__/lib/api-token.test.ts
+++ b/apps/frontend/__tests__/lib/api-token.test.ts
@@ -25,6 +25,11 @@ describe('mintApiToken', () => {
   beforeEach(() => {
     process.env.NEXTAUTH_SECRET = SECRET;
   });
+  // Restore after every test so the delete-secret case can't leak into a later
+  // test if Jest reorders execution.
+  afterEach(() => {
+    process.env.NEXTAUTH_SECRET = SECRET;
+  });
   afterAll(() => {
     process.env.NEXTAUTH_SECRET = orig;
   });

--- a/apps/frontend/__tests__/lib/auth-helpers.test.ts
+++ b/apps/frontend/__tests__/lib/auth-helpers.test.ts
@@ -1,0 +1,48 @@
+import { getSession } from 'next-auth/react';
+
+// jest.setup.js globally mocks @/lib/auth-helpers; test the real implementation.
+jest.unmock('@/lib/auth-helpers');
+const { getAuthToken } = jest.requireActual('@/lib/auth-helpers');
+
+jest.mock('next-auth/react', () => ({ getSession: jest.fn() }));
+
+const mockGetSession = getSession as jest.MockedFunction<typeof getSession>;
+
+describe('getAuthToken', () => {
+  beforeEach(() => mockGetSession.mockReset());
+
+  it('returns the session apiToken (the real signed JWT, not a placeholder)', async () => {
+    const realToken = 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1c2VyXzEifQ.sig';
+    mockGetSession.mockResolvedValue({
+      user: { id: 'user_1' },
+      apiToken: realToken,
+      expires: '2099-01-01',
+    } as never);
+
+    await expect(getAuthToken()).resolves.toBe(realToken);
+  });
+
+  it('never returns the legacy nextauth-<id> placeholder', async () => {
+    mockGetSession.mockResolvedValue({
+      user: { id: 'user_1' },
+      apiToken: 'header.payload.sig',
+      expires: '2099-01-01',
+    } as never);
+
+    const token = await getAuthToken();
+    expect(token).not.toMatch(/^nextauth-/);
+  });
+
+  it('returns null when there is no session', async () => {
+    mockGetSession.mockResolvedValue(null);
+    await expect(getAuthToken()).resolves.toBeNull();
+  });
+
+  it('returns null when the session has no apiToken', async () => {
+    mockGetSession.mockResolvedValue({
+      user: { id: 'user_1' },
+      expires: '2099-01-01',
+    } as never);
+    await expect(getAuthToken()).resolves.toBeNull();
+  });
+});

--- a/apps/frontend/auth.ts
+++ b/apps/frontend/auth.ts
@@ -6,6 +6,7 @@ import GoogleProvider from "next-auth/providers/google"
 import GitHubProvider from "next-auth/providers/github"
 import CredentialsProvider from "next-auth/providers/credentials"
 import client from "./lib/db"
+import { mintApiToken } from "./lib/api-token"
 
 // Development mode flag
 const isDevelopment = process.env.NODE_ENV === 'development'
@@ -82,8 +83,18 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
       if (session?.user) {
         session.user.id = token.id as string
       }
-      // Add the JWT token to the session so we can pass it to the backend
+      // Keep the OAuth provider access token (legacy field).
       session.accessToken = token.accessToken as string | undefined
+      // Mint a backend-verifiable HS256 JWT (sub=userId) so API calls
+      // authenticate under SKIP_AUTH=false. Best-effort: a missing secret
+      // must not crash session reads (the backend then returns 401).
+      if (token.id) {
+        try {
+          session.apiToken = mintApiToken(token.id as string)
+        } catch {
+          session.apiToken = undefined
+        }
+      }
       return session
     },
     async signIn() {

--- a/apps/frontend/auth.ts
+++ b/apps/frontend/auth.ts
@@ -91,7 +91,10 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
       if (token.id) {
         try {
           session.apiToken = mintApiToken(token.id as string)
-        } catch {
+        } catch (err) {
+          // Don't crash session reads, but surface the cause — otherwise a
+          // misconfigured secret silently 401s every API call with no signal.
+          console.error('[auth] mintApiToken failed:', err)
           session.apiToken = undefined
         }
       }

--- a/apps/frontend/lib/api-token.ts
+++ b/apps/frontend/lib/api-token.ts
@@ -1,0 +1,37 @@
+import { createHmac } from 'node:crypto';
+
+// API token lifetime (seconds). Short-lived so a leaked token expires quickly;
+// the NextAuth session callback re-mints it on every session read, so the
+// client always holds a fresh one.
+const API_TOKEN_TTL_SECONDS = 60 * 60;
+
+function base64url(input: string): string {
+  return Buffer.from(input, 'utf8').toString('base64url');
+}
+
+/**
+ * Mint a backend-verifiable API token for the given user.
+ *
+ * Produces a standard HS256 JWT signed with NEXTAUTH_SECRET carrying the user
+ * id as `sub`. The FastAPI backend (`app/auth/nextauth_auth.py`) decodes
+ * exactly this (`jwt.decode(..., algorithms=["HS256"])`, reads `sub`), so no
+ * backend change is needed — it replaces the old placeholder `nextauth-${id}`
+ * string that the backend rejected under SKIP_AUTH=false.
+ *
+ * Runs only in the Node runtime (the NextAuth config is Node-only via the
+ * MongoDB adapter), so `node:crypto` is available — no extra dependency.
+ */
+export function mintApiToken(userId: string): string {
+  const secret = process.env.NEXTAUTH_SECRET;
+  if (!secret) {
+    throw new Error('NEXTAUTH_SECRET is not set; cannot mint API token');
+  }
+  const now = Math.floor(Date.now() / 1000);
+  const header = base64url(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
+  const payload = base64url(
+    JSON.stringify({ sub: userId, iat: now, exp: now + API_TOKEN_TTL_SECONDS }),
+  );
+  const signingInput = `${header}.${payload}`;
+  const signature = createHmac('sha256', secret).update(signingInput).digest('base64url');
+  return `${signingInput}.${signature}`;
+}

--- a/apps/frontend/lib/auth-helpers.ts
+++ b/apps/frontend/lib/auth-helpers.ts
@@ -1,18 +1,14 @@
 import { getSession } from 'next-auth/react';
 
+/**
+ * Return the backend-verifiable API token for the current session.
+ *
+ * The token is an HS256 JWT (sub=userId) minted server-side in the NextAuth
+ * `session` callback (see auth.ts -> lib/api-token.ts) and signed with
+ * NEXTAUTH_SECRET, which the FastAPI backend validates. Returns null when there
+ * is no session or the token could not be minted.
+ */
 export async function getAuthToken() {
   const session = await getSession();
-
-  // For now, we'll use a placeholder token
-  // In a real implementation, you'd want to:
-  // 1. Use the NextAuth JWT directly, or
-  // 2. Create a custom endpoint to exchange the session for an API token
-
-  if (session?.user?.id) {
-    // Create a simple token that the backend can validate
-    // This is temporary - in production you'd want proper JWT signing
-    return `nextauth-${session.user.id}`;
-  }
-
-  return null;
+  return session?.apiToken ?? null;
 }

--- a/apps/frontend/types/next-auth.d.ts
+++ b/apps/frontend/types/next-auth.d.ts
@@ -6,5 +6,7 @@ declare module "next-auth" {
       id: string
     } & DefaultSession["user"]
     accessToken?: string
+    /** Backend-verifiable HS256 JWT (sub=userId) for API Authorization. */
+    apiToken?: string
   }
 }


### PR DESCRIPTION
Closes #251 (P0.1 launch blocker).

## Problem
The frontend's only API credential was the placeholder string `nextauth-${session.user.id}` (`lib/auth-helpers.ts`). Under `SKIP_AUTH=false` (staging/prod) the backend requires an HS256 JWT signed with `NEXTAUTH_SECRET` and reads the `sub` claim (`app/auth/nextauth_auth.py`). So **every authenticated request returned 401** — the app only functioned with auth disabled. There was no session→token exchange anywhere.

## Fix (frontend-only — the backend verifier was already correct)
- `lib/api-token.ts` (new): `mintApiToken(userId)` builds a standard **HS256 JWT** (`sub=userId`, 1h exp) signed with `NEXTAUTH_SECRET` using `node:crypto`. The NextAuth config is Node-only (MongoDB adapter), so no extra dependency and no edge-runtime concern (middleware is cookie-only and does not import `auth.ts`).
- `auth.ts`: the `session` callback mints the token and exposes it as `session.apiToken` (best-effort — a missing secret doesn't crash session reads; the backend then 401s).
- `lib/auth-helpers.ts`: `getAuthToken()` now returns `session.apiToken` (was the placeholder). All ~20 callsites use the returned string as the Bearer token, so they're fixed transparently.
- `types/next-auth.d.ts`: add `apiToken?: string` to `Session`.

The backend `get_current_user_id` already decodes exactly this token shape — **zero backend code change**.

## Tests
- `__tests__/lib/api-token.test.ts` (node env): independently HMAC-verifies the minted token, asserts `alg=HS256`, `sub`, future `exp`, wrong-secret rejection, and missing-secret throw.
- `__tests__/lib/auth-helpers.test.ts`: `getAuthToken` returns `apiToken`, never the legacy `nextauth-` prefix, null without a session/token.
- `apps/backend/tests/test_auth/test_nextauth.py`: asserts the legacy `nextauth-<id>` placeholder is rejected **401** under `SKIP_AUTH=false` (AC paper-trail).

## Demo (end-to-end, cross-language)
A token minted by the frontend logic, fed to the **real backend `get_current_user_id`**:
```
Backend get_current_user_id -> alice_42
PASS: real frontend token accepted by real backend verifier, sub=alice_42
PASS: legacy nextauth-bob_99 rejected -> 401
```

## Known limitations / out of scope
- The AC note "bind any SKIP_AUTH dev instance to localhost" overlaps the staging port-binding blocker (#258) and is handled there; the #149 env gate already prevents `SKIP_AUTH=true` outside dev/test.
- Token is re-minted on every session read (stateless, 1h TTL) — no refresh endpoint needed for this design.
