### PR TITLE
fix(security): deny-by-default auth middleware + guard /api/chat & /api/upload (#253)

### DIFF
--- a/apps/frontend/__tests__/app/api/chat/route.test.ts
+++ b/apps/frontend/__tests__/app/api/chat/route.test.ts
@@ -1,0 +1,56 @@
+/**
+ * @jest-environment node
+ *
+ * Guards the security additions to the OpenAI chat proxy (issue #253):
+ * an auth() gate and a per-user rate limit. OpenAI is mocked so no network
+ * call or API key is needed.
+ */
+import { auth } from '@/auth'
+import { __resetRateLimits } from '@/lib/api-guards'
+
+jest.mock('@/auth', () => ({ auth: jest.fn() }))
+
+const mockCreate = jest.fn()
+jest.mock('openai', () => ({
+  OpenAI: jest.fn().mockImplementation(() => ({
+    chat: { completions: { create: mockCreate } },
+  })),
+}))
+
+import { POST } from '@/app/api/chat/route'
+
+const mockAuth = auth as jest.MockedFunction<typeof auth>
+
+function chatRequest(): Request {
+  return new Request('http://localhost/api/chat', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ message: 'hi', context: 'ctx', messageHistory: [] }),
+  })
+}
+
+describe('POST /api/chat', () => {
+  beforeEach(() => {
+    __resetRateLimits()
+    mockAuth.mockResolvedValue({ user: { id: 'test-user' } } as never)
+    mockCreate.mockResolvedValue({ choices: [{ message: { content: 'reply' } }] })
+  })
+
+  it('returns 401 without a session and never calls OpenAI', async () => {
+    mockAuth.mockResolvedValue(null as never)
+
+    const res = await POST(chatRequest())
+    expect(res.status).toBe(401)
+    expect(mockCreate).not.toHaveBeenCalled()
+  })
+
+  it('returns 429 once the per-user limit is exceeded', async () => {
+    // Limit is 20/min; the 21st request in the window is blocked.
+    for (let i = 0; i < 20; i++) {
+      expect((await POST(chatRequest())).status).toBe(200)
+    }
+    const blocked = await POST(chatRequest())
+    expect(blocked.status).toBe(429)
+    expect(blocked.headers.get('Retry-After')).toBeTruthy()
+  })
+})

--- a/apps/frontend/__tests__/app/api/upload/route.test.ts
+++ b/apps/frontend/__tests__/app/api/upload/route.test.ts
@@ -14,6 +14,13 @@
  */
 import ExcelJS from 'exceljs'
 import { POST } from '@/app/api/upload/route'
+import { auth } from '@/auth'
+import { __resetRateLimits } from '@/lib/api-guards'
+
+// Mock the auth module so tests never load NextAuth/MongoDB; default is an
+// authenticated session, overridden per-test for the unauthenticated case.
+jest.mock('@/auth', () => ({ auth: jest.fn() }))
+const mockAuth = auth as jest.MockedFunction<typeof auth>
 
 const XLSX_MIME = 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
 
@@ -48,6 +55,34 @@ function makeRequestWithFile(file: {
 }
 
 describe('POST /api/upload', () => {
+  beforeEach(() => {
+    __resetRateLimits()
+    // Authenticated by default (id present); the auth suite overrides this.
+    mockAuth.mockResolvedValue({ user: { id: 'test-user' } } as never)
+  })
+
+  describe('authentication & rate limiting', () => {
+    it('returns 401 when there is no session', async () => {
+      mockAuth.mockResolvedValue(null as never)
+      const blob = new Blob(['name\nAlice\n'], { type: 'text/csv' })
+
+      const res = await POST(makeRequest(blob, 'data.csv'))
+      expect(res.status).toBe(401)
+      expect((await res.json()).error).toBe('Unauthorized')
+    })
+
+    it('returns 429 once the per-user limit is exceeded', async () => {
+      const csv = () => new Blob(['name\nAlice\n'], { type: 'text/csv' })
+      // Limit is 30/min; the 31st request in the window is blocked.
+      for (let i = 0; i < 30; i++) {
+        expect((await POST(makeRequest(csv(), 'data.csv'))).status).toBe(200)
+      }
+      const blocked = await POST(makeRequest(csv(), 'data.csv'))
+      expect(blocked.status).toBe(429)
+      expect(blocked.headers.get('Retry-After')).toBeTruthy()
+    })
+  })
+
   describe('file size guard', () => {
     it('returns 413 before reading an oversized preview file into memory', async () => {
       const file = {
@@ -296,6 +331,21 @@ describe('POST /api/upload', () => {
         ['Bob', '25'],
       ])
       expect(body.fileType).toBe('csv')
+    })
+
+    it('caps the preview at 10 rows without parsing the whole file', async () => {
+      const lines = ['col']
+      for (let i = 0; i < 500; i++) lines.push(`v${i}`)
+      const blob = new Blob([lines.join('\n') + '\n'], { type: 'text/csv' })
+
+      const res = await POST(makeRequest(blob, 'big.csv'))
+      expect(res.status).toBe(200)
+
+      const body = await res.json()
+      expect(body.headers).toEqual(['col'])
+      expect(body.previewData).toHaveLength(10)
+      expect(body.previewData[0]).toEqual(['v0'])
+      expect(body.previewData[9]).toEqual(['v9'])
     })
   })
 

--- a/apps/frontend/__tests__/lib/api-guards.test.ts
+++ b/apps/frontend/__tests__/lib/api-guards.test.ts
@@ -1,0 +1,33 @@
+import { rateLimit, __resetRateLimits } from '@/lib/api-guards'
+
+describe('rateLimit', () => {
+  beforeEach(() => __resetRateLimits())
+
+  it('allows requests up to the limit, then blocks', () => {
+    const opts = { limit: 3, windowMs: 1000, now: 1000 }
+    expect(rateLimit('u1', opts).allowed).toBe(true)
+    expect(rateLimit('u1', opts).allowed).toBe(true)
+    expect(rateLimit('u1', opts).allowed).toBe(true)
+
+    const blocked = rateLimit('u1', opts)
+    expect(blocked.allowed).toBe(false)
+    expect(blocked.remaining).toBe(0)
+    expect(blocked.retryAfterMs).toBeGreaterThan(0)
+  })
+
+  it('tracks each key independently', () => {
+    const opts = { limit: 1, windowMs: 1000, now: 5000 }
+    expect(rateLimit('a', opts).allowed).toBe(true)
+    expect(rateLimit('a', opts).allowed).toBe(false)
+    // A different key still has its own fresh budget.
+    expect(rateLimit('b', opts).allowed).toBe(true)
+  })
+
+  it('resets once the window has elapsed', () => {
+    expect(rateLimit('u', { limit: 1, windowMs: 1000, now: 0 }).allowed).toBe(true)
+    // Still inside the window → blocked.
+    expect(rateLimit('u', { limit: 1, windowMs: 1000, now: 500 }).allowed).toBe(false)
+    // Window elapsed → allowed again.
+    expect(rateLimit('u', { limit: 1, windowMs: 1000, now: 1000 }).allowed).toBe(true)
+  })
+})

--- a/apps/frontend/__tests__/middleware.test.ts
+++ b/apps/frontend/__tests__/middleware.test.ts
@@ -1,0 +1,65 @@
+/**
+ * @jest-environment node
+ */
+jest.mock('next-auth/jwt', () => ({ getToken: jest.fn() }))
+
+import middleware from '@/middleware'
+import { getToken } from 'next-auth/jwt'
+import type { NextRequest } from 'next/server'
+
+const mockGetToken = getToken as jest.MockedFunction<typeof getToken>
+
+function mockRequest(pathname: string, { method = 'GET' }: { method?: string } = {}): NextRequest {
+  const url = `http://localhost:3000${pathname}`
+  return {
+    nextUrl: { pathname },
+    url,
+    method,
+    headers: {
+      get: (h: string) => (h === 'origin' ? 'http://localhost:3000' : null),
+    },
+  } as unknown as NextRequest
+}
+
+describe('middleware (deny-by-default)', () => {
+  beforeEach(() => mockGetToken.mockReset())
+
+  it.each([
+    '/admin',
+    '/settings/api',
+    '/predict',
+    '/evaluate',
+    '/transform',
+    '/features',
+    '/experiments',
+    '/recipes',
+    '/review',
+    '/dashboard',
+    '/', // previously the only implicitly-covered root
+    '/some-future-page', // proves new pages are protected automatically
+  ])('redirects requests without a valid session for protected page %s', async (pathname) => {
+    mockGetToken.mockResolvedValue(null) // no / invalid token
+    const res = await middleware(mockRequest(pathname))
+    expect(res.status).toBe(307) // NextResponse.redirect default
+    expect(res.headers.get('location')).toContain('/auth/signin')
+    expect(res.headers.get('location')).toContain(`callbackUrl=${encodeURIComponent(pathname)}`)
+  })
+
+  it('allows a request with a valid session to a protected page', async () => {
+    mockGetToken.mockResolvedValue({ sub: 'user-1' } as never)
+    const res = await middleware(mockRequest('/admin'))
+    expect(res.status).not.toBe(307)
+  })
+
+  it('always allows the public auth flow (without checking a token)', async () => {
+    const res = await middleware(mockRequest('/auth/signin'))
+    expect(res.status).not.toBe(307)
+    expect(mockGetToken).not.toHaveBeenCalled()
+  })
+
+  it('does not redirect API routes (they self-guard with 401)', async () => {
+    const res = await middleware(mockRequest('/api/chat', { method: 'POST' }))
+    expect(res.status).not.toBe(307)
+    expect(mockGetToken).not.toHaveBeenCalled()
+  })
+})

--- a/apps/frontend/app/api/chat/route.ts
+++ b/apps/frontend/app/api/chat/route.ts
@@ -1,9 +1,14 @@
 import { NextResponse } from 'next/server'
 import { OpenAI } from 'openai'
+import { auth } from '@/auth'
+import { rateLimit } from '@/lib/api-guards'
 
 // Add proper Next.js API route configuration
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
+
+// Per-user throttle for the OpenAI proxy (guards against cost amplification).
+const CHAT_RATE_LIMIT = { limit: 20, windowMs: 60_000 }
 
 // Lazily constructed: the OpenAI SDK throws when apiKey is undefined, which
 // breaks `next build` page-data collection in environments without secrets
@@ -35,6 +40,21 @@ Remember: Your main value is in helping users understand their specific data, no
 
 export async function POST(request: Request) {
   try {
+    // Require an authenticated session — this route is a paid OpenAI proxy.
+    const session = await auth()
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    // Throttle per user to prevent cost-amplification abuse.
+    const limit = rateLimit(`chat:${session.user.id}`, CHAT_RATE_LIMIT)
+    if (!limit.allowed) {
+      return NextResponse.json(
+        { error: 'Too many requests' },
+        { status: 429, headers: { 'Retry-After': String(Math.ceil(limit.retryAfterMs / 1000)) } }
+      )
+    }
+
     const { message, context, messageHistory = [] } = await request.json()
 
     // Construct the messages array with system prompt, context, and history

--- a/apps/frontend/app/api/upload/route.ts
+++ b/apps/frontend/app/api/upload/route.ts
@@ -1,10 +1,15 @@
 import { NextResponse } from 'next/server'
 import ExcelJS from 'exceljs'
 import { parse } from 'csv-parse/sync'
+import { auth } from '@/auth'
+import { rateLimit } from '@/lib/api-guards'
 
 // Add proper Next.js API route configuration
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
+
+// Per-user throttle to bound parser-amplification abuse.
+const UPLOAD_RATE_LIMIT = { limit: 30, windowMs: 60_000 }
 
 const PREVIEW_UPLOAD_MAX_BYTES = 100 * 1024 * 1024
 const PREVIEW_UPLOAD_MAX_LABEL = `${PREVIEW_UPLOAD_MAX_BYTES / (1024 * 1024)}MB`
@@ -38,6 +43,21 @@ function normalizeCell(value: unknown): CellPrimitive {
 
 export async function POST(request: Request) {
   try {
+    // Require an authenticated session before buffering/parsing any file.
+    const session = await auth()
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    // Throttle per user to bound parser-amplification abuse.
+    const limit = rateLimit(`upload:${session.user.id}`, UPLOAD_RATE_LIMIT)
+    if (!limit.allowed) {
+      return NextResponse.json(
+        { error: 'Too many requests' },
+        { status: 429, headers: { 'Retry-After': String(Math.ceil(limit.retryAfterMs / 1000)) } }
+      )
+    }
+
     // Get the form data from the request
     const formData = await request.formData()
     const file = formData.get('file') as File
@@ -69,7 +89,8 @@ export async function POST(request: Request) {
       const records = parse(content, {
         columns: true,
         skip_empty_lines: true,
-        trim: true
+        trim: true,
+        to: PREVIEW_ROW_LIMIT // stop after the preview; don't scan the whole file
       })
 
       if (records.length === 0) {

--- a/apps/frontend/lib/api-guards.ts
+++ b/apps/frontend/lib/api-guards.ts
@@ -1,0 +1,57 @@
+// lib/api-guards.ts
+// Shared guards for Next.js API route handlers: a small in-memory rate limiter.
+
+interface WindowState {
+  count: number
+  resetAt: number
+}
+
+// ponytail: in-memory per-instance limiter — counters reset on redeploy and are NOT
+// shared across serverless/edge instances. Fine for throttling abuse from a single
+// worker; swap this Map for Redis/Upstash if the frontend runs multi-instance and
+// cross-instance limits start to matter.
+const buckets = new Map<string, WindowState>()
+
+export interface RateLimitOptions {
+  /** Max requests allowed per window. */
+  limit: number
+  /** Window length in milliseconds. */
+  windowMs: number
+  /** Injectable clock for testing; defaults to Date.now(). */
+  now?: number
+}
+
+export interface RateLimitResult {
+  allowed: boolean
+  remaining: number
+  /** Milliseconds until the current window resets (0 when allowed with headroom). */
+  retryAfterMs: number
+}
+
+/**
+ * Fixed-window rate limit keyed by an arbitrary string (e.g. a user id).
+ * Returns whether the request is allowed and how long to wait if not.
+ */
+export function rateLimit(key: string, options: RateLimitOptions): RateLimitResult {
+  const { limit, windowMs } = options
+  const now = options.now ?? Date.now()
+  const state = buckets.get(key)
+
+  // New key, or the previous window has elapsed → start a fresh window.
+  if (!state || now >= state.resetAt) {
+    buckets.set(key, { count: 1, resetAt: now + windowMs })
+    return { allowed: true, remaining: limit - 1, retryAfterMs: 0 }
+  }
+
+  if (state.count >= limit) {
+    return { allowed: false, remaining: 0, retryAfterMs: state.resetAt - now }
+  }
+
+  state.count += 1
+  return { allowed: true, remaining: limit - state.count, retryAfterMs: 0 }
+}
+
+/** Test-only helper to clear all rate-limit state between cases. */
+export function __resetRateLimits(): void {
+  buckets.clear()
+}

--- a/apps/frontend/middleware.ts
+++ b/apps/frontend/middleware.ts
@@ -1,38 +1,39 @@
 // ./middleware.ts
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
+import { getToken } from "next-auth/jwt";
 
-export default function middleware(request: NextRequest) {
+export default async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
-  // Skip auth for auth routes themselves
+  // Public auth flow (sign-in/out, error pages, NextAuth endpoints) — always allowed.
   if (pathname.startsWith('/auth/') || pathname.startsWith('/api/auth/')) {
     return NextResponse.next();
   }
 
-  // Check for session cookie (next-auth uses this)
-  const sessionCookie = request.cookies.get('authjs.session-token') ||
-                       request.cookies.get('__Secure-authjs.session-token'); // Production uses secure prefix
+  // API routes are guarded by their own handlers (which return 401 JSON on missing
+  // sessions), not by page-redirect middleware. Let them through untouched.
+  if (pathname.startsWith('/api/')) {
+    return NextResponse.next();
+  }
 
-  // Define protected routes
-  const protectedRoutes = ['/', '/dashboard', '/onboarding', '/api/protected', '/upload', '/prepare', '/explore', '/analyze', '/model', '/deploy', '/monitor', '/insights'];
-  const isProtectedRoute = protectedRoutes.some(route => pathname === route || pathname.startsWith(route + '/'));
+  // Deny-by-default for pages: every page requires a valid session unless explicitly
+  // public above. New pages are protected automatically — there is no allowlist to
+  // keep in sync, which is the drift that left /admin, /settings/api, /predict, etc.
+  // exposed under the old opt-in allowlist. Verify the Auth.js JWT (signature +
+  // expiry), not just cookie presence, so a stale or forged session-token cookie
+  // cannot serve a protected page.
+  const token = await getToken({ req: request, secret: process.env.NEXTAUTH_SECRET });
 
-  // Enforce authentication for protected routes
-  if (isProtectedRoute && !sessionCookie) {
+  if (!token) {
     const signInUrl = new URL('/auth/signin', request.url);
     signInUrl.searchParams.set('callbackUrl', pathname);
     return NextResponse.redirect(signInUrl);
   }
-  
-  // Skip CORS handling for internal API routes
-  if (pathname.startsWith('/api/')) {
-    return NextResponse.next();
-  }
-  
-  // Your existing CORS handling
+
+  // Authenticated page request — apply existing CORS handling.
   const origin = request.headers.get('origin') || '*';
-  
+
   if (request.method === 'OPTIONS') {
     return new NextResponse(null, {
       status: 204,
@@ -44,13 +45,13 @@ export default function middleware(request: NextRequest) {
       },
     });
   }
-  
+
   const response = NextResponse.next();
   response.headers.set('Access-Control-Allow-Origin', origin);
   response.headers.set('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS');
   response.headers.set('Access-Control-Allow-Headers', 'Content-Type, Authorization, Accept');
   response.headers.set('Access-Control-Max-Age', '86400');
-  
+
   return response;
 }
 


### PR DESCRIPTION
Closes #253 (P0.3 · security · high)

## Problem
- `middleware.ts` used an **opt-in** protected-route allowlist that had drifted: it omitted real authenticated pages (`/admin`, `/settings/api`, `/predict`, `/evaluate`, `/transform`, `/features`, `/experiments`, `/recipes`, `/review`) while listing dead entries (`/analyze`, `/insights`, `/api/protected`). Sensitive pages loaded without a session.
- `/api/chat` called OpenAI with **no auth check** → open LLM proxy / cost amplification.
- `/api/upload` had **no auth check** and the CSV path parsed the entire file into memory → parser-amplification. (The xlsx path and a 100MB size guard were already hardened in #173.)

## Changes
| Area | Fix |
|------|-----|
| `middleware.ts` | **Deny-by-default**: every page requires a session unless explicitly public (`/auth/*`). Verifies the Auth.js JWT via `getToken` (signature + expiry), not just cookie presence, so a stale/forged cookie can't serve a protected page. API routes pass through and self-guard. New pages are protected automatically. |
| `app/api/chat/route.ts` | `auth()` → 401 on missing session + per-user rate limit (20/min) → 429. |
| `app/api/upload/route.ts` | `auth()` → 401 + per-user rate limit (30/min); cap CSV parsing to preview rows (`to: 11`) instead of scanning the whole file. |
| `lib/api-guards.ts` *(new)* | Shared in-memory fixed-window `rateLimit()`. |

## Acceptance criteria
- [x] Deny-by-default middleware (public allowlist only) — chose this over enumerating routes so the secure state is the default state; now JWT-validated rather than cookie-presence.
- [x] `auth()` 401 checks + rate limiting on `/api/chat` and `/api/upload`.
- [x] Lowered preview parse limit (~11 rows) for CSV (xlsx + 100MB guard already done in #173).

## Tests (all green: full frontend suite 1183 passing)
- `__tests__/lib/api-guards.test.ts` — limit boundary, per-key isolation, window reset.
- `__tests__/middleware.test.ts` (node env) — every listed sensitive page **and an arbitrary future page** redirect without a valid JWT; valid session, `/auth/*`, and `/api/*` pass; public routes don't even call `getToken`.
- `__tests__/app/api/chat/route.test.ts` (node env) — 401 without session (OpenAI never called), 429 over the limit.
- `__tests__/app/api/upload/route.test.ts` — 401/429 + CSV preview cap; existing exceljs characterization tests updated to mock `auth()`.

## Known limitations
- **Rate limiter is in-memory per instance** — counters reset on redeploy and are not shared across serverless/edge instances. Adequate for single-worker abuse throttling; swap the `Map` for Redis/Upstash if the frontend scales horizontally (`ponytail:` comment at the source).
- The 100MB upload size guard (`#173`) runs after `formData()` buffers the body; proxy/platform request-size limits remain the real memory boundary, as documented there. Out of scope for this PR.

## Note
Rebased onto current `main` after an initial revision was built on a stale local checkout. No CI/workflow files are touched.