### PR TITLE
fix(security): refuse wildcard CORS with credentials outside dev (#256)

### DIFF
--- a/.env.staging.example
+++ b/.env.staging.example
@@ -59,7 +59,15 @@ OPENAI_API_KEY=REPLACE_WITH_OPENAI_API_KEY
 # Backend secret key for JWT and encryption (generate with: openssl rand -hex 32)
 BACKEND_SECRET_KEY=REPLACE_WITH_RANDOM_SECRET_KEY_64_CHARS
 
-# CORS allowed origins (comma-separated)
+# Backend CORS allowed origins (comma-separated OR a JSON array). Read by the
+# backend as BACKEND_CORS_ORIGINS (app/config.py). MUST be explicit origin(s):
+# the backend refuses '*' in production-like envs because credentialed wildcard
+# CORS lets any site make authenticated requests.
+BACKEND_CORS_ORIGINS=https://narrative.yourdomain.com,https://staging.yourdomain.com
+
+# Frontend page-middleware CORS allowlist (comma-separated), read as
+# ALLOWED_ORIGINS (apps/frontend/middleware.ts). Leave empty unless a trusted
+# cross-origin site must call the frontend; same-origin needs no entry.
 ALLOWED_ORIGINS=https://narrative.yourdomain.com,https://staging.yourdomain.com
 
 # ═══════════════════════════════════════════════════════════════

--- a/apps/backend/app/config.py
+++ b/apps/backend/app/config.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import os
 from pathlib import Path
@@ -97,6 +98,58 @@ def validate_skip_auth(
     )
 
 
+def _parse_cors_origins(raw: str | None) -> list[str]:
+    """Parse an origins list from a JSON array or a comma-separated string.
+
+    Accepts ``["https://a"]`` (config convention) and ``https://a,https://b``
+    (the staging template convention). Unset/blank ⇒ the dev wildcard ``["*"]``.
+    """
+    if not raw or not raw.strip():
+        return ["*"]
+    raw = raw.strip()
+    try:
+        parsed = json.loads(raw)
+        if isinstance(parsed, list) and parsed:
+            return [str(o).strip() for o in parsed]
+    except (json.JSONDecodeError, ValueError):
+        pass
+    parts = [p.strip() for p in raw.split(",") if p.strip()]
+    return parts or ["*"]
+
+
+def resolve_cors_origins(
+    raw: str | None, environment: str | None = None
+) -> list[str]:
+    """Resolve CORS origins, refusing wildcard in production-like envs (#256).
+
+    CORS is registered with ``allow_credentials=True`` (main.py); with a ``"*"``
+    origin Starlette reflects the caller's Origin and sends
+    ``Access-Control-Allow-Credentials: true`` — letting ANY site make
+    authenticated cross-origin requests. So a wildcard (explicit, or the unset
+    default) is refused outside development: the backend fails to start rather
+    than silently running wildcard CORS on a deployment.
+
+    ``environment`` defaults to every set environment signal (a stray
+    ``ENVIRONMENT=development`` must not outvote a real ``NODE_ENV=production``),
+    mirroring ``validate_skip_auth``.
+    """
+    origins = _parse_cors_origins(raw)
+    if environment is not None:
+        prod_like = environment.strip().lower() in PRODUCTION_LIKE_ENVIRONMENTS
+    else:
+        prod_like = is_production_like()
+    if prod_like and "*" in origins:
+        env = environment or get_environment()
+        raise ValueError(
+            f"BACKEND_CORS_ORIGINS must list explicit origin(s) in {env!r} — "
+            "wildcard '*' with credentialed CORS lets any site make "
+            "authenticated cross-origin requests. Set BACKEND_CORS_ORIGINS to "
+            "your deployed frontend origin(s), e.g. "
+            "'https://app.example.com,https://staging.example.com'."
+        )
+    return origins
+
+
 class Settings(BaseModel):
     # MongoDB settings
     MONGODB_URI: str = os.getenv("MONGODB_URI", "mongodb://localhost:27017")
@@ -149,16 +202,7 @@ class Settings(BaseModel):
     # CORS settings
     @property
     def BACKEND_CORS_ORIGINS(self) -> list[str]:
-        cors_origins = os.getenv("BACKEND_CORS_ORIGINS", '["*"]')
-        if cors_origins:
-            import json
-
-            try:
-                return json.loads(cors_origins)
-            except (json.JSONDecodeError, ValueError):
-                pass
-        # Default to allow all origins in development
-        return ["*"]
+        return resolve_cors_origins(os.getenv("BACKEND_CORS_ORIGINS"))
 
     @field_validator("AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY")
     @classmethod

--- a/apps/backend/tests/test_security/test_cors_config.py
+++ b/apps/backend/tests/test_security/test_cors_config.py
@@ -1,0 +1,68 @@
+"""Tests for the CORS origin resolver (issue #256).
+
+The backend registers CORS with ``allow_credentials=True`` (main.py). With
+``allow_origins=["*"]`` Starlette reflects the caller's Origin and emits
+``Access-Control-Allow-Credentials: true`` — so a wildcard there lets ANY site
+make authenticated cross-origin requests. Staging shipped this because compose
+set ``ALLOWED_ORIGINS`` (a name nothing reads) instead of ``BACKEND_CORS_ORIGINS``,
+leaving the wildcard default in place.
+
+``resolve_cors_origins`` is the pure guard (mirrors ``validate_skip_auth``):
+- parses JSON *or* comma-separated origin lists,
+- refuses ``"*"`` in production-like environments (fail-closed startup).
+"""
+
+import pytest
+
+from app.config import resolve_cors_origins
+
+pytestmark = [pytest.mark.unit, pytest.mark.security]
+
+
+class TestResolveCorsOrigins:
+    """resolve_cors_origins(raw, environment) — pure origin resolution."""
+
+    # --- parsing -----------------------------------------------------------
+
+    def test_parses_json_list(self):
+        assert resolve_cors_origins(
+            '["https://a.example.com","https://b.example.com"]',
+            environment="development",
+        ) == ["https://a.example.com", "https://b.example.com"]
+
+    def test_parses_comma_separated(self):
+        """The staging template documents comma-separated origins."""
+        assert resolve_cors_origins(
+            "https://a.example.com, https://b.example.com",
+            environment="staging",
+        ) == ["https://a.example.com", "https://b.example.com"]
+
+    def test_unset_defaults_to_wildcard_in_development(self):
+        assert resolve_cors_origins(None, environment="development") == ["*"]
+        assert resolve_cors_origins("", environment="development") == ["*"]
+
+    # --- production-like refusal (the fix) ---------------------------------
+
+    @pytest.mark.parametrize(
+        "environment", ["production", "prod", "staging", "live", "release"]
+    )
+    def test_wildcard_refused_in_production_like(self, environment):
+        with pytest.raises(ValueError, match="BACKEND_CORS_ORIGINS"):
+            resolve_cors_origins('["*"]', environment=environment)
+
+    @pytest.mark.parametrize("raw", [None, "", "*", '["*"]'])
+    def test_unset_or_wildcard_all_refused_in_staging(self, raw):
+        """Fail-closed: a mis/unconfigured staging deploy must not run wildcard."""
+        with pytest.raises(ValueError, match="BACKEND_CORS_ORIGINS"):
+            resolve_cors_origins(raw, environment="staging")
+
+    def test_explicit_origins_allowed_in_production_like(self):
+        assert resolve_cors_origins(
+            '["https://app.example.com"]', environment="production"
+        ) == ["https://app.example.com"]
+
+    # --- development keeps wildcard (DX preserved) -------------------------
+
+    @pytest.mark.parametrize("environment", ["development", "test"])
+    def test_wildcard_allowed_in_development_and_test(self, environment):
+        assert resolve_cors_origins('["*"]', environment=environment) == ["*"]

--- a/apps/backend/tests/test_security/test_cors_config.py
+++ b/apps/backend/tests/test_security/test_cors_config.py
@@ -56,6 +56,13 @@ class TestResolveCorsOrigins:
         with pytest.raises(ValueError, match="BACKEND_CORS_ORIGINS"):
             resolve_cors_origins(raw, environment="staging")
 
+    def test_wildcard_mixed_with_explicit_origin_still_refused(self):
+        """One explicit origin does not 'dilute' a wildcard — any '*' refuses."""
+        with pytest.raises(ValueError, match="BACKEND_CORS_ORIGINS"):
+            resolve_cors_origins(
+                '["*","https://app.example.com"]', environment="production"
+            )
+
     def test_explicit_origins_allowed_in_production_like(self):
         assert resolve_cors_origins(
             '["https://app.example.com"]', environment="production"

--- a/apps/frontend/__tests__/middleware.test.ts
+++ b/apps/frontend/__tests__/middleware.test.ts
@@ -96,6 +96,13 @@ describe('middleware CORS allowlist (#256)', () => {
     expect(res.headers.get('Access-Control-Allow-Origin')).toBeNull()
   })
 
+  it('sets Vary: Origin so caches never replay one origin\'s ACAO for another', async () => {
+    const allowed = await middleware(mockRequest('/dashboard', { origin: 'https://app.example.com' }))
+    expect(allowed.headers.get('Vary')).toBe('Origin')
+    const blocked = await middleware(mockRequest('/dashboard', { origin: 'https://evil.example.com' }))
+    expect(blocked.headers.get('Vary')).toBe('Origin')
+  })
+
   it('honors the allowlist on OPTIONS preflight (allowed vs blocked)', async () => {
     const allowed = await middleware(mockRequest('/dashboard', { method: 'OPTIONS', origin: 'https://staging.example.com' }))
     expect(allowed.status).toBe(204)

--- a/apps/frontend/__tests__/middleware.test.ts
+++ b/apps/frontend/__tests__/middleware.test.ts
@@ -76,8 +76,9 @@ describe('middleware CORS allowlist (#256)', () => {
     process.env.ALLOWED_ORIGINS = 'https://app.example.com, https://staging.example.com'
   })
 
-  afterAll(() => {
-    process.env.ALLOWED_ORIGINS = ORIGINAL
+  afterEach(() => {
+    if (ORIGINAL === undefined) delete process.env.ALLOWED_ORIGINS
+    else process.env.ALLOWED_ORIGINS = ORIGINAL
   })
 
   it('echoes an allowlisted Origin', async () => {

--- a/apps/frontend/__tests__/middleware.test.ts
+++ b/apps/frontend/__tests__/middleware.test.ts
@@ -9,14 +9,17 @@ import type { NextRequest } from 'next/server'
 
 const mockGetToken = getToken as jest.MockedFunction<typeof getToken>
 
-function mockRequest(pathname: string, { method = 'GET' }: { method?: string } = {}): NextRequest {
+function mockRequest(
+  pathname: string,
+  { method = 'GET', origin = 'http://localhost:3000' }: { method?: string; origin?: string | null } = {}
+): NextRequest {
   const url = `http://localhost:3000${pathname}`
   return {
     nextUrl: { pathname },
     url,
     method,
     headers: {
-      get: (h: string) => (h === 'origin' ? 'http://localhost:3000' : null),
+      get: (h: string) => (h === 'origin' ? origin : null),
     },
   } as unknown as NextRequest
 }
@@ -61,5 +64,45 @@ describe('middleware (deny-by-default)', () => {
     const res = await middleware(mockRequest('/api/chat', { method: 'POST' }))
     expect(res.status).not.toBe(307)
     expect(mockGetToken).not.toHaveBeenCalled()
+  })
+})
+
+describe('middleware CORS allowlist (#256)', () => {
+  const ORIGINAL = process.env.ALLOWED_ORIGINS
+
+  beforeEach(() => {
+    mockGetToken.mockReset()
+    mockGetToken.mockResolvedValue({ sub: 'user-1' } as never) // authenticated
+    process.env.ALLOWED_ORIGINS = 'https://app.example.com, https://staging.example.com'
+  })
+
+  afterAll(() => {
+    process.env.ALLOWED_ORIGINS = ORIGINAL
+  })
+
+  it('echoes an allowlisted Origin', async () => {
+    const res = await middleware(mockRequest('/dashboard', { origin: 'https://app.example.com' }))
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe('https://app.example.com')
+  })
+
+  it('does NOT set Access-Control-Allow-Origin for an off-allowlist Origin', async () => {
+    const res = await middleware(mockRequest('/dashboard', { origin: 'https://evil.example.com' }))
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBeNull()
+  })
+
+  it('does not reflect an arbitrary Origin when the allowlist is empty', async () => {
+    process.env.ALLOWED_ORIGINS = ''
+    const res = await middleware(mockRequest('/dashboard', { origin: 'https://app.example.com' }))
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBeNull()
+  })
+
+  it('honors the allowlist on OPTIONS preflight (allowed vs blocked)', async () => {
+    const allowed = await middleware(mockRequest('/dashboard', { method: 'OPTIONS', origin: 'https://staging.example.com' }))
+    expect(allowed.status).toBe(204)
+    expect(allowed.headers.get('Access-Control-Allow-Origin')).toBe('https://staging.example.com')
+
+    const blocked = await middleware(mockRequest('/dashboard', { method: 'OPTIONS', origin: 'https://evil.example.com' }))
+    expect(blocked.status).toBe(204)
+    expect(blocked.headers.get('Access-Control-Allow-Origin')).toBeNull()
   })
 })

--- a/apps/frontend/middleware.ts
+++ b/apps/frontend/middleware.ts
@@ -31,26 +31,35 @@ export default async function middleware(request: NextRequest) {
     return NextResponse.redirect(signInUrl);
   }
 
-  // Authenticated page request — apply existing CORS handling.
-  const origin = request.headers.get('origin') || '*';
+  // Authenticated page request — apply CORS handling. Never reflect an arbitrary
+  // Origin (that is CSRF-friendly): echo the caller's Origin only when it is on
+  // the configured allowlist, otherwise omit Access-Control-Allow-Origin so the
+  // browser blocks the cross-origin read. Same-origin requests need no ACAO.
+  const allowlist = (process.env.ALLOWED_ORIGINS ?? '')
+    .split(',')
+    .map((o) => o.trim())
+    .filter(Boolean);
+  const requestOrigin = request.headers.get('origin');
+  const allowedOrigin =
+    requestOrigin && allowlist.includes(requestOrigin) ? requestOrigin : null;
+
+  const corsHeaders: Record<string, string> = {
+    'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type, Authorization, Accept',
+    'Access-Control-Max-Age': '86400',
+  };
+  if (allowedOrigin) {
+    corsHeaders['Access-Control-Allow-Origin'] = allowedOrigin;
+  }
 
   if (request.method === 'OPTIONS') {
-    return new NextResponse(null, {
-      status: 204,
-      headers: {
-        'Access-Control-Allow-Origin': origin,
-        'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
-        'Access-Control-Allow-Headers': 'Content-Type, Authorization, Accept',
-        'Access-Control-Max-Age': '86400',
-      },
-    });
+    return new NextResponse(null, { status: 204, headers: corsHeaders });
   }
 
   const response = NextResponse.next();
-  response.headers.set('Access-Control-Allow-Origin', origin);
-  response.headers.set('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS');
-  response.headers.set('Access-Control-Allow-Headers', 'Content-Type, Authorization, Accept');
-  response.headers.set('Access-Control-Max-Age', '86400');
+  for (const [key, value] of Object.entries(corsHeaders)) {
+    response.headers.set(key, value);
+  }
 
   return response;
 }

--- a/apps/frontend/middleware.ts
+++ b/apps/frontend/middleware.ts
@@ -47,6 +47,10 @@ export default async function middleware(request: NextRequest) {
     'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
     'Access-Control-Allow-Headers': 'Content-Type, Authorization, Accept',
     'Access-Control-Max-Age': '86400',
+    // The response's ACAO depends on the request Origin (present, absent, or a
+    // specific allowlisted value). Behind a shared cache/CDN (nginx), Vary:
+    // Origin prevents one origin's cached CORS result being replayed for another.
+    Vary: 'Origin',
   };
   if (allowedOrigin) {
     corsHeaders['Access-Control-Allow-Origin'] = allowedOrigin;

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -54,7 +54,10 @@ services:
 
       # Security
       SECRET_KEY: ${BACKEND_SECRET_KEY}
-      ALLOWED_ORIGINS: ${ALLOWED_ORIGINS}
+      # CORS: the backend reads BACKEND_CORS_ORIGINS (config.py). It refuses '*'
+      # in production-like envs, so this MUST list explicit staging origin(s) —
+      # the old ALLOWED_ORIGINS name was read by nothing and left CORS wildcard.
+      BACKEND_CORS_ORIGINS: ${BACKEND_CORS_ORIGINS:?BACKEND_CORS_ORIGINS must list explicit staging origin(s) in .env.staging}
       # The backend validates NextAuth JWTs, so it needs the same secret the
       # frontend signs them with (app/auth/nextauth_auth.py).
       NEXTAUTH_SECRET: ${NEXTAUTH_SECRET:?NEXTAUTH_SECRET must be set in .env.staging}
@@ -101,6 +104,9 @@ services:
       GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET}
       GITHUB_ID: ${GITHUB_ID}
       GITHUB_SECRET: ${GITHUB_SECRET}
+      # CORS allowlist for the Next.js page middleware (middleware.ts). Empty ⇒
+      # no cross-origin Origin is echoed (same-origin needs no ACAO).
+      ALLOWED_ORIGINS: ${ALLOWED_ORIGINS}
     depends_on:
       - backend
     healthcheck:

--- a/docs/deployment/PRODUCTION_DEPLOYMENT.md
+++ b/docs/deployment/PRODUCTION_DEPLOYMENT.md
@@ -170,6 +170,10 @@ BACKEND_SECRET_KEY=your_backend_secret_key_64_chars
 # Explicit origin(s) — the backend refuses '*' in production-like envs (credentialed
 # wildcard CORS lets any site make authenticated requests). Comma-separated or JSON array.
 BACKEND_CORS_ORIGINS=https://your-domain.com
+# Frontend Next.js page-middleware CORS allowlist (comma-separated). Leave empty for
+# single-origin deployments (same-origin needs no Access-Control-Allow-Origin); set only
+# if a trusted cross-origin site must call the frontend tier.
+ALLOWED_ORIGINS=https://your-domain.com
 ENVIRONMENT=production
 LOG_LEVEL=info
 

--- a/docs/deployment/PRODUCTION_DEPLOYMENT.md
+++ b/docs/deployment/PRODUCTION_DEPLOYMENT.md
@@ -167,7 +167,9 @@ GITHUB_SECRET=your_github_client_secret
 # ═══════════════════════════════════════
 
 BACKEND_SECRET_KEY=your_backend_secret_key_64_chars
-ALLOWED_ORIGINS=https://your-domain.com
+# Explicit origin(s) — the backend refuses '*' in production-like envs (credentialed
+# wildcard CORS lets any site make authenticated requests). Comma-separated or JSON array.
+BACKEND_CORS_ORIGINS=https://your-domain.com
 ENVIRONMENT=production
 LOG_LEVEL=info
 

--- a/docs/deployment/STAGING_DEPLOYMENT_GUIDE.md
+++ b/docs/deployment/STAGING_DEPLOYMENT_GUIDE.md
@@ -115,7 +115,8 @@ nano .env.staging
 - `NEXTAUTH_SECRET`: Generated secret
 - `NEXT_PUBLIC_API_URL`: https://narrative.yourdomain.com/api/v1 (must include `/api/v1`)
 - `NEXTAUTH_URL`: https://narrative.yourdomain.com
-- `ALLOWED_ORIGINS`: https://narrative.yourdomain.com
+- `BACKEND_CORS_ORIGINS`: https://narrative.yourdomain.com (explicit origin(s); the backend refuses `*` in production-like envs)
+- `ALLOWED_ORIGINS`: https://narrative.yourdomain.com (frontend page-middleware CORS allowlist)
 - Google/GitHub OAuth credentials (if using authentication)
 
 **Save and secure the file**:


### PR DESCRIPTION
Closes #256 (P0.6 · security · high — from the SaaS launch-readiness audit).

## Problem
Staging ran **wildcard credentialed CORS**. `docker-compose.staging.yml` set `ALLOWED_ORIGINS` — a name nothing reads — so the backend fell back to its `BACKEND_CORS_ORIGINS` default of `["*"]`. Because CORS is registered with `allow_credentials=True` (`main.py`), Starlette **reflects the caller's Origin** and emits `Access-Control-Allow-Credentials: true`, letting any website make authenticated cross-origin requests (CSRF-style abuse). The frontend page middleware had the same arbitrary-Origin reflection (`|| '*'`).

## Fix (maps to the 3 acceptance criteria)
- **AC1 — config var rename.** `docker-compose.staging.yml` + `.env.staging.example` now set `BACKEND_CORS_ORIGINS` (backend) to explicit origin(s), with a `${BACKEND_CORS_ORIGINS:?…}` guard so a misconfigured staging deploy fails fast. The frontend service gets `ALLOWED_ORIGINS` for its middleware allowlist.
- **AC2 — config refuses wildcard.** New pure `resolve_cors_origins(raw, environment)` in `config.py` (mirrors the existing `validate_skip_auth` pure-function pattern): parses a JSON array *or* comma-separated list, and **raises** on `["*"]` (explicit or the unset default) in production-like envs → the backend fails to start rather than silently running wildcard CORS. Development/test keep the wildcard default (DX preserved).
- **AC3 — frontend allowlist.** `middleware.ts` replaces the `|| '*'` reflection with an `ALLOWED_ORIGINS` allowlist: the caller's Origin is echoed only when allowlisted, otherwise `Access-Control-Allow-Origin` is omitted (browser blocks the cross-origin read; same-origin needs no ACAO).

## Verification
Demoed the real startup path across environments — staging with no explicit origins **refuses at startup**; explicit origins (comma or JSON) resolve; dev/test keep `["*"]`; production explicitly setting `["*"]` is refused.

- Backend: `tests/test_security/test_cors_config.py` — 15 tests (parsing, prod-like refusal, dev/test allow). ✅
- Frontend: extended `__tests__/middleware.test.ts` — 4 new allowlist tests (echo allowlisted, block off-list, empty allowlist reflects nothing, OPTIONS preflight). ✅
- `ruff` + `mypy app/config.py` clean; `tsc --noEmit` + `eslint middleware.ts` clean; service-free backend security/auth/utils suites green.

## Known limitations
- "Outside development" is implemented as **production-like** (`production`/`prod`/`staging`/`live`/`release`), reusing the repo's existing `is_production_like()` classification. An **unset** environment (local dev) keeps the wildcard default so local DX isn't broken — deployments always set `ENVIRONMENT`, and staging additionally can't start without `BACKEND_CORS_ORIGINS`.
- Malformed values like `BACKEND_CORS_ORIGINS=[https://a.com]` (brackets, unquoted — not valid JSON, not the documented comma format) parse literally; the template documents the two supported formats.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added separate CORS allowlists for backend and frontend cross-origin requests, with clearer staging and production configuration guidance.

* **Bug Fixes**
  * Tightened cross-origin handling so only approved origins are reflected.
  * Prevented wildcard CORS settings in production-like environments.
  * Improved preflight request responses to behave consistently with allowlist rules.

* **Tests**
  * Added coverage for origin parsing, allowlist behavior, and preflight responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->