### PR TITLE
fix(security): bind staging published ports to loopback (#258)

### DIFF
--- a/apps/backend/tests/test_security/test_staging_ports.py
+++ b/apps/backend/tests/test_security/test_staging_ports.py
@@ -1,0 +1,53 @@
+"""Regression guard: staging compose must publish host ports on loopback only.
+
+Issue #258 (P0.8): `ports: "8010:8000"` / `"3011:3000"` / `"6381:6379"` bound
+every published port to 0.0.0.0, so on the shared VPS the API/app/redis were
+reachable over plaintext HTTP at the host IP — bypassing nginx TLS/HSTS/security
+headers (nginx upstreams to 127.0.0.1). Docker's iptables DNAT rules are also
+evaluated before UFW, so a 0.0.0.0 publish leaks even when the firewall doesn't
+`allow` the port. Binding the host side to 127.0.0.1 is the control that holds.
+
+These tests parse the real compose file (not a fixture) so re-exposing any port
+fails the build.
+"""
+
+from pathlib import Path
+
+import yaml
+
+# apps/backend/tests/test_security/ -> repo root
+REPO_ROOT = Path(__file__).resolve().parents[4]
+COMPOSE_FILE = REPO_ROOT / "docker-compose.staging.yml"
+
+
+def _published_ports() -> list[tuple[str, str]]:
+    """Yield (service_name, port_mapping) for every published port."""
+    compose = yaml.safe_load(COMPOSE_FILE.read_text())
+    published = []
+    for name, service in compose.get("services", {}).items():
+        for mapping in service.get("ports", []) or []:
+            published.append((name, str(mapping)))
+    return published
+
+
+def test_compose_file_exists():
+    assert COMPOSE_FILE.is_file(), f"missing {COMPOSE_FILE}"
+
+
+def test_all_published_ports_bind_loopback():
+    ports = _published_ports()
+    assert ports, "expected staging services to publish ports"
+    offenders = [
+        (svc, m) for svc, m in ports if not m.startswith("127.0.0.1:")
+    ]
+    assert not offenders, (
+        "staging published ports must bind to 127.0.0.1 (loopback) so the shared "
+        f"VPS doesn't expose them past nginx: {offenders}"
+    )
+
+
+def test_expected_services_published():
+    """The three host ports nginx/redis rely on are still published."""
+    mappings = {m for _, m in _published_ports()}
+    for expected in ("127.0.0.1:8010:8000", "127.0.0.1:3011:3000", "127.0.0.1:6381:6379"):
+        assert expected in mappings, f"expected published port {expected}, got {mappings}"

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -18,6 +18,14 @@
 #   another app on the shared VPS)
 # - Backend: 8010 (host), proxied via nginx
 # - Redis: 6381 (host port)
+#
+# All published ports bind to 127.0.0.1 ONLY (issue #258). On the shared VPS a
+# 0.0.0.0 bind exposes the API/app/redis over plaintext HTTP at the host IP,
+# bypassing nginx TLS/HSTS/security headers (nginx upstreams to 127.0.0.1). It
+# also leaks past UFW, since Docker's iptables DNAT is evaluated before the
+# firewall — so loopback binding, not `ufw allow`, is the control that holds.
+# nginx (nginx-staging.conf) and deploy.yml's health check reach these via
+# localhost, so loopback binding keeps both working.
 # ═══════════════════════════════════════════════════════════════
 
 services:
@@ -29,7 +37,7 @@ services:
     container_name: narrative-staging-backend
     restart: unless-stopped
     ports:
-      - "8010:8000"  # Custom port to avoid conflicts
+      - "127.0.0.1:8010:8000"  # loopback only — reached via nginx upstream (#258)
     environment:
       # Application
       ENVIRONMENT: staging
@@ -96,7 +104,7 @@ services:
     container_name: narrative-staging-frontend
     restart: unless-stopped
     ports:
-      - "3011:3000"  # Custom port to avoid conflicts (3010 is taken on the shared VPS)
+      - "127.0.0.1:3011:3000"  # loopback only — reached via nginx upstream (#258)
     environment:
       NODE_ENV: production
       NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL}
@@ -133,7 +141,7 @@ services:
     container_name: narrative-staging-redis
     restart: unless-stopped
     ports:
-      - "6381:6379"  # Custom port to avoid conflicts
+      - "127.0.0.1:6381:6379"  # loopback only — redis is internal, never public (#258)
     command: redis-server --requirepass ${REDIS_PASSWORD} --appendonly yes --maxmemory 512mb --maxmemory-policy allkeys-lru
     volumes:
       - redis_data:/data

--- a/docs/deployment/STAGING_DEPLOYMENT_GUIDE.md
+++ b/docs/deployment/STAGING_DEPLOYMENT_GUIDE.md
@@ -230,6 +230,12 @@ ufw status
 # (3011) and backend (8010) on localhost, and Redis (6381) is internal.
 # MongoDB is in Atlas — ensure the server's public IP is in the Atlas
 # project's IP Access List instead.
+#
+# Do NOT `ufw allow` 3011/8010/6381 (issue #258). Those ports are published on
+# 127.0.0.1 only in docker-compose.staging.yml, so they are already unreachable
+# from outside the host. Opening them in UFW would not even help: Docker's
+# iptables DNAT rules are evaluated before UFW, so a public bind leaks past the
+# firewall — loopback binding in compose is the real control.
 
 # Reload firewall
 ufw reload


### PR DESCRIPTION
Closes #258 (P0.8).

## Problem
`docker-compose.staging.yml` published the backend (`8010:8000`), frontend (`3011:3000`), and redis (`6381:6379`) on **`0.0.0.0`**. On the shared VPS that made the API/app/redis reachable over **plaintext HTTP at the host IP**, bypassing nginx TLS/HSTS/security headers (nginx upstreams only to `127.0.0.1`). Docker's iptables `DNAT` rules are also evaluated *before* UFW, so a public bind leaks past the firewall regardless of `ufw allow` rules.

## Fix
Bind all three published ports to `127.0.0.1`:

| service | before | after |
|---|---|---|
| backend | `8010:8000` | `127.0.0.1:8010:8000` |
| frontend | `3011:3000` | `127.0.0.1:3011:3000` |
| redis | `6381:6379` | `127.0.0.1:6381:6379` |

## Acceptance criteria
- [x] **Published ports bound to loopback** — verified via `docker-compose config` rendering `127.0.0.1:8010:8000/tcp`, `127.0.0.1:3011:3000/tcp`, `127.0.0.1:6381:6379/tcp`.
- [x] **nginx still reaches them** — `nginx-staging.conf` already upstreams to `127.0.0.1:8010`/`3011` (unchanged); `deploy.yml`'s post-deploy health check hits `localhost:8010` on the host. Loopback binding keeps both working.
- [x] **Host firewall restricts app ports** — the staging guide (Step 8) already opens no app ports; augmented with *why* loopback binding (not `ufw allow`) is the control, since Docker DNAT bypasses UFW.

## Verification
- New `tests/test_security/test_staging_ports.py` parses the real compose file and fails if any published port re-exposes `0.0.0.0` (RED before fix caught all 3 ports; GREEN after). Mirrors the `test_security/` deploy-config guards added in #256/#257.
- Full `test_security` suite green (104 passed); `docker-compose config` valid.

## Known limitations
- Config/docs-only change; no runtime code path. The regression guard is a static YAML parse, not a live socket test (a live bind test would need Docker in CI).
- Third-party (opencode/codex) review not run for this ~30-line infra diff; escalate with `/code-review ultra <PR#>` if deeper review is wanted.