### PR TITLE
fix(security): invite-only beta allowlist signup gate (#261)

### DIFF
--- a/.env.staging.example
+++ b/.env.staging.example
@@ -99,6 +99,19 @@ GITHUB_ID=REPLACE_WITH_GITHUB_CLIENT_ID
 GITHUB_SECRET=REPLACE_WITH_GITHUB_CLIENT_SECRET
 
 # ═══════════════════════════════════════════════════════════════
+# INVITE-ONLY BETA GATE (#261)
+# ═══════════════════════════════════════════════════════════════
+# Comma-separated allowlist of invitee emails. REQUIRED — compose fails to
+# start if unset. Only these emails may sign in (NextAuth signIn callback +
+# backend mirror); anyone else lands on the "Invite Required" page.
+# To add an invitee: append their email here and re-deploy (or `docker compose
+# up -d` to restart the services so the new value is picked up).
+INVITE_ALLOWLIST=alice@example.com,bob@example.com
+# Optional: where rejected users request access (mailto: or a form URL).
+# Unset ⇒ the error page falls back to a mailto link.
+NEXT_PUBLIC_INVITE_REQUEST_URL=
+
+# ═══════════════════════════════════════════════════════════════
 # SECURITY NOTES
 # ═══════════════════════════════════════════════════════════════
 #

--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -54,3 +54,11 @@ NEXTAUTH_URL=http://localhost:3000
 # explicitly development/test; startup fails hard otherwise. Never enable in
 # staging/production.
 SKIP_AUTH=true
+
+# Invite-only beta gate (issue #261). Comma-separated allowlist of invitee
+# emails; the backend rejects (403) any authenticated request whose token email
+# is not listed — mirroring the NextAuth signIn allowlist (the primary gate).
+# LEAVE EMPTY to disable the gate (dev/test). In staging/production set this to
+# the same value the frontend uses. To add an invitee: append their email and
+# restart. Example: INVITE_ALLOWLIST=alice@example.com,bob@example.com
+INVITE_ALLOWLIST=

--- a/apps/backend/app/auth/nextauth_auth.py
+++ b/apps/backend/app/auth/nextauth_auth.py
@@ -83,8 +83,8 @@ async def get_current_user_id(
             raise HTTPException(status_code=401, detail="Invalid authentication token")
 
         # Invite-only beta gate (issue #261): defense-in-depth mirror of the
-        # NextAuth signIn allowlist. Read fresh each request so an updated
-        # allowlist takes effect without a restart. Enforced only when
+        # NextAuth signIn allowlist. Reads the env directly (a small split on a
+        # short list — negligible per request). Enforced only when
         # INVITE_ALLOWLIST is set; the email claim is minted by the frontend.
         allowlist = parse_invite_allowlist(os.getenv("INVITE_ALLOWLIST"))
         if allowlist and not is_email_allowed(payload.get("email"), allowlist):

--- a/apps/backend/app/auth/nextauth_auth.py
+++ b/apps/backend/app/auth/nextauth_auth.py
@@ -15,7 +15,11 @@ logger = logging.getLogger(__name__)
 # matching app.config — a stray .env must not override production settings)
 load_dotenv()
 
-from app.config import validate_skip_auth  # noqa: E402
+from app.config import (  # noqa: E402
+    is_email_allowed,
+    parse_invite_allowlist,
+    validate_skip_auth,
+)
 
 # Get NextAuth configuration
 NEXTAUTH_SECRET = os.getenv("NEXTAUTH_SECRET")
@@ -77,6 +81,18 @@ async def get_current_user_id(
             # In that case, we'd need to validate with the NextAuth API
             logger.error("No user ID found in token")
             raise HTTPException(status_code=401, detail="Invalid authentication token")
+
+        # Invite-only beta gate (issue #261): defense-in-depth mirror of the
+        # NextAuth signIn allowlist. Read fresh each request so an updated
+        # allowlist takes effect without a restart. Enforced only when
+        # INVITE_ALLOWLIST is set; the email claim is minted by the frontend.
+        allowlist = parse_invite_allowlist(os.getenv("INVITE_ALLOWLIST"))
+        if allowlist and not is_email_allowed(payload.get("email"), allowlist):
+            logger.warning("Invite gate: rejected non-allowlisted user")
+            raise HTTPException(
+                status_code=403,
+                detail="Access is limited to invited beta users.",
+            )
 
         return user_id
 

--- a/apps/backend/app/config.py
+++ b/apps/backend/app/config.py
@@ -150,6 +150,37 @@ def resolve_cors_origins(
     return origins
 
 
+# Invite-only beta gate (issue #261). The primary control is the NextAuth
+# `signIn` callback (frontend), which blocks non-allowlisted users before any
+# session/token is minted. The backend mirrors the same INVITE_ALLOWLIST check
+# in get_current_user_id as defense-in-depth (catches allowlist revocation
+# within the token TTL). Both tiers share these pure helpers' semantics.
+def parse_invite_allowlist(raw: str | None) -> set[str]:
+    """Parse INVITE_ALLOWLIST (comma-separated emails) into a lowercased set.
+
+    Empty/unset ⇒ empty set ⇒ the invite gate is disabled (allow all). Mirrors
+    the frontend `parseAllowlist` so both tiers read one source of truth.
+    """
+    if not raw or not raw.strip():
+        return set()
+    return {e.strip().lower() for e in raw.split(",") if e.strip()}
+
+
+def is_email_allowed(email: str | None, allowlist: set[str]) -> bool:
+    """True if the invite gate admits ``email``.
+
+    An empty allowlist disables the gate (everyone allowed). When active, the
+    email must be listed (case-insensitive); a missing email is rejected — but
+    by construction every admitted user has an email (the signIn gate rejects
+    email-less sign-ins), so this only bites forged/stale tokens.
+    """
+    if not allowlist:
+        return True
+    if not email:
+        return False
+    return email.strip().lower() in allowlist
+
+
 # One logical S3 bucket has historically been read under several env var names
 # (#257): uploads via AWS_BUCKET_NAME/S3_BUCKET_NAME, the download allowlist via
 # AWS_S3_BUCKET, versioning via S3_BUCKET. A deploy that sets only one name left

--- a/apps/backend/scripts/demo_invite_gate_261.py
+++ b/apps/backend/scripts/demo_invite_gate_261.py
@@ -1,0 +1,72 @@
+"""Demo: invite-only beta gate (#261) — exercises the REAL gate end-to-end.
+
+Mints HS256 tokens exactly like the frontend and drives the backend mirror
+(get_current_user_id) with the gate on/off, proving the AC:
+  - a non-allowlisted email is DENIED (403)
+  - an allowlisted email is ADMITTED
+Plus the frontend allowlist semantics via the pure config helpers.
+
+Run: cd apps/backend && PYTHONPATH=. uv run python scripts/demo_invite_gate_261.py
+"""
+
+import asyncio
+import os
+from unittest.mock import patch
+
+from fastapi import HTTPException
+from fastapi.security import HTTPAuthorizationCredentials
+from jose import jwt
+
+from app.config import is_email_allowed, parse_invite_allowlist
+
+SECRET = "demo-secret"
+
+
+def mint(email: str | None) -> HTTPAuthorizationCredentials:
+    claims = {"sub": "user_demo"}
+    if email:
+        claims["email"] = email
+    return HTTPAuthorizationCredentials(
+        scheme="Bearer", credentials=jwt.encode(claims, SECRET, algorithm="HS256")
+    )
+
+
+async def call(cred) -> str:
+    # Import inside so the SKIP_AUTH/secret patches below are in effect.
+    from app.auth.nextauth_auth import get_current_user_id
+
+    return await get_current_user_id(cred)
+
+
+async def main() -> None:
+    print("=== Pure allowlist semantics (shared by both tiers) ===")
+    allow = parse_invite_allowlist(" Alice@Example.com , bob@example.com ")
+    print("parsed allowlist:", sorted(allow))
+    print("  alice admitted (case-insensitive):", is_email_allowed("ALICE@example.com", allow))
+    print("  eve denied:", is_email_allowed("eve@evil.com", allow))
+    print("  empty list disables gate (eve allowed):", is_email_allowed("eve@evil.com", set()))
+
+    with patch("app.auth.nextauth_auth.NEXTAUTH_SECRET", SECRET), patch(
+        "app.auth.nextauth_auth.SKIP_AUTH", False
+    ):
+        print("\n=== Backend mirror: gate ACTIVE (INVITE_ALLOWLIST set) ===")
+        with patch.dict(os.environ, {"INVITE_ALLOWLIST": "alice@example.com"}):
+            uid = await call(mint("alice@example.com"))
+            print(f"  allowlisted alice -> ADMITTED as {uid!r}")
+            for label, email in [("non-allowlisted eve", "eve@evil.com"), ("missing email", None)]:
+                try:
+                    await call(mint(email))
+                    print(f"  {label} -> ADMITTED (UNEXPECTED!)")
+                except HTTPException as e:
+                    print(f"  {label} -> DENIED {e.status_code} {e.detail!r}")
+
+        print("\n=== Backend mirror: gate OFF (INVITE_ALLOWLIST empty) ===")
+        with patch.dict(os.environ, {"INVITE_ALLOWLIST": ""}):
+            uid = await call(mint("eve@evil.com"))
+            print(f"  any signed token -> ADMITTED as {uid!r} (gate disabled)")
+
+    print("\nAll outcomes match the acceptance criteria.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/apps/backend/tests/test_security/test_invite_allowlist.py
+++ b/apps/backend/tests/test_security/test_invite_allowlist.py
@@ -1,0 +1,101 @@
+"""Invite-only beta gate — allowlist config + backend mirror (issue #261).
+
+The launch is a free, invite-only beta but OAuth signup is open by default. The
+primary gate is the NextAuth `signIn` callback (frontend); the backend mirrors
+the same INVITE_ALLOWLIST check in ``get_current_user_id`` as defense-in-depth.
+
+Covers the AC directly: a non-allowlisted email is denied and an allowlisted one
+is admitted — both at the pure-function layer and through the real JWT path.
+"""
+
+from unittest.mock import patch
+
+import pytest
+from fastapi import HTTPException
+from fastapi.security import HTTPAuthorizationCredentials
+from jose import jwt
+
+from app.auth.nextauth_auth import get_current_user_id
+from app.config import is_email_allowed, parse_invite_allowlist
+
+pytestmark = [pytest.mark.unit, pytest.mark.security]
+
+TEST_SECRET = "test-secret"
+
+
+def _bearer(payload: dict) -> HTTPAuthorizationCredentials:
+    token = jwt.encode(payload, TEST_SECRET, algorithm="HS256")
+    return HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
+
+
+class TestParseInviteAllowlist:
+    def test_unset_or_blank_is_empty(self):
+        assert parse_invite_allowlist(None) == set()
+        assert parse_invite_allowlist("") == set()
+        assert parse_invite_allowlist("   ") == set()
+
+    def test_splits_trims_lowercases_drops_blanks(self):
+        assert parse_invite_allowlist(" Alice@Example.com , bob@example.com ,, ") == {
+            "alice@example.com",
+            "bob@example.com",
+        }
+
+
+class TestIsEmailAllowed:
+    LIST = {"alice@example.com", "bob@example.com"}
+
+    def test_admits_listed_email_case_insensitive(self):
+        assert is_email_allowed("alice@example.com", self.LIST) is True
+        assert is_email_allowed("ALICE@Example.com", self.LIST) is True
+
+    def test_denies_unlisted_email(self):
+        assert is_email_allowed("eve@evil.com", self.LIST) is False
+
+    def test_denies_missing_email_when_gate_active(self):
+        assert is_email_allowed(None, self.LIST) is False
+        assert is_email_allowed("", self.LIST) is False
+
+    def test_empty_allowlist_disables_gate(self):
+        assert is_email_allowed("eve@evil.com", set()) is True
+        assert is_email_allowed(None, set()) is True
+
+
+@pytest.fixture
+def auth_enabled():
+    """Real secret, auth on, SKIP_AUTH off (mirrors test_nextauth.py)."""
+    with patch.dict(
+        "os.environ", {"NEXTAUTH_SECRET": TEST_SECRET, "SKIP_AUTH": "false"}, clear=False
+    ):
+        with patch("app.auth.nextauth_auth.NEXTAUTH_SECRET", TEST_SECRET):
+            with patch("app.auth.nextauth_auth.SKIP_AUTH", False):
+                yield
+
+
+class TestBackendMirrorEnforcement:
+    """get_current_user_id enforces INVITE_ALLOWLIST when configured."""
+
+    @pytest.mark.asyncio
+    async def test_allowlisted_email_admitted(self, auth_enabled):
+        with patch.dict("os.environ", {"INVITE_ALLOWLIST": "alice@example.com"}):
+            uid = await get_current_user_id(
+                _bearer({"sub": "user_1", "email": "alice@example.com"})
+            )
+        assert uid == "user_1"
+
+    @pytest.mark.asyncio
+    async def test_non_allowlisted_email_denied_403(self, auth_enabled):
+        with patch.dict("os.environ", {"INVITE_ALLOWLIST": "alice@example.com"}):
+            with pytest.raises(HTTPException) as exc:
+                await get_current_user_id(
+                    _bearer({"sub": "user_2", "email": "eve@evil.com"})
+                )
+        assert exc.value.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_gate_off_when_empty_allows_any_email(self, auth_enabled):
+        # Empty INVITE_ALLOWLIST → gate disabled → any signed token passes.
+        with patch.dict("os.environ", {"INVITE_ALLOWLIST": ""}):
+            uid = await get_current_user_id(
+                _bearer({"sub": "user_3", "email": "eve@evil.com"})
+            )
+        assert uid == "user_3"

--- a/apps/backend/tests/test_security/test_invite_allowlist.py
+++ b/apps/backend/tests/test_security/test_invite_allowlist.py
@@ -92,6 +92,17 @@ class TestBackendMirrorEnforcement:
         assert exc.value.status_code == 403
 
     @pytest.mark.asyncio
+    async def test_no_email_claim_denied_when_gate_active(self, auth_enabled):
+        # A token minted before this PR (no email claim) is rejected while the
+        # gate is active. Intentional/fail-closed: the frontend re-mints an
+        # email-bearing token on the next session read, so the transition
+        # self-heals within the token TTL.
+        with patch.dict("os.environ", {"INVITE_ALLOWLIST": "alice@example.com"}):
+            with pytest.raises(HTTPException) as exc:
+                await get_current_user_id(_bearer({"sub": "user_alice"}))
+        assert exc.value.status_code == 403
+
+    @pytest.mark.asyncio
     async def test_gate_off_when_empty_allows_any_email(self, auth_enabled):
         # Empty INVITE_ALLOWLIST → gate disabled → any signed token passes.
         with patch.dict("os.environ", {"INVITE_ALLOWLIST": ""}):

--- a/apps/frontend/__tests__/app/auth-error.page.test.tsx
+++ b/apps/frontend/__tests__/app/auth-error.page.test.tsx
@@ -21,15 +21,16 @@ describe('AuthErrorPage', () => {
     render(<AuthErrorPage />);
     expect(screen.getByText('Invite Required')).toBeInTheDocument();
     expect(screen.getByText(/invite-only beta/i)).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /request access/i })).toBeInTheDocument();
+    // asChild renders the action as a real <a> (role "link"), not a nested <button>.
+    expect(screen.getByRole('link', { name: /request access/i })).toBeInTheDocument();
   });
 
-  it('shows no Request access button for unrelated errors', () => {
+  it('shows no Request access action for unrelated errors', () => {
     mockError = 'Configuration';
     render(<AuthErrorPage />);
     expect(screen.getByText('Authentication Error')).toBeInTheDocument();
     expect(
-      screen.queryByRole('button', { name: /request access/i }),
+      screen.queryByRole('link', { name: /request access/i }),
     ).not.toBeInTheDocument();
   });
 });

--- a/apps/frontend/__tests__/app/auth-error.page.test.tsx
+++ b/apps/frontend/__tests__/app/auth-error.page.test.tsx
@@ -1,0 +1,35 @@
+/**
+ * Auth error page — invite-only "request access" message (issue #261).
+ *
+ * A rejected sign-in redirects to /auth/error?error=AccessDenied; the page must
+ * show a clear invite-only message and a Request access action (not a generic
+ * error).
+ */
+
+import { render, screen } from '@testing-library/react';
+import AuthErrorPage from '@/app/auth/error/page';
+
+let mockError: string | null = 'AccessDenied';
+
+jest.mock('next/navigation', () => ({
+  useSearchParams: () => ({ get: () => mockError }),
+}));
+
+describe('AuthErrorPage', () => {
+  it('shows an invite-only message and Request access button for AccessDenied', () => {
+    mockError = 'AccessDenied';
+    render(<AuthErrorPage />);
+    expect(screen.getByText('Invite Required')).toBeInTheDocument();
+    expect(screen.getByText(/invite-only beta/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /request access/i })).toBeInTheDocument();
+  });
+
+  it('shows no Request access button for unrelated errors', () => {
+    mockError = 'Configuration';
+    render(<AuthErrorPage />);
+    expect(screen.getByText('Authentication Error')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /request access/i }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/apps/frontend/__tests__/lib/invite-allowlist.test.ts
+++ b/apps/frontend/__tests__/lib/invite-allowlist.test.ts
@@ -5,7 +5,7 @@
  * allowlisted one is admitted, plus the gate-disabled (empty list) default.
  */
 
-import { parseAllowlist, isEmailAllowed } from '@/lib/invite-allowlist';
+import { parseAllowlist, isEmailAllowed, isSignInAllowed } from '@/lib/invite-allowlist';
 
 describe('parseAllowlist', () => {
   it('returns an empty set for unset/empty input', () => {
@@ -46,7 +46,7 @@ describe('isEmailAllowed', () => {
     expect(isEmailAllowed(null, '')).toBe(true);
   });
 
-  it('reads process.env.INVITE_ALLOWLIST by default', () => {
+  it('reads process.env.INVITE_ALLOWLIST by default (email path)', () => {
     const prev = process.env.INVITE_ALLOWLIST;
     process.env.INVITE_ALLOWLIST = 'alice@example.com';
     try {
@@ -56,5 +56,25 @@ describe('isEmailAllowed', () => {
       if (prev === undefined) delete process.env.INVITE_ALLOWLIST;
       else process.env.INVITE_ALLOWLIST = prev;
     }
+  });
+});
+
+describe('isSignInAllowed', () => {
+  const LIST = 'alice@example.com';
+
+  it('checks OAuth sign-ins against the allowlist by email', () => {
+    expect(isSignInAllowed('google', 'alice@example.com', LIST)).toBe(true);
+    expect(isSignInAllowed('github', 'eve@evil.com', LIST)).toBe(false);
+  });
+
+  it('rejects the credentials provider when the gate is active, even with an allowlisted email', () => {
+    // The credentials provider self-attests its email, so an allowlisted value
+    // submitted through it must NOT pass while the gate is on.
+    expect(isSignInAllowed('credentials', 'alice@example.com', LIST)).toBe(false);
+  });
+
+  it('allows the credentials provider when the gate is disabled (dev/test)', () => {
+    expect(isSignInAllowed('credentials', 'test@narrativeml.com', '')).toBe(true);
+    expect(isSignInAllowed('credentials', 'test@narrativeml.com', undefined)).toBe(true);
   });
 });

--- a/apps/frontend/__tests__/lib/invite-allowlist.test.ts
+++ b/apps/frontend/__tests__/lib/invite-allowlist.test.ts
@@ -77,4 +77,10 @@ describe('isSignInAllowed', () => {
     expect(isSignInAllowed('credentials', 'test@narrativeml.com', '')).toBe(true);
     expect(isSignInAllowed('credentials', 'test@narrativeml.com', undefined)).toBe(true);
   });
+
+  it('treats a null/undefined provider as the OAuth (email) path', () => {
+    // NextAuth may call signIn with a null account on some adapter paths.
+    expect(isSignInAllowed(null, 'alice@example.com', LIST)).toBe(true);
+    expect(isSignInAllowed(undefined, 'eve@evil.com', LIST)).toBe(false);
+  });
 });

--- a/apps/frontend/__tests__/lib/invite-allowlist.test.ts
+++ b/apps/frontend/__tests__/lib/invite-allowlist.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Invite-only beta gate — allowlist logic (issue #261).
+ *
+ * Asserts the AC directly: a non-allowlisted email is denied and an
+ * allowlisted one is admitted, plus the gate-disabled (empty list) default.
+ */
+
+import { parseAllowlist, isEmailAllowed } from '@/lib/invite-allowlist';
+
+describe('parseAllowlist', () => {
+  it('returns an empty set for unset/empty input', () => {
+    expect(parseAllowlist(undefined).size).toBe(0);
+    expect(parseAllowlist('').size).toBe(0);
+    expect(parseAllowlist('   ').size).toBe(0);
+  });
+
+  it('splits, trims, lowercases, and drops blanks', () => {
+    const set = parseAllowlist(' Alice@Example.com , bob@example.com ,, ');
+    expect(set.has('alice@example.com')).toBe(true);
+    expect(set.has('bob@example.com')).toBe(true);
+    expect(set.size).toBe(2);
+  });
+});
+
+describe('isEmailAllowed', () => {
+  const LIST = 'alice@example.com, bob@example.com';
+
+  it('admits an allowlisted email (case-insensitive)', () => {
+    expect(isEmailAllowed('alice@example.com', LIST)).toBe(true);
+    expect(isEmailAllowed('ALICE@example.com', LIST)).toBe(true);
+  });
+
+  it('denies a non-allowlisted email', () => {
+    expect(isEmailAllowed('eve@evil.com', LIST)).toBe(false);
+  });
+
+  it('denies a missing email when the gate is active', () => {
+    expect(isEmailAllowed(null, LIST)).toBe(false);
+    expect(isEmailAllowed(undefined, LIST)).toBe(false);
+    expect(isEmailAllowed('', LIST)).toBe(false);
+  });
+
+  it('disables the gate (allows everyone) when the list is empty/unset', () => {
+    expect(isEmailAllowed('eve@evil.com', '')).toBe(true);
+    expect(isEmailAllowed('eve@evil.com', undefined)).toBe(true);
+    expect(isEmailAllowed(null, '')).toBe(true);
+  });
+
+  it('reads process.env.INVITE_ALLOWLIST by default', () => {
+    const prev = process.env.INVITE_ALLOWLIST;
+    process.env.INVITE_ALLOWLIST = 'alice@example.com';
+    try {
+      expect(isEmailAllowed('alice@example.com')).toBe(true);
+      expect(isEmailAllowed('eve@evil.com')).toBe(false);
+    } finally {
+      if (prev === undefined) delete process.env.INVITE_ALLOWLIST;
+      else process.env.INVITE_ALLOWLIST = prev;
+    }
+  });
+});

--- a/apps/frontend/app/auth/error/page.tsx
+++ b/apps/frontend/app/auth/error/page.tsx
@@ -11,9 +11,15 @@ export default function AuthErrorPage() {
   const searchParams = useSearchParams();
   const error = searchParams.get('error');
 
+  // Where rejected users request an invite. Configurable per deploy; falls back
+  // to a mailto so the "request access" path always works (issue #261).
+  const requestAccessUrl =
+    process.env.NEXT_PUBLIC_INVITE_REQUEST_URL ?? 'mailto:beta@narrativeml.com?subject=Beta%20access%20request';
+
   const errorMessages: Record<string, string> = {
     Configuration: 'There is a problem with the server configuration.',
-    AccessDenied: 'You do not have permission to sign in.',
+    AccessDenied:
+      "This is a private, invite-only beta. The email you used isn't on the invite list yet.",
     Verification: 'The verification token has expired or has already been used.',
     OAuthSignin: 'Error in constructing an authorization URL.',
     OAuthCallback: 'Error in handling the response from OAuth provider.',
@@ -36,14 +42,23 @@ export default function AuthErrorPage() {
           <div className="mx-auto mb-4 w-12 h-12 rounded-full bg-red-100 flex items-center justify-center">
             <AlertCircle className="w-6 h-6 text-red-600" />
           </div>
-          <CardTitle className="text-2xl font-bold">Authentication Error</CardTitle>
+          <CardTitle className="text-2xl font-bold">
+            {error === 'AccessDenied' ? 'Invite Required' : 'Authentication Error'}
+          </CardTitle>
           <CardDescription className="text-red-600">
             {errorMessage}
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
+          {error === 'AccessDenied' && (
+            <a href={requestAccessUrl}>
+              <Button className="w-full">
+                Request access
+              </Button>
+            </a>
+          )}
           <Link href="/auth/signin">
-            <Button className="w-full">
+            <Button variant={error === 'AccessDenied' ? 'outline' : 'default'} className="w-full">
               Back to Sign In
             </Button>
           </Link>

--- a/apps/frontend/app/auth/error/page.tsx
+++ b/apps/frontend/app/auth/error/page.tsx
@@ -50,18 +50,20 @@ export default function AuthErrorPage() {
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
+          {/* asChild renders a single <a>/<Link> styled as a button — nesting a
+              real <button> inside an anchor is invalid HTML and breaks a11y. */}
           {error === 'AccessDenied' && (
-            <a href={requestAccessUrl}>
-              <Button className="w-full">
-                Request access
-              </Button>
-            </a>
-          )}
-          <Link href="/auth/signin">
-            <Button variant={error === 'AccessDenied' ? 'outline' : 'default'} className="w-full">
-              Back to Sign In
+            <Button asChild className="w-full">
+              <a href={requestAccessUrl}>Request access</a>
             </Button>
-          </Link>
+          )}
+          <Button
+            asChild
+            variant={error === 'AccessDenied' ? 'outline' : 'default'}
+            className="w-full"
+          >
+            <Link href="/auth/signin">Back to Sign In</Link>
+          </Button>
         </CardContent>
       </Card>
     </div>

--- a/apps/frontend/auth.ts
+++ b/apps/frontend/auth.ts
@@ -7,7 +7,7 @@ import GitHubProvider from "next-auth/providers/github"
 import CredentialsProvider from "next-auth/providers/credentials"
 import client from "./lib/db"
 import { mintApiToken } from "./lib/api-token"
-import { isEmailAllowed } from "./lib/invite-allowlist"
+import { isSignInAllowed } from "./lib/invite-allowlist"
 
 // Development mode flag
 const isDevelopment = process.env.NODE_ENV === 'development'
@@ -105,14 +105,19 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
       }
       return session
     },
-    async signIn({ user }) {
+    async signIn({ user, account }) {
       // Invite-only beta gate (issue #261). Runs server-side in NextAuth, so a
       // rejected user never gets a session or a minted API token — the primary
       // control; the FastAPI backend mirrors it as defense-in-depth. Returning
       // false redirects to /auth/error?error=AccessDenied (see that page for
       // the "request access" message). An empty INVITE_ALLOWLIST disables the
       // gate (dev/test/un-configured deploys).
-      return isEmailAllowed(user?.email)
+      //
+      // The credentials provider self-attests its email and is registered only
+      // in dev/test (see providers above), so it must never satisfy the email
+      // gate: when the allowlist is active, only federated OAuth sign-ins pass.
+      // The test user still signs in locally where INVITE_ALLOWLIST is unset.
+      return isSignInAllowed(account?.provider, user?.email)
     },
   },
   secret: process.env.NEXTAUTH_SECRET,

--- a/apps/frontend/auth.ts
+++ b/apps/frontend/auth.ts
@@ -7,6 +7,7 @@ import GitHubProvider from "next-auth/providers/github"
 import CredentialsProvider from "next-auth/providers/credentials"
 import client from "./lib/db"
 import { mintApiToken } from "./lib/api-token"
+import { isEmailAllowed } from "./lib/invite-allowlist"
 
 // Development mode flag
 const isDevelopment = process.env.NODE_ENV === 'development'
@@ -90,7 +91,11 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
       // must not crash session reads (the backend then returns 401).
       if (token.id) {
         try {
-          session.apiToken = mintApiToken(token.id as string)
+          // Carry the email claim so the backend can mirror the invite gate.
+          session.apiToken = mintApiToken(
+            token.id as string,
+            token.email as string | null | undefined,
+          )
         } catch (err) {
           // Don't crash session reads, but surface the cause — otherwise a
           // misconfigured secret silently 401s every API call with no signal.
@@ -100,10 +105,14 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
       }
       return session
     },
-    async signIn() {
-      // You can add custom logic here if needed
-      // Return true to allow sign in
-      return true
+    async signIn({ user }) {
+      // Invite-only beta gate (issue #261). Runs server-side in NextAuth, so a
+      // rejected user never gets a session or a minted API token — the primary
+      // control; the FastAPI backend mirrors it as defense-in-depth. Returning
+      // false redirects to /auth/error?error=AccessDenied (see that page for
+      // the "request access" message). An empty INVITE_ALLOWLIST disables the
+      // gate (dev/test/un-configured deploys).
+      return isEmailAllowed(user?.email)
     },
   },
   secret: process.env.NEXTAUTH_SECRET,

--- a/apps/frontend/lib/api-token.ts
+++ b/apps/frontend/lib/api-token.ts
@@ -20,17 +20,24 @@ function base64url(input: string): string {
  *
  * Runs only in the Node runtime (the NextAuth config is Node-only via the
  * MongoDB adapter), so `node:crypto` is available — no extra dependency.
+ *
+ * The optional `email` claim lets the backend mirror the invite-only allowlist
+ * gate (issue #261) as defense-in-depth; omitted when the user has no email.
  */
-export function mintApiToken(userId: string): string {
+export function mintApiToken(userId: string, email?: string | null): string {
   const secret = process.env.NEXTAUTH_SECRET;
   if (!secret) {
     throw new Error('NEXTAUTH_SECRET is not set; cannot mint API token');
   }
   const now = Math.floor(Date.now() / 1000);
   const header = base64url(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
-  const payload = base64url(
-    JSON.stringify({ sub: userId, iat: now, exp: now + API_TOKEN_TTL_SECONDS }),
-  );
+  const claims: Record<string, unknown> = {
+    sub: userId,
+    iat: now,
+    exp: now + API_TOKEN_TTL_SECONDS,
+  };
+  if (email) claims.email = email;
+  const payload = base64url(JSON.stringify(claims));
   const signingInput = `${header}.${payload}`;
   const signature = createHmac('sha256', secret).update(signingInput).digest('base64url');
   return `${signingInput}.${signature}`;

--- a/apps/frontend/lib/invite-allowlist.ts
+++ b/apps/frontend/lib/invite-allowlist.ts
@@ -1,0 +1,45 @@
+// frontend/lib/invite-allowlist.ts
+//
+// Invite-only beta gate (issue #261).
+//
+// The launch is a free, invite-only beta, but OAuth signup is open by default —
+// anyone with a Google/GitHub account could sign in and consume unbounded
+// compute (AutoML, SHAP, batch prediction). This restricts sign-in to an
+// env-configured email allowlist (`INVITE_ALLOWLIST`, comma-separated). The
+// FastAPI backend reads the same var and mirrors this check as defense-in-depth
+// (app/config.py / app/auth/nextauth_auth.py).
+//
+// An EMPTY / unset list DISABLES the gate (allow all) so local dev, tests, and
+// any not-yet-configured deploy keep working. Production fail-closed is enforced
+// at the deploy layer: staging compose requires INVITE_ALLOWLIST via `${VAR:?}`
+// (same pattern as the CORS/S3 deploy guards, issues #256/#257).
+
+/** Parse a comma-separated allowlist into a lowercased, trimmed set of emails. */
+export function parseAllowlist(raw: string | undefined | null): Set<string> {
+  if (!raw) return new Set();
+  return new Set(
+    raw
+      .split(',')
+      .map((e) => e.trim().toLowerCase())
+      .filter(Boolean),
+  );
+}
+
+/**
+ * True if `email` may sign in.
+ *
+ * An empty allowlist means the gate is disabled — everyone is allowed. When the
+ * gate is active, the email must be present on the list (case-insensitive); a
+ * missing email is rejected.
+ *
+ * @param raw defaults to `process.env.INVITE_ALLOWLIST` (injectable for tests).
+ */
+export function isEmailAllowed(
+  email: string | null | undefined,
+  raw: string | undefined | null = process.env.INVITE_ALLOWLIST,
+): boolean {
+  const allowlist = parseAllowlist(raw);
+  if (allowlist.size === 0) return true; // gate disabled
+  if (!email) return false;
+  return allowlist.has(email.trim().toLowerCase());
+}

--- a/apps/frontend/lib/invite-allowlist.ts
+++ b/apps/frontend/lib/invite-allowlist.ts
@@ -43,3 +43,22 @@ export function isEmailAllowed(
   if (!email) return false;
   return allowlist.has(email.trim().toLowerCase());
 }
+
+/**
+ * Decide whether a sign-in attempt passes the invite gate.
+ *
+ * The credentials provider (registered only in dev/test) self-attests its
+ * email, so it must never satisfy the email gate — it may pass only when the
+ * gate is disabled (empty allowlist). Federated OAuth providers are checked
+ * against the allowlist by their attested email.
+ *
+ * @param raw defaults to `process.env.INVITE_ALLOWLIST` (injectable for tests).
+ */
+export function isSignInAllowed(
+  provider: string | null | undefined,
+  email: string | null | undefined,
+  raw: string | undefined | null = process.env.INVITE_ALLOWLIST,
+): boolean {
+  if (provider === 'credentials') return isEmailAllowed(null, raw);
+  return isEmailAllowed(email, raw);
+}

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -78,6 +78,11 @@ services:
       # The backend validates NextAuth JWTs, so it needs the same secret the
       # frontend signs them with (app/auth/nextauth_auth.py).
       NEXTAUTH_SECRET: ${NEXTAUTH_SECRET:?NEXTAUTH_SECRET must be set in .env.staging}
+      # Invite-only beta gate (#261): comma-separated allowlist of invitee
+      # emails. Required for staging — an empty value disables the gate, which
+      # would leave the "invite-only" beta open to any Google/GitHub account.
+      # The frontend signIn callback is the primary gate; the backend mirrors it.
+      INVITE_ALLOWLIST: ${INVITE_ALLOWLIST:?INVITE_ALLOWLIST (comma-separated invitee emails) must be set in .env.staging}
     volumes:
       - backend_logs:/app/logs
     depends_on:
@@ -117,6 +122,12 @@ services:
       # host arrives via X-Forwarded-Host, so it must be trusted explicitly.
       AUTH_TRUST_HOST: "true"
       NEXTAUTH_SECRET: ${NEXTAUTH_SECRET}
+      # Invite-only beta gate (#261) — same allowlist the backend mirrors. The
+      # NextAuth signIn callback (auth.ts) rejects non-listed emails here.
+      INVITE_ALLOWLIST: ${INVITE_ALLOWLIST:?INVITE_ALLOWLIST (comma-separated invitee emails) must be set in .env.staging}
+      # Optional: where rejected users are pointed to request access (mailto or
+      # a form URL). Defaults to a mailto in the error page when unset.
+      NEXT_PUBLIC_INVITE_REQUEST_URL: ${NEXT_PUBLIC_INVITE_REQUEST_URL:-}
       GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID}
       GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET}
       GITHUB_ID: ${GITHUB_ID}

--- a/docs/deployment/STAGING_DEPLOYMENT_GUIDE.md
+++ b/docs/deployment/STAGING_DEPLOYMENT_GUIDE.md
@@ -117,6 +117,7 @@ nano .env.staging
 - `NEXTAUTH_URL`: https://narrative.yourdomain.com
 - `BACKEND_CORS_ORIGINS`: https://narrative.yourdomain.com (explicit origin(s); the backend refuses `*` in production-like envs)
 - `ALLOWED_ORIGINS`: https://narrative.yourdomain.com (frontend page-middleware CORS allowlist)
+- `INVITE_ALLOWLIST`: comma-separated invitee emails (**required** — the invite-only beta gate; compose refuses to start if unset). See [Managing beta invitees](#managing-beta-invitees).
 - Google/GitHub OAuth credentials (if using authentication)
 
 **Save and secure the file**:
@@ -416,10 +417,47 @@ docker compose -f docker-compose.staging.yml --env-file .env.staging ps
 
 ---
 
+## Managing beta invitees
+
+The launch is a **free, invite-only beta**. Signup is gated by an email
+allowlist (issue #261) — OAuth is open to any Google/GitHub account, so without
+this gate anyone could sign in and consume compute.
+
+**How it works:**
+- `INVITE_ALLOWLIST` is a comma-separated list of invitee emails, shared by the
+  frontend and backend services (see `docker-compose.staging.yml`).
+- The **NextAuth `signIn` callback** (`apps/frontend/auth.ts`) is the primary
+  gate: a non-listed email never gets a session — they land on the
+  **"Invite Required"** page (`/auth/error?error=AccessDenied`) with a
+  *Request access* button.
+- The **FastAPI backend** (`app/auth/nextauth_auth.py`) mirrors the check and
+  returns **403** for any authenticated request whose token email isn't listed
+  (defense-in-depth; catches revocation within the ~1h token TTL).
+- An **empty** `INVITE_ALLOWLIST` disables the gate. Staging compose therefore
+  **fails to start** if it's unset (`${INVITE_ALLOWLIST:?...}`).
+
+**To add an invitee:**
+1. Edit `.env.staging` and append the email to `INVITE_ALLOWLIST`
+   (e.g. `INVITE_ALLOWLIST=alice@example.com,bob@example.com,carol@example.com`).
+2. Re-apply so both services pick up the new value:
+   ```bash
+   docker compose -f docker-compose.staging.yml up -d
+   ```
+   (No rebuild needed — it's a runtime env var.)
+
+**To revoke access:** remove the email and `up -d`. Any live token for that user
+stops working within the token TTL (≤1h) via the backend mirror.
+
+**Optional:** set `NEXT_PUBLIC_INVITE_REQUEST_URL` to a form/mailto link for the
+*Request access* button (defaults to a mailto when unset).
+
+---
+
 ## Security Checklist
 
 Post-deployment security verification:
 
+- [ ] `INVITE_ALLOWLIST` set to the intended beta cohort (both services)
 - [ ] All services running with authentication enabled
 - [ ] Atlas IP Access List restricted to the staging server (no 0.0.0.0/0)
 - [ ] Redis requires password

--- a/docs/deployment/STAGING_DEPLOYMENT_GUIDE.md
+++ b/docs/deployment/STAGING_DEPLOYMENT_GUIDE.md
@@ -445,8 +445,17 @@ this gate anyone could sign in and consume compute.
    ```
    (No rebuild needed — it's a runtime env var.)
 
-**To revoke access:** remove the email and `up -d`. Any live token for that user
-stops working within the token TTL (≤1h) via the backend mirror.
+**To revoke access:** remove the email and `up -d`. Any live *session* token for
+that user stops working within the token TTL (≤1h) via the backend mirror.
+
+> **Scope note (defense-in-depth):** the backend mirror covers session-authed
+> routes (`get_current_user_id`). Production model-serving routes authenticate
+> with an **API key** (`X-API-Key`, `verify_api_key`) and are *not* re-checked
+> against `INVITE_ALLOWLIST`. This is safe for the beta because API keys can only
+> be created by an already-invited user, so an outsider can never mint one. If
+> you de-allowlist a user who already holds an API key, revoke their key
+> explicitly (`DELETE /api/v1/production/api-keys/{id}`) — the allowlist alone
+> won't disable it. The primary `signIn` gate remains the load-bearing control.
 
 **Optional:** set `NEXT_PUBLIC_INVITE_REQUEST_URL` to a form/mailto link for the
 *Request access* button (defaults to a mailto when unset).

--- a/docs/deployment/STAGING_DEPLOYMENT_GUIDE.md
+++ b/docs/deployment/STAGING_DEPLOYMENT_GUIDE.md
@@ -436,6 +436,12 @@ this gate anyone could sign in and consume compute.
 - An **empty** `INVITE_ALLOWLIST` disables the gate. Staging compose therefore
   **fails to start** if it's unset (`${INVITE_ALLOWLIST:?...}`).
 
+> **First activation:** when the gate is first enabled (or on this feature's
+> initial deploy), every *active* session must refresh its token before it
+> carries the `email` claim the backend mirror checks — so **all** existing
+> sessions (not just un-invited ones) will re-auth within the token TTL (≤1h).
+> Expected and self-healing; no action needed.
+
 **To add an invitee:**
 1. Edit `.env.staging` and append the email to `INVITE_ALLOWLIST`
    (e.g. `INVITE_ALLOWLIST=alice@example.com,bob@example.com,carol@example.com`).

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,48 +1,28 @@
-# Issue #255 [P0.5] — MCP server cannot start; its single tool is incompatible with real datasets
+# Issue #261 (P0.11) — Invite allowlist signup gate
 
-**Plan source:** self-authored (no plan comment on the issue). No architectural fork → proceeding autonomously.
+**Plan source:** self-authored (no plan comment). No architectural fork → proceeding autonomously.
 
-## Findings (state vs. acceptance criteria)
+**Goal:** Restrict the invite-only beta so only allowlisted emails can sign in / consume compute.
 
-Much of this issue's hardening already landed in #254 (ownership checks, bucket-pinned
-S3 parsing, temp cleanup in `finally`, generic errors). Verified live:
-- `import main` fails today with `PackageNotFoundError: No package metadata was found for fastmcp` (vendored copy) → server can't start.
-- `mcp.server.fastmcp.FastMCP` (SDK, locked 1.25.0) is a drop-in: `.tool()` accepts the pydantic-model param, `sse_app()` returns a Starlette app.
+## Design decision
+- **Env allowlist** (`INVITE_ALLOWLIST`, comma-separated emails), NOT a Mongo `Invite` collection.
+  AC permits either; env list is sufficient for a small beta cohort and far less code. (YAGNI)
+- **Gate off when the var is empty** (preserves dev/test + un-configured deploys) — fail-closed is
+  enforced at the *deploy* layer via `${INVITE_ALLOWLIST:?}` in staging compose, mirroring #256/#257.
 
-## Steps
+## Steps (TDD)
+1. **Frontend** `lib/invite-allowlist.ts` — pure `isEmailAllowed(email)` (case-insensitive, trimmed;
+   empty list ⇒ allow). Test: `__tests__/lib/invite-allowlist.test.ts`.
+2. **Frontend** `auth.ts` `signIn` callback → `isEmailAllowed(user.email)`; `mintApiToken(userId, email)`
+   carries the email claim for the backend mirror.
+3. **Frontend** `app/auth/error/page.tsx` — clear invite-only "request access" message for `AccessDenied`.
+4. **Backend** `config.py` — pure `parse_invite_allowlist(raw)` + `is_email_allowed(email, allowlist)`.
+   Test: `tests/test_security/test_invite_allowlist.py`.
+5. **Backend** `nextauth_auth.py` `get_current_user_id` — when allowlist set AND token has `email`,
+   403 if not allowed (defense-in-depth; absent email falls through — signIn is the real gate).
+   Test: extend `tests/test_auth/test_nextauth.py`.
+6. **Docs/config** — `.env` examples, staging compose `${INVITE_ALLOWLIST:?}` guard,
+   and a "How to add invitees" section in the deployment guide.
 
-- [ ] **1. Fix startup import (AC1).** `main.py`: drop the `sys.path.insert(... fastmcp/src)` +
-  `from fastmcp.server.server import FastMCP`; use `from mcp.server.fastmcp import FastMCP`.
-  Delete the vendored `fastmcp/` dir (143 tracked files) — no longer imported.
-  `pyproject.toml`: bump `mcp>=1.6.0` → `mcp>=1.25.0`.
-- [ ] **2. Offload blocking calls (AC4).** `tools/eda_summary.py`: run the blocking
-  S3 download + `pd.read_csv` + pandas analysis via `asyncio.to_thread` so the async
-  handler doesn't block the event loop. Keep temp cleanup in the async `finally`.
-- [ ] **3. Deslop dead/stale code (AC6 "correct or implement").** Delete dead
-  `tool_runner.py` (calls nonexistent `eda_summary.run`, imported nowhere) and the empty
-  stubs `tools/model_train.py`, `tools/null_analysis.py`. Fix `render.yaml`
-  (Poetry + `pip install -e ./fastmcp` → `python main.py`, no vendored install).
-- [ ] **4. Tests (AC5).** Non-mocked temp-file cleanup test (real file removed on success
-  *and* on read failure) in `tests/test_tools/`; subprocess smoke test that `main` imports
-  (proves the server can start). URL-parse tests already exist and are non-mocked.
-- [ ] **5. Docs (AC6).** Rewrite `README.md` to reality: single `eda_summary_tool`, entry
-  point `main.py` (not `server.py`), actual dir layout, real run command; remove the ~9
-  advertised-but-nonexistent tools and the vendored-fastmcp doc link. Update root
-  `CLAUDE.md` MCP-setup snippet (`server.py` → `main.py`) and the `### MCP Server` note
-  (startability fixed).
-
-## Acceptance criteria checklist
-
-- [ ] Import `FastMCP` from `mcp.server.fastmcp`; vendored copy dropped (AC1)
-- [ ] Reuses a hardened S3 URL parser (AC2 — satisfied by #254's `parse_and_validate_s3_url`, a superset of the backend's `parse_s3_url`; kept local since the apps aren't linked)
-- [ ] Temp files cleaned up in `finally` (AC3 — done in #254; preserved)
-- [ ] Blocking calls offloaded via `asyncio.to_thread` (AC4)
-- [ ] Non-mocked URL-parse + cleanup tests (AC5)
-- [ ] README/CLAUDE.md corrected (AC6)
-
-## Deviations / decisions (autonomous)
-
-- **Keep MCP-local `parse_and_validate_s3_url`** rather than importing the backend's
-  `parse_s3_url`: the MCP app is standalone (backend isn't a dependency), and the local
-  parser is a strict superset (adds bucket allowlisting). Reusing it satisfies AC2's intent.
-- **Drop, not fix, the vendored fastmcp** (AC allows either) — lazy + correct.
+## Non-goals
+- No Mongo Invite collection / CRUD UI. No self-serve request-access form (message + email link only).


### PR DESCRIPTION
Closes #261 (P0.11).

## Problem
The launch is a *free, invite-only beta*, but OAuth signup is open — any Google/GitHub account could sign in and consume unbounded compute (AutoML, SHAP, batch prediction). No allowlist or invite gate existed.

## Change
Restrict sign-in to an env-configured email allowlist (`INVITE_ALLOWLIST`, comma-separated). **Empty ⇒ gate disabled** (dev/test/un-configured); fail-closed is enforced at the deploy layer via `${INVITE_ALLOWLIST:?}` in staging compose (mirrors the CORS/S3 deploy guards, #256/#257).

**Primary gate — NextAuth `signIn` callback** (`apps/frontend/auth.ts`): runs server-side, so a rejected user never gets a session or a minted token. Non-listed emails redirect to a new **"Invite Required"** page with a *Request access* button.

**Server-side mirror (defense-in-depth)** — `get_current_user_id` (`apps/backend/app/auth/nextauth_auth.py`): the frontend now mints an `email` claim into the API token; the backend returns **403** for any session-authed request whose token email isn't allowlisted (catches allowlist revocation within the ≤1h token TTL).

Pure, shared-semantics helpers on both tiers: `isEmailAllowed`/`isSignInAllowed` (frontend), `parse_invite_allowlist`/`is_email_allowed` (backend `config.py`).

## Acceptance criteria
- ✅ Gate in `signIn` callback + server-side mirror, rejecting non-allowlisted emails (env list).
- ✅ Rejected users get a clear invite-only "request access" message (not a generic error).
- ✅ Tests: non-allowlisted denied + allowlisted admitted — on **both** tiers (`test_invite_allowlist.py`, `invite-allowlist.test.ts`) plus error-page render.
- ✅ Documented how to add invitees — "Managing beta invitees" in `STAGING_DEPLOYMENT_GUIDE.md` + env examples.

## Demo (outcome evidence)
`apps/backend/scripts/demo_invite_gate_261.py` drives the real gate end-to-end:
```
=== Backend mirror: gate ACTIVE (INVITE_ALLOWLIST set) ===
  allowlisted alice -> ADMITTED as 'user_demo'
  non-allowlisted eve -> DENIED 403 'Access is limited to invited beta users.'
  missing email -> DENIED 403 'Access is limited to invited beta users.'
=== Backend mirror: gate OFF (INVITE_ALLOWLIST empty) ===
  any signed token -> ADMITTED as 'user_demo' (gate disabled)
```

## Design decision
Env allowlist, **not** a Mongo `Invite` collection. The AC permits either; an env list is sufficient for a small beta cohort and far less code (no model/CRUD/UI). (YAGNI)

## Cross-family review (opencode / GLM)
- **Credentials-provider bypass (Major):** the credentials provider is dev/test-only, but hardened anyway — `isSignInAllowed` refuses credentials whenever the gate is active (an allowlisted email can't be replayed through the self-attested credentials path); dev/test E2E still works because the gate is off there.
- **`emailVerified` check (declined):** `user.emailVerified` is unset at `signIn` for new OAuth users (`createUser` runs *after* the callback), so requiring it would block **all** legitimate sign-ins; Google/GitHub already guarantee email ownership before it's usable.
- **API-key routes (Medium, documented):** the production serving routes authenticate via `verify_api_key`, not `get_current_user_id`, so they're outside the mirror. Keys are minted only by already-invited users, so an outsider can't create one — documented as an explicit scope boundary (revoke keys explicitly on de-invite).

## Known limitations
- API-key serving routes aren't re-checked against the allowlist (see above).
- Backend revocation window = the token TTL (≤1h).
- No self-serve request-access form (message + configurable mailto/URL only).

## Tests
- Frontend: `__tests__/lib/invite-allowlist.test.ts`, `__tests__/app/auth-error.page.test.tsx` — 15 passing; `type-check` + `eslint` clean.
- Backend: `tests/test_security/test_invite_allowlist.py` (pure helpers + real-JWT auth enforcement); full `test_auth/` + `test_security/` (164) green; `ruff` + `mypy` clean.
