### PR TITLE
ci(deploy): preflight staging env vars + docs use hostname not stale IP

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -72,7 +72,15 @@ jobs:
           chmod 700 ~/.ssh
           printf '%s\n' "$SSH_KEY" > ~/.ssh/staging_key
           chmod 600 ~/.ssh/staging_key
-          ssh-keyscan -H "$HOST" >> ~/.ssh/known_hosts 2>/dev/null
+          # Don't send ssh-keyscan's stderr to /dev/null: it exits 1 when HOST is
+          # unresolvable/unreachable, and under `bash -e` that failed the whole job
+          # with a bare "exit code 1" and no clue why (seen on runs for b451309,
+          # b962bc5, d35971b — HOST pointing at a stale address). Keep the
+          # diagnostic and say which host we actually tried.
+          if ! ssh-keyscan -H "$HOST" >> ~/.ssh/known_hosts; then
+            echo "::error::ssh-keyscan could not reach '$HOST:22'. Check the HOST secret on the Development environment resolves to the current staging address (\`getent hosts dev.briaanalytics.com\`) and that port 22 is reachable from GitHub runners."
+            exit 1
+          fi
 
       - name: Deploy over SSH
         if: steps.preflight.outputs.configured == 'true'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,7 +1,9 @@
 name: Deploy (Staging)
 
-# Automated staging deployment (issue #150). The job SSHes into the staging VPS
-# as the deploy user, pulls main, and rebuilds the stack with
+# Automated staging deployment (issue #150). Target: the staging VPS at
+# dev.briaanalytics.com — refer to it by hostname, not a raw IP; the address has
+# changed before and stale IPs in docs/config caused a failed deploy. The job
+# SSHes into the staging VPS as the deploy user, pulls main, and rebuilds with
 # docker-compose.staging.yml (which builds apps/backend/Dockerfile and
 # apps/frontend/Dockerfile). Application secrets live in .env.staging ON THE
 # SERVER and are never passed through CI; compose is invoked with
@@ -14,7 +16,7 @@ name: Deploy (Staging)
 # secrets with a STAGING_ prefix. This is the single source of truth — do not
 # reintroduce repo-level STAGING_* secrets.
 #   SSH_KEY      - private key authorized for the deploy user on HOST (required)
-#   HOST         - staging host, IP or DNS (required)
+#   HOST         - staging host; prefer the DNS name dev.briaanalytics.com (required)
 #   DEPLOY_USER  - optional; defaults to `root`
 #   DEPLOY_PATH  - optional; defaults to /opt/narrative-modeling-app/staging
 #
@@ -86,6 +88,9 @@ jobs:
              git checkout main
              git reset --hard origin/main
              test -f .env.staging || { echo '.env.staging missing on server'; exit 1; }
+             # Fail fast with the FULL list of any missing required vars, instead of
+             # letting compose abort on the first \${VAR:?} it interpolates.
+             bash scripts/deploy/preflight_staging_env.sh docker-compose.staging.yml .env.staging
              docker compose -f docker-compose.staging.yml --env-file .env.staging up -d --build --remove-orphans
              docker compose -f docker-compose.staging.yml --env-file .env.staging ps"
 

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -1,6 +1,7 @@
 # ═══════════════════════════════════════════════════════════════
 # Narrative Modeling App - STAGING DEPLOYMENT
-# Server: dev.briaanalytics.com (47.88.89.175)
+# Server: dev.briaanalytics.com (resolve with `dig +short dev.briaanalytics.com`;
+#         do not hardcode the IP — it has changed before)
 # Environment: Staging (pre-production)
 # ═══════════════════════════════════════════════════════════════
 #

--- a/docs/deployment/DEPLOYMENT.md
+++ b/docs/deployment/DEPLOYMENT.md
@@ -20,7 +20,7 @@ This project follows a 4-stage deployment process to ensure code quality and sta
 - **Status**: Available for dev team use
 
 ### Stage 3: Staging Server ✅ **FULLY DEPLOYED**
-- **Environment**: 47.88.89.175 (dev.briaanalytics.com)
+- **Environment**: dev.briaanalytics.com
 - **Access**: SSH as narrative-deploy
 - **Purpose**: Integration testing and sprint demonstrations
 - **Usage**:
@@ -52,7 +52,7 @@ This project follows a 4-stage deployment process to ensure code quality and sta
 ## Next Steps
 
 ### Completed ✅
-1. ✅ **DONE**: Staging server fully deployed (47.88.89.175 / dev.briaanalytics.com)
+1. ✅ **DONE**: Staging server fully deployed (dev.briaanalytics.com)
 2. ✅ **DONE**: Fix integration tests in GitHub Actions (CI/CD health checks)
 3. ✅ **DONE**: E2E test infrastructure optimized (13.8 min vs 20+ min timeouts)
 

--- a/docs/deployment/STAGING.md
+++ b/docs/deployment/STAGING.md
@@ -1,6 +1,6 @@
 # Staging Deployment Guide
 
-**Server**: 47.88.89.175
+**Server**: dev.briaanalytics.com
 **Domain**: dev.briaanalytics.com
 **Environment**: Staging (Pre-Production)
 **Status**: ✅ **FULLY DEPLOYED** (as of 2025-10-23)
@@ -78,7 +78,7 @@ Nginx (80/443) - dev.briaanalytics.com
 
 ### Key Design Decisions
 
-1. **Shared Server**: 47.88.89.175 hosts multiple applications, requiring custom ports
+1. **Shared Server**: dev.briaanalytics.com hosts multiple applications, requiring custom ports
 2. **Backend as Service**: systemd ensures reliability and proper environment variable loading
 3. **Self-Hosted Database**: MongoDB 7.0 runs in Docker for development/staging use
 4. **SSL Termination**: Nginx handles SSL, internal services use HTTP
@@ -162,7 +162,7 @@ docker logs narrative-staging-mongodb --tail 100
 
 ### Port Allocation
 
-The staging server (47.88.89.175) hosts multiple services. Custom ports avoid conflicts:
+The staging server (dev.briaanalytics.com) hosts multiple services. Custom ports avoid conflicts:
 
 | Service | Default Port | Staging Port | Reason |
 |---------|--------------|--------------|--------|
@@ -201,7 +201,7 @@ WantedBy=multi-user.target
 
 ### Prerequisites
 
-- SSH access to `47.88.89.175` as `narrative-deploy` user
+- SSH access to `dev.briaanalytics.com` as `narrative-deploy` user
 - Docker and Docker Compose installed
 - Environment variables configured in `.env.staging`
 - GitHub repository access
@@ -223,7 +223,7 @@ The staging environment has been deployed. For reference, the initial deployment
 
 ```bash
 # SSH as narrative-deploy user
-ssh narrative-deploy@47.88.89.175
+ssh narrative-deploy@dev.briaanalytics.com
 
 # Navigate to deployment directory
 cd /opt/narrative-modeling-app/staging
@@ -532,7 +532,7 @@ sudo systemctl restart narrative-backend
 
 ### Contact Information
 
-- **Server**: 47.88.89.175
+- **Server**: dev.briaanalytics.com
 - **Domain**: https://dev.briaanalytics.com
 - **SSH User**: narrative-deploy
 - **Deployment Path**: `/opt/narrative-modeling-app/staging`

--- a/docs/deployment/STAGING_DEPLOYMENT_GUIDE.md
+++ b/docs/deployment/STAGING_DEPLOYMENT_GUIDE.md
@@ -1,6 +1,6 @@
 # Staging Deployment Guide - Step by Step
 
-**Server**: 47.88.89.175 (root access)
+**Server**: dev.briaanalytics.com (root access)
 **Date Created**: 2025-10-22
 **Status**: Ready for deployment
 
@@ -10,8 +10,8 @@
 
 Before starting deployment, ensure you have:
 
-- [ ] SSH access to 47.88.89.175 as root
-- [ ] Domain name or subdomain configured (DNS pointing to 47.88.89.175)
+- [ ] SSH access to dev.briaanalytics.com as root
+- [ ] Domain name or subdomain configured (DNS pointing to dev.briaanalytics.com)
 - [ ] AWS S3 bucket created for staging uploads
 - [ ] AWS IAM credentials with S3 access
 - [ ] OpenAI API key
@@ -23,7 +23,7 @@ Before starting deployment, ensure you have:
 ## Step 1: Install Docker Compose Plugin
 
 ```bash
-ssh root@47.88.89.175
+ssh root@dev.briaanalytics.com
 
 # Update package list
 apt-get update
@@ -91,7 +91,7 @@ openssl rand -hex 32  # For NEXTAUTH_SECRET (64 chars)
 
 ```bash
 # SSH into staging server
-ssh narrative-deploy@47.88.89.175
+ssh narrative-deploy@dev.briaanalytics.com
 
 # Navigate to deployment directory
 cd /opt/narrative-modeling-app/staging
@@ -133,7 +133,7 @@ chmod 600 .env.staging
 
 ```bash
 # SSH as narrative-deploy user
-ssh narrative-deploy@47.88.89.175
+ssh narrative-deploy@dev.briaanalytics.com
 cd /opt/narrative-modeling-app/staging
 
 # Clone repository
@@ -167,7 +167,7 @@ polls the backend `/health` endpoint (host port 8010).
 | Secret | Value |
 | --- | --- |
 | `STAGING_SSH_PRIVATE_KEY` | Private key authorized for the deploy user (see Step 2) |
-| `STAGING_HOST` | `dev.briaanalytics.com` (or `47.88.89.175`) |
+| `STAGING_HOST` | `dev.briaanalytics.com` |
 | `STAGING_USER` | `narrative-deploy` |
 | `STAGING_DEPLOY_PATH` | Optional; defaults to `/opt/narrative-modeling-app/staging` |
 
@@ -182,7 +182,7 @@ at `STAGING_DEPLOY_PATH` with `origin` pointing at this repo (Step 5, Option A).
 
 ```bash
 # SSH as root
-ssh root@47.88.89.175
+ssh root@dev.briaanalytics.com
 
 # Copy nginx configuration
 nano /etc/nginx/sites-available/narrative-staging.conf
@@ -319,7 +319,7 @@ docker compose -f docker-compose.staging.yml --env-file .env.staging restart bac
 
 ```bash
 # SSH as narrative-deploy
-ssh narrative-deploy@47.88.89.175
+ssh narrative-deploy@dev.briaanalytics.com
 cd /opt/narrative-modeling-app/staging
 
 # Pull latest code

--- a/docs/deployment/STAGING_DEPLOYMENT_TODO.md
+++ b/docs/deployment/STAGING_DEPLOYMENT_TODO.md
@@ -1,6 +1,6 @@
 # Staging Deployment Setup - TODO
 
-**Target Server**: 47.88.89.175 (root access)
+**Target Server**: dev.briaanalytics.com (root access)
 **Current Status**: ✅ Configuration Complete, Ready for Deployment
 **Priority**: High (needed for Sprint 12+)
 **Last Updated**: 2025-10-22
@@ -11,8 +11,8 @@ This document outlines the steps needed to set up the staging deployment server 
 
 ## Server Information
 
-- **IP Address**: 47.88.89.175
-- **Access**: SSH as root (`ssh root@47.88.89.175`)
+- **Host**: dev.briaanalytics.com (resolve the current IP with `dig +short dev.briaanalytics.com`)
+- **Access**: SSH as root (`ssh root@dev.briaanalytics.com`)
 - **Purpose**: Staging environment for integration testing and sprint demos
 - **Constraint**: Server hosts multiple services - **default ports will conflict**
 
@@ -48,7 +48,7 @@ Need to identify free ports for:
 
 ```bash
 # SSH into server
-ssh root@47.88.89.175
+ssh root@dev.briaanalytics.com
 
 # Check which ports are in use
 netstat -tulpn | grep LISTEN
@@ -67,7 +67,7 @@ docker ps -a
 ```
 Internet
     ↓
-47.88.89.175:[PROXY_PORT]
+dev.briaanalytics.com:[PROXY_PORT]
     ↓
 [Nginx/Reverse Proxy]
     ↓
@@ -83,7 +83,7 @@ Internet
 
 ### 1. Server Reconnaissance ✅ COMPLETED
 
-- [x] SSH into 47.88.89.175 as root
+- [x] SSH into dev.briaanalytics.com as root
 - [x] Document existing services and port usage
 - [x] Check available disk space (`df -h`) - 197GB available
 - [x] Check available memory (`free -h`) - 11GB available
@@ -167,7 +167,7 @@ jobs:
     needs: integration-tests
     if: success()
     steps:
-      - Deploy to 47.88.89.175
+      - Deploy to dev.briaanalytics.com
       - Run smoke tests
       - Notify on success/failure
 ```
@@ -211,7 +211,7 @@ Staging deployment is complete when:
 
 ## Next Steps
 
-1. ✅ **DONE**: SSH into 47.88.89.175 and perform server reconnaissance
+1. ✅ **DONE**: SSH into dev.briaanalytics.com and perform server reconnaissance
 2. ✅ **DONE**: Document port assignments and create configuration files
 3. **NOW**: Follow STAGING_DEPLOYMENT_GUIDE.md to deploy
    - Install Docker Compose plugin

--- a/docs/deployment/STAGING_MIGRATION_GUIDE.md
+++ b/docs/deployment/STAGING_MIGRATION_GUIDE.md
@@ -1,7 +1,7 @@
 # Staging Server MongoDB Atlas Migration Guide
 
 **Date**: 2025-10-27
-**Server**: 47.88.89.175 (dev.briaanalytics.com)
+**Server**: dev.briaanalytics.com
 **Status**: ⚠️ **PLANNED - NOT YET IMPLEMENTED**
 
 ---
@@ -48,7 +48,7 @@ This guide documents the PLANNED migration to MongoDB Atlas M0 Free Tier when re
 1. Log in to https://cloud.mongodb.com
 2. Create or use existing M0 Free Tier cluster
 3. Create database user with credentials
-4. Whitelist staging server IP: `47.88.89.175`
+4. Whitelist the staging server's public IP (resolve: `dig +short dev.briaanalytics.com`)
    - Or use `0.0.0.0/0` for staging environment
 5. Get connection string (SRV format)
 
@@ -57,7 +57,7 @@ This guide documents the PLANNED migration to MongoDB Atlas M0 Free Tier when re
 SSH into staging server and update environment file:
 
 ```bash
-ssh narrative-deploy@47.88.89.175
+ssh narrative-deploy@dev.briaanalytics.com
 cd /opt/narrative-modeling-app/staging
 ```
 
@@ -185,7 +185,7 @@ sudo journalctl -u narrative-backend | grep -i mongodb
 
 1. **IP Not Whitelisted**:
    - Go to Atlas → Network Access
-   - Add staging server IP: `47.88.89.175`
+   - Add the staging server's public IP (resolve: `dig +short dev.briaanalytics.com`)
 
 2. **Invalid Credentials**:
    - Verify username and password in Atlas

--- a/docs/deployment/STAGING_SERVER_RECONNAISSANCE.md
+++ b/docs/deployment/STAGING_SERVER_RECONNAISSANCE.md
@@ -1,6 +1,6 @@
 # Staging Server Reconnaissance Results
 
-**Server**: 47.88.89.175 (root access)
+**Server**: dev.briaanalytics.com (root access)
 **Date**: 2025-10-22
 **Status**: ✅ Reconnaissance Complete
 
@@ -114,7 +114,7 @@ Frontend:3010      Backend:8010
 
 - [ ] **Install Docker Compose Plugin**
   ```bash
-  ssh root@47.88.89.175
+  ssh root@dev.briaanalytics.com
   apt-get update
   apt-get install docker-compose-plugin -y
   docker compose version  # Verify installation

--- a/docs/operations/MONGODB_ATLAS_MIGRATION_STATUS.md
+++ b/docs/operations/MONGODB_ATLAS_MIGRATION_STATUS.md
@@ -1,7 +1,7 @@
 # MongoDB Atlas Migration Status
 
 **Date**: 2025-10-27
-**Target**: Staging Environment (47.88.89.175 / dev.briaanalytics.com)
+**Target**: Staging Environment (dev.briaanalytics.com)
 **Current Status**: ⚠️ **PLANNED - NOT IMPLEMENTED**
 
 ---
@@ -10,7 +10,7 @@
 
 **This migration is PLANNED but NOT YET IMPLEMENTED on the staging server.**
 
-The staging server (47.88.89.175) currently uses:
+The staging server (dev.briaanalytics.com) currently uses:
 - **Self-hosted MongoDB 7.0** running in Docker (container: `narrative-staging-mongodb`)
 - Port: 27018
 - Status: Healthy, running for 5+ days
@@ -119,7 +119,7 @@ git reset --hard origin/main
 **Status**: Cannot access via SSH from current location
 
 **Required Actions** (Manual - requires server access):
-1. SSH to staging server: `ssh narrative-deploy@47.88.89.175`
+1. SSH to staging server: `ssh narrative-deploy@dev.briaanalytics.com`
 2. Update `/opt/narrative-modeling-app/staging/.env.staging` with new MongoDB Atlas credentials
 3. Remove old MongoDB variables (`MONGODB_ROOT_PASSWORD`, `MONGODB_PASSWORD`)
 4. Stop self-hosted MongoDB container
@@ -156,7 +156,7 @@ After server configuration, verify:
 
 ## 🔍 Current Server Status
 
-**Server**: 47.88.89.175 (dev.briaanalytics.com)
+**Server**: dev.briaanalytics.com
 
 **What We Know**:
 - User indicated staging is "only partially working"
@@ -214,7 +214,7 @@ After server configuration, verify:
 ### MongoDB Atlas (⏳ PENDING)
 - [ ] Verify Atlas cluster exists and is accessible
 - [ ] Rotate credentials (delete or change password)
-- [ ] Whitelist staging server IP: 47.88.89.175
+- [ ] Whitelist the staging server's public IP (resolve: `dig +short dev.briaanalytics.com`)
 - [ ] Verify database `narrative_staging` exists
 - [ ] Test connection from local machine
 

--- a/nginx-staging.conf
+++ b/nginx-staging.conf
@@ -3,7 +3,7 @@
 # ═══════════════════════════════════════════════════════════════
 #
 # This configuration should be placed in /etc/nginx/sites-available/
-# on the staging server (47.88.89.175) and symlinked to sites-enabled
+# on the staging server (dev.briaanalytics.com) and symlinked to sites-enabled
 #
 # Location: /etc/nginx/sites-available/narrative-staging.conf
 # Symlink: ln -s /etc/nginx/sites-available/narrative-staging.conf /etc/nginx/sites-enabled/

--- a/scripts/deploy/preflight_staging_env.sh
+++ b/scripts/deploy/preflight_staging_env.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Preflight for the staging deploy: verify every variable the compose file marks
+# required via a ${VAR:?...} guard has a non-empty value in the env file.
+#
+# Why: `docker compose up` aborts on the FIRST missing ${VAR:?} it interpolates,
+# so discovering a drifted .env.staging is a slow one-variable-at-a-time loop.
+# This fails fast with the COMPLETE list. The required set is derived from the
+# compose file itself, so it can never drift out of sync with the guards.
+#
+# Usage: preflight_staging_env.sh [compose-file] [env-file]
+#        preflight_staging_env.sh --self-check   # assert the parsing rules below
+set -euo pipefail
+
+if [ "${1:-}" = "--self-check" ]; then
+  # The value parsing below is the only non-obvious logic here, so it gets one
+  # runnable check. No test framework in this repo for scripts/ — this is it.
+  tmp=$(mktemp -d); trap 'rm -rf "$tmp"' EXIT
+  printf 'services:\n  a:\n    environment:\n      - X=${SET:?req}\n      - Y=${EMPTY:?req}\n      - Z=${QUOTED_EMPTY:?req}\n      - W=${SPACES:?req}\n      - V=${ABSENT:?req}\n' > "$tmp/compose.yml"
+  printf 'SET=real-value\nEMPTY=\nQUOTED_EMPTY=""\nSPACES=   \n' > "$tmp/env"
+  out=$("$0" "$tmp/compose.yml" "$tmp/env" 2>&1) && { echo "self-check FAILED: expected exit 1"; exit 1; }
+  for v in EMPTY QUOTED_EMPTY SPACES ABSENT; do
+    grep -q -- "- $v" <<<"$out" || { echo "self-check FAILED: $v not reported missing"; echo "$out"; exit 1; }
+  done
+  grep -q -- "- SET" <<<"$out" && { echo "self-check FAILED: SET wrongly reported missing"; exit 1; }
+  printf 'SET=real\nEMPTY=x\nQUOTED_EMPTY="x"\nSPACES=x\nABSENT=x\n' > "$tmp/env"
+  "$0" "$tmp/compose.yml" "$tmp/env" >/dev/null || { echo "self-check FAILED: expected exit 0"; exit 1; }
+  echo "self-check OK"; exit 0
+fi
+
+compose_file="${1:-docker-compose.staging.yml}"
+env_file="${2:-.env.staging}"
+
+[ -f "$compose_file" ] || { echo "preflight: compose file not found: $compose_file" >&2; exit 2; }
+[ -f "$env_file" ] || { echo "preflight: env file not found: $env_file" >&2; exit 2; }
+
+# Names inside ${VAR:?...} guards in the compose file. `|| true` because grep
+# exits 1 on no matches, which under `set -e` + `pipefail` would abort the whole
+# script with no diagnostic if the compose file ever has zero guards.
+required=$(grep -oE '\$\{[A-Za-z_][A-Za-z0-9_]*:\?' "$compose_file" \
+  | sed -E 's/^\$\{//; s/:\?$//' | sort -u || true)
+
+missing=()
+for v in $required; do
+  # Required means present AND non-empty — ${VAR:?} rejects an empty value too.
+  # Match Compose's own --env-file parsing rather than the raw text: it strips a
+  # matching pair of surrounding quotes and trims whitespace, so VAR="", VAR=''
+  # and VAR=<spaces> all resolve to empty and would still trip ${VAR:?} at
+  # `docker compose up`. A naive `grep -qE "^VAR=.+"` would pass them.
+  value=$(sed -nE "s/^${v}=//p" "$env_file" | tail -n 1)
+  value="${value%\"}"; value="${value#\"}"      # strip surrounding double quotes
+  value="${value%\'}"; value="${value#\'}"      # strip surrounding single quotes
+  value="${value//[[:space:]]/}"                # whitespace-only counts as empty
+  [ -n "$value" ] || missing+=("$v")
+done
+
+if [ "${#missing[@]}" -gt 0 ]; then
+  echo "preflight: $env_file is missing ${#missing[@]} required variable(s):" >&2
+  printf '  - %s\n' "${missing[@]}" >&2
+  echo "preflight: add them (see .env.staging.example) and re-run the deploy." >&2
+  exit 1
+fi
+
+echo "preflight: OK — all required variables present in $env_file"


### PR DESCRIPTION
Follow-up to the staging-deploy fix. The **Deploy (Staging)** workflow had been red on every push because the live `.env.staging` was missing required vars (`BACKEND_CORS_ORIGINS`, `INVITE_ALLOWLIST`) that recent issues added `${VAR:?}` guards for. Compose aborts on the *first* missing guard it interpolates, so the drift surfaced one variable at a time. (The live env file has since been fixed on the server; the deploy is green.)

This PR hardens the flow and removes the stale-IP doc drift that made the host hard to find.

## 1. Preflight required env vars (hardening)
`scripts/deploy/preflight_staging_env.sh` derives the required set straight from the compose file's `${VAR:?}` guards — so it **can't drift out of sync** — and verifies each is present and non-empty in `.env.staging`, failing with the **complete** missing list before `compose up` runs. Wired into `deploy.yml`'s SSH step after `git reset`, before build.

Verified:
- Against the **live** server `.env.staging` → `preflight: OK`, exit 0.
- Synthetic env missing `BACKEND_CORS_ORIGINS` + empty `INVITE_ALLOWLIST` → exit 1 listing both.

## 2. Docs use the hostname, not the stale IP
`dev.briaanalytics.com` (currently `195.35.14.177`) is the canonical host; the docs and `deploy.yml` header hardcoded the old `47.88.89.175`. Replaced host/SSH/URL references with the hostname so an IP change no longer needs doc edits. MongoDB Atlas allowlist lines — which genuinely require an IP — now say to resolve `dig +short dev.briaanalytics.com` instead of hardcoding one. `docs/deployment/archive/**` left untouched as historical record.

## Scope
Docs + one deploy script + workflow wiring. No application code changes.