### PR TITLE
chore(ci): ignore Node major bumps in dependabot (frontend docker + @types/node)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,6 +39,14 @@ updates:
     labels:
       - "dependencies"
       - "docker"
+    ignore:
+      # Node major bumps are pinned to 20 to match CI (issue #277), enforced by
+      # `test_frontend_dockerfile_node_major_matches_ci`. A Node-major PR fails
+      # `CI Success` by design (PR #337 was closed for this). Re-enable by
+      # removing this once CI itself moves off Node 20. Digest + minor/patch
+      # refreshes still flow.
+      - dependency-name: "node"
+        update-types: ["version-update:semver-major"]
 
   # Staging compose — refreshes the `redis:7-alpine@sha256:…` digest pinned in the
   # repo-root `docker-compose.staging.yml` (deploy path, not CI).
@@ -90,6 +98,13 @@ updates:
     labels:
       - "dependencies"
       - "security"
+    ignore:
+      # @types/node tracks the runtime major, which is pinned to Node 20 (CI +
+      # deployed image, issue #277). Node 26 type defs would type-check code
+      # against APIs absent at runtime (PR #343 was closed for this). Re-enable
+      # by removing this once the runtime moves off Node 20.
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]
     groups:
       npm-minor-patch:
         update-types:


### PR DESCRIPTION
## What

Adds two Dependabot `ignore` rules so Node **major** bumps stop regenerating:
- frontend Docker `node` → semver-major ignored
- npm `@types/node` → semver-major ignored

Digest and minor/patch refreshes still flow normally.

## Why

The Node runtime and CI are pinned to **20** (issue #277), enforced by `test_frontend_dockerfile_node_major_matches_ci`. Dependabot kept opening Node-major PRs that fail the required `CI Success` check by design:
- #337 (`node:20-alpine` → `node:26-alpine`) — failed the guard test, closed
- #343 (`@types/node` 20 → 26) — type defs would mismatch the Node-20 runtime, closed

These rules prevent the weekly re-open churn. Remove them if/when CI itself moves off Node 20.

Refs #277