### PR TITLE
fix(security): require NEXTAUTH_URL in production fail-fast auth guard (#317)

### DIFF
--- a/apps/frontend/__tests__/lib/auth-config.test.ts
+++ b/apps/frontend/__tests__/lib/auth-config.test.ts
@@ -2,6 +2,7 @@ import { missingAuthEnv, assertAuthConfig } from '@/lib/auth-config';
 
 const FULL = {
   NEXTAUTH_SECRET: 's',
+  NEXTAUTH_URL: 'https://app.example.com',
   GOOGLE_CLIENT_ID: 'gid',
   GOOGLE_CLIENT_SECRET: 'gsec',
   GITHUB_ID: 'hid',
@@ -20,6 +21,7 @@ describe('missingAuthEnv', () => {
     // CI builds with dummy but non-empty values — must not trip the guard.
     const dummy = {
       NEXTAUTH_SECRET: 'test-secret-for-ci-only',
+      NEXTAUTH_URL: 'http://localhost:3000',
       GOOGLE_CLIENT_ID: 'dummy-client-id',
       GOOGLE_CLIENT_SECRET: 'dummy-client-secret',
       GITHUB_ID: 'dummy-client-id',
@@ -31,6 +33,7 @@ describe('missingAuthEnv', () => {
   it('lists every missing or blank var in production', () => {
     expect(missingAuthEnv({}, 'production')).toEqual([
       'NEXTAUTH_SECRET',
+      'NEXTAUTH_URL',
       'GOOGLE_CLIENT_ID',
       'GOOGLE_CLIENT_SECRET',
       'GITHUB_ID',
@@ -51,6 +54,10 @@ describe('assertAuthConfig', () => {
   it('throws a clear error naming the missing vars in production', () => {
     expect(() => assertAuthConfig({ ...FULL, NEXTAUTH_SECRET: '' }, 'production')).toThrow(
       /NEXTAUTH_SECRET/,
+    );
+    // #317: blank NEXTAUTH_URL would let NextAuth infer a wrong redirect URI behind nginx.
+    expect(() => assertAuthConfig({ ...FULL, NEXTAUTH_URL: '' }, 'production')).toThrow(
+      /NEXTAUTH_URL/,
     );
   });
 });

--- a/apps/frontend/lib/auth-config.ts
+++ b/apps/frontend/lib/auth-config.ts
@@ -10,10 +10,15 @@
 // creds (the credentials provider + dummy fallbacks), so the guard is disabled
 // there. Trigger is *missing/blank*, not "equals dummy", so CI's `next build`
 // (which sets non-empty dummy values) is unaffected.
+//
+// NEXTAUTH_URL is also required (#317): a blank value makes NextAuth infer the
+// base URL from request headers, producing wrong OAuth redirect URIs behind the
+// nginx reverse proxy the app deploys under.
 
 /** Env vars required for OAuth sign-in + JWT signing to work in production. */
 export const REQUIRED_PROD_AUTH_ENV = [
   'NEXTAUTH_SECRET',
+  'NEXTAUTH_URL',
   'GOOGLE_CLIENT_ID',
   'GOOGLE_CLIENT_SECRET',
   'GITHUB_ID',


### PR DESCRIPTION
Closes #317. Follow-up from PR #316 (issue #271).

## What
Adds `NEXTAUTH_URL` to `REQUIRED_PROD_AUTH_ENV` in `apps/frontend/lib/auth-config.ts`. A production deploy with a blank `NEXTAUTH_URL` now fails fast at startup instead of letting NextAuth infer the base URL from request headers — which produces wrong OAuth redirect URIs behind the nginx reverse proxy the app deploys under.

## Why only `NEXTAUTH_URL` (not `NEXTAUTH_URL_INTERNAL`)
NextAuth resolves the base URL as `NEXTAUTH_URL_INTERNAL → NEXTAUTH_URL → request headers`. Requiring `NEXTAUTH_URL` closes the header-inference hole; requiring `_INTERNAL` too would break deploys (e.g. staging) that set only `NEXTAUTH_URL`.

## Guard stays green — every build/deploy surface already sets it
| Surface | `NEXTAUTH_URL` |
|---|---|
| CI `next build` (ci.yml:261) | `http://localhost:3000` |
| CI e2e-smoke (ci.yml:446) | set (+ `NODE_ENV=development` disables guard) |
| Dockerfile build | `http://localhost:3000` |
| Staging compose | `${NEXTAUTH_URL}` from `.env.staging` |

The guard trips only on *missing/blank* in `NODE_ENV=production`, so non-empty placeholders are unaffected.

## Tests
`__tests__/lib/auth-config.test.ts` updated: `NEXTAUTH_URL` added to the FULL/dummy fixtures and the "lists every missing var" expectation, plus a new assertion that a blank `NEXTAUTH_URL` throws in production. Jest (5 passed), `tsc --noEmit`, and eslint all clean.

## Demo / outcome evidence
`missingAuthEnv({}, 'production')` now includes `NEXTAUTH_URL`, and `assertAuthConfig({...FULL, NEXTAUTH_URL: ''}, 'production')` throws `/NEXTAUTH_URL/` — verified green by the updated jest suite. In dev/test the guard remains a no-op.

## Known limitations
- Scope is presence-only (non-empty). It does not validate that `NEXTAUTH_URL` is a well-formed https URL — consistent with the existing guard's contract for the other vars.