### PR TITLE
fix(ci): dependabot.yml is invalid — all dependency updates are silently stopped

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -115,10 +115,11 @@ updates:
   # accurate). Grouped so all action bumps land in one PR per week.
   - package-ecosystem: "github-actions"
     cooldown:
+      # Only `default-days` here: Dependabot rejects `semver-{major,minor,patch}-days`
+      # for the github-actions ecosystem, and one invalid key invalidates the WHOLE
+      # file — every ecosystem silently stops updating, security bumps included.
+      # The per-semver keys are supported for npm (see the frontend block above).
       default-days: 14
-      semver-major-days: 14
-      semver-minor-days: 7
-      semver-patch-days: 7
     directory: "/"
     schedule:
       interval: "weekly"

--- a/apps/backend/tests/test_security/test_dependabot_config.py
+++ b/apps/backend/tests/test_security/test_dependabot_config.py
@@ -1,0 +1,69 @@
+"""Regression guard: .github/dependabot.yml must stay valid for Dependabot.
+
+An invalid key anywhere in this file invalidates the WHOLE config — Dependabot
+rejects it outright and every ecosystem silently stops updating, security bumps
+included. That is a supply-chain control failing closed with no local signal:
+nothing in `ci.yml` parses this file, and the only feedback is a
+`.github/dependabot.yml` check-run that GitHub posts *after* a merge, and only
+on commits that touch the file.
+
+That is exactly how it broke: the `github-actions` block carried
+`semver-{major,minor,patch}-days` cooldown keys, which Dependabot supports for
+npm but NOT for github-actions. It sat there unnoticed until PR #347 touched the
+file for an unrelated reason and triggered revalidation, which reported:
+
+    The property '#/updates/5/cooldown/semver-major-days' is not supported
+    for the package ecosystem 'github-actions'.
+
+These tests parse the real file so a reintroduction fails the build instead of
+quietly stopping dependency updates.
+"""
+
+from pathlib import Path
+
+import yaml
+
+# apps/backend/tests/test_security/ -> repo root
+REPO_ROOT = Path(__file__).resolve().parents[4]
+DEPENDABOT_CONFIG = REPO_ROOT / ".github" / "dependabot.yml"
+
+# Cooldown keys Dependabot rejects for the github-actions ecosystem.
+SEMVER_COOLDOWN_KEYS = (
+    "semver-major-days",
+    "semver-minor-days",
+    "semver-patch-days",
+)
+
+
+def _updates() -> list[dict]:
+    config = yaml.safe_load(DEPENDABOT_CONFIG.read_text())
+    assert config["version"] == 2, "Dependabot config must declare version 2"
+    return config["updates"]
+
+
+def test_dependabot_config_is_parseable() -> None:
+    """The file must be valid YAML with a non-empty `updates` list."""
+    updates = _updates()
+    assert updates, "dependabot.yml declares no update blocks"
+    for i, update in enumerate(updates):
+        assert update.get("package-ecosystem"), f"updates[{i}] has no package-ecosystem"
+        assert update.get("directory"), f"updates[{i}] has no directory"
+
+
+def test_github_actions_cooldown_has_no_semver_day_keys() -> None:
+    """github-actions cooldown accepts `default-days` only.
+
+    Dependabot rejects the per-semver variants for this ecosystem, and one bad
+    key takes the entire file down with it.
+    """
+    for i, update in enumerate(_updates()):
+        if update.get("package-ecosystem") != "github-actions":
+            continue
+        cooldown = update.get("cooldown") or {}
+        offenders = sorted(k for k in SEMVER_COOLDOWN_KEYS if k in cooldown)
+        assert not offenders, (
+            f"updates[{i}] (github-actions) sets {offenders} under `cooldown`. "
+            "Dependabot does not support these for github-actions and will "
+            "reject the whole dependabot.yml, silently stopping ALL dependency "
+            "updates including security patches. Use `default-days` only."
+        )


### PR DESCRIPTION
## The problem

**Dependabot is currently rejecting `.github/dependabot.yml` outright, so every dependency update is stopped.** Found while triaging the open Dependabot PRs.

The `.github/dependabot.yml` check-run on `669a443` (the #347 merge commit) says:

```
Dependabot encountered the following error when parsing your `.github/dependabot.yml`:

The property '#/updates/5/cooldown/semver-major-days' is not supported for the package ecosystem 'github-actions'.
The property '#/updates/5/cooldown/semver-minor-days' is not supported for the package ecosystem 'github-actions'.
The property '#/updates/5/cooldown/semver-patch-days' is not supported for the package ecosystem 'github-actions'.
```

`updates[5]` is the `github-actions` block. Dependabot supports `semver-{major,minor,patch}-days` for npm — the frontend block uses them fine — but **not** for `github-actions`.

The severity is in the blast radius: **one invalid key invalidates the whole file.** It's not that Actions bumps stop; it's that *every* ecosystem stops — backend `pip`, frontend `npm`, all three `docker` blocks, and `github-actions` — with no PRs and no warning.

## Why it went unnoticed

- Nothing in `ci.yml` parses `dependabot.yml`, so there is no local or PR signal.
- GitHub only posts the `.github/dependabot.yml` check-run on commits that **touch** the file, and only *after* the merge. Confirmed: the check exists on `669a443` and on no other recent `main` commit.
- So the misconfiguration sat dormant until #347 edited the file for an unrelated reason (ignoring Node majors) and triggered revalidation. **#347 did not cause this** — it exposed it.

This is a supply-chain control failing **closed and silent**, which is the worst combination.

## Why it's worth fixing now rather than filing

The critical Auth.js fix just merged in #382 — [GHSA-7rqj-j65f-68wh](https://github.com/advisories/GHSA-7rqj-j65f-68wh), homoglyph `@` bypass in the email normalizer — reached this repo *because Dependabot opened a PR for it*. With the config rejected, the next such advisory produces nothing.

## The fix

Drop the three unsupported keys, keeping `default-days: 14` for the `github-actions` block. A comment records why the per-semver keys can't come back and that npm is different, so the asymmetry doesn't read as an oversight.

## Regression guard

`apps/backend/tests/test_security/test_dependabot_config.py` — follows `test_staging_ports.py`'s existing pattern of parsing the **real** repo config rather than a fixture, and lives in `test_security/` because this is the mechanism that delivers security patches.

Two tests: the file parses as version 2 with well-formed update blocks, and no `github-actions` block carries the semver cooldown keys.

**Verified it's a real guard, not a tautology** — reintroducing `semver-major-days` makes it fail and name the offender:

```
AssertionError: updates[5] (github-actions) sets ['semver-major-days'] under `cooldown`.
Dependabot does not support these for github-actions and will reject the whole
dependabot.yml, silently stopping ALL dependency updates including security patches.
Use `default-days` only.
```

## Verification

| Gate | Result |
|---|---|
| `pytest tests/test_security/test_dependabot_config.py` | 2 passed |
| negative control (bad key reintroduced) | fails as intended, names the key |
| `ruff check` + `ruff format --check` | clean |
| `mypy app/` | no issues, 168 source files |

Post-merge, GitHub will re-validate the file (this PR touches it) — the `.github/dependabot.yml` check should flip to passing on the merge commit, which is the real confirmation.
