### PR TITLE
fix(deploy): reach staging over Tailscale; pin host key instead of ssh-keyscan (#384)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -103,18 +103,24 @@ jobs:
           SSH_KEY: ${{ secrets.SSH_KEY }}
           SSH_KNOWN_HOSTS: ${{ secrets.SSH_KNOWN_HOSTS }}
         run: |
+          # umask BEFORE writing: `printf > file` then `chmod 600` leaves the file
+          # world-readable under the runner's default umask (022) for the moment in
+          # between. That matters most for staging_key, which is a PRIVATE KEY.
+          umask 077
           mkdir -p ~/.ssh
           chmod 700 ~/.ssh
           printf '%s\n' "$SSH_KEY" > ~/.ssh/staging_key
-          chmod 600 ~/.ssh/staging_key
           # Pinned host key from a secret rather than a live `ssh-keyscan` of HOST.
           # Two reasons: ssh-keyscan was trust-on-first-use (it accepted whatever
           # answered, so a MITM on the path was never detected), and it was the step
-          # that failed opaquely once 22 was firewalled. Populate the secret from a
-          # trusted session, having verified the fingerprint out of band:
+          # that failed opaquely once 22 was firewalled.
+          #
+          # ROTATION: if the VPS host key ever changes, deploys fail closed with
+          # "Host key verification failed" — that is the intended behaviour, not a
+          # bug. Re-pin from a trusted session, verifying the fingerprint out of
+          # band first, using the tailnet HOST value (labels must match HOST):
           #   ssh-keyscan -H <tailnet-host> | gh secret set SSH_KNOWN_HOSTS --env Development
           printf '%s\n' "$SSH_KNOWN_HOSTS" >> ~/.ssh/known_hosts
-          chmod 600 ~/.ssh/known_hosts
 
       - name: Deploy over SSH
         if: steps.preflight.outputs.configured == 'true'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,9 +1,7 @@
 name: Deploy (Staging)
 
-# Automated staging deployment (issue #150). Target: the staging VPS at
-# dev.briaanalytics.com — refer to it by hostname, not a raw IP; the address has
-# changed before and stale IPs in docs/config caused a failed deploy. The job
-# SSHes into the staging VPS as the deploy user, pulls main, and rebuilds with
+# Automated staging deployment (issue #150). The job reaches the staging VPS over
+# Tailscale, SSHes in as the deploy user, pulls main, and rebuilds with
 # docker-compose.staging.yml (which builds apps/backend/Dockerfile and
 # apps/frontend/Dockerfile). Application secrets live in .env.staging ON THE
 # SERVER and are never passed through CI; compose is invoked with
@@ -11,19 +9,33 @@ name: Deploy (Staging)
 # managed Atlas cluster (MONGODB_URI in .env.staging) — no Mongo container is
 # deployed.
 #
+# NETWORK PATH (issue #384) — the VPS firewalls port 22 off the public internet:
+# `ufw` allows 22 only from the home subnet and `on tailscale0`. A GitHub-hosted
+# runner therefore CANNOT ssh to dev.briaanalytics.com; it joins the tailnet and
+# connects to the box's tailnet address instead. Consequences:
+#   * HOST must be the tailnet MagicDNS name (…​.ts.net) or 100.x address —
+#     setting it to dev.briaanalytics.com will hang and then fail.
+#   * SSH_KNOWN_HOSTS must be labelled with that same HOST value.
+#   * The tailnet ACL must let `tag:ci` reach the staging box on port 22.
+# Humans on the home subnet can still ssh to dev.briaanalytics.com directly; only
+# CI needs the tailnet. Mirrors the working setup in frankbria/codeframe.
+#
 # Secrets live on the `Development` GitHub Environment
 # (Settings → Environments → Development → Environment secrets), NOT as repo
 # secrets with a STAGING_ prefix. This is the single source of truth — do not
 # reintroduce repo-level STAGING_* secrets.
-#   SSH_KEY      - private key authorized for the deploy user on HOST (required)
-#   HOST         - staging host; prefer the DNS name dev.briaanalytics.com (required)
-#   DEPLOY_USER  - optional; defaults to `root`
-#   DEPLOY_PATH  - optional; defaults to /opt/narrative-modeling-app/staging
+#   SSH_KEY            - private key authorized for the deploy user on HOST (required)
+#   HOST               - staging box's TAILNET name/address, not its public DNS (required)
+#   SSH_KNOWN_HOSTS    - pinned host key(s) for HOST; replaces live ssh-keyscan TOFU (required)
+#   TS_OAUTH_CLIENT_ID - Tailscale OAuth client id, tag:ci scope (required)
+#   TS_OAUTH_SECRET    - Tailscale OAuth client secret (required)
+#   DEPLOY_USER        - optional; defaults to `root`
+#   DEPLOY_PATH        - optional; defaults to /opt/narrative-modeling-app/staging
 #
-# Until SSH_KEY + HOST are configured the job is a no-op that succeeds with a
-# warning, so main stays green. Idempotent: re-running on the same commit
-# reconciles the server to that commit and rebuilds; `docker compose up -d`
-# only recreates changed containers.
+# Until all five required secrets are configured the job is a no-op that succeeds
+# with a warning naming the missing ones, so main stays green. Idempotent:
+# re-running on the same commit reconciles the server to that commit and
+# rebuilds; `docker compose up -d` only recreates changed containers.
 
 on:
   push:
@@ -54,33 +66,55 @@ jobs:
         env:
           SSH_KEY: ${{ secrets.SSH_KEY }}
           HOST: ${{ secrets.HOST }}
+          SSH_KNOWN_HOSTS: ${{ secrets.SSH_KNOWN_HOSTS }}
+          TS_OAUTH_CLIENT_ID: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          TS_OAUTH_SECRET: ${{ secrets.TS_OAUTH_SECRET }}
         run: |
-          if [ -z "$SSH_KEY" ] || [ -z "$HOST" ]; then
+          missing=()
+          [ -n "$SSH_KEY" ]            || missing+=("SSH_KEY")
+          [ -n "$HOST" ]               || missing+=("HOST")
+          [ -n "$SSH_KNOWN_HOSTS" ]    || missing+=("SSH_KNOWN_HOSTS")
+          [ -n "$TS_OAUTH_CLIENT_ID" ] || missing+=("TS_OAUTH_CLIENT_ID")
+          [ -n "$TS_OAUTH_SECRET" ]    || missing+=("TS_OAUTH_SECRET")
+          if [ "${#missing[@]}" -gt 0 ]; then
             echo "configured=false" >> "$GITHUB_OUTPUT"
-            echo "::warning::Development environment deploy secrets not set (SSH_KEY/HOST) — skipping deploy. See .github/workflows/deploy.yml header."
+            echo "::warning::Deploy secrets not set (${missing[*]}) — skipping deploy so main stays green. See .github/workflows/deploy.yml header."
           else
             echo "configured=true" >> "$GITHUB_OUTPUT"
           fi
+
+      # The VPS firewalls port 22 off the public internet (ufw allows 22 only from
+      # the home subnet and `on tailscale0`), so a GitHub-hosted runner cannot SSH
+      # in directly — that is what broke every deploy after 2026-07-30 01:11
+      # (issue #384). The runner joins the tailnet instead. HOST must therefore be
+      # the box's tailnet MagicDNS name or 100.x address, NOT dev.briaanalytics.com.
+      # Mirrors the working setup in frankbria/codeframe.
+      - name: Connect to Tailscale
+        if: steps.preflight.outputs.configured == 'true'
+        uses: tailscale/github-action@6cae46e2d796f265265cfcf628b72a32b4d7cade # v3.3.0
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          tags: tag:ci
 
       - name: Configure SSH
         if: steps.preflight.outputs.configured == 'true'
         env:
           SSH_KEY: ${{ secrets.SSH_KEY }}
-          HOST: ${{ secrets.HOST }}
+          SSH_KNOWN_HOSTS: ${{ secrets.SSH_KNOWN_HOSTS }}
         run: |
           mkdir -p ~/.ssh
           chmod 700 ~/.ssh
           printf '%s\n' "$SSH_KEY" > ~/.ssh/staging_key
           chmod 600 ~/.ssh/staging_key
-          # Don't send ssh-keyscan's stderr to /dev/null: it exits 1 when HOST is
-          # unresolvable/unreachable, and under `bash -e` that failed the whole job
-          # with a bare "exit code 1" and no clue why (seen on runs for b451309,
-          # b962bc5, d35971b — HOST pointing at a stale address). Keep the
-          # diagnostic and say which host we actually tried.
-          if ! ssh-keyscan -H "$HOST" >> ~/.ssh/known_hosts; then
-            echo "::error::ssh-keyscan could not reach '$HOST:22'. Check the HOST secret on the Development environment resolves to the current staging address (\`getent hosts dev.briaanalytics.com\`) and that port 22 is reachable from GitHub runners."
-            exit 1
-          fi
+          # Pinned host key from a secret rather than a live `ssh-keyscan` of HOST.
+          # Two reasons: ssh-keyscan was trust-on-first-use (it accepted whatever
+          # answered, so a MITM on the path was never detected), and it was the step
+          # that failed opaquely once 22 was firewalled. Populate the secret from a
+          # trusted session, having verified the fingerprint out of band:
+          #   ssh-keyscan -H <tailnet-host> | gh secret set SSH_KNOWN_HOSTS --env Development
+          printf '%s\n' "$SSH_KNOWN_HOSTS" >> ~/.ssh/known_hosts
+          chmod 600 ~/.ssh/known_hosts
 
       - name: Deploy over SSH
         if: steps.preflight.outputs.configured == 'true'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ Narrative Modeling App — an AI-guided platform that democratizes machine learn
 - Backend full suite green locally (~1,460 passed); pytest uses the **test** database, never `MONGODB_URI`.
 - **`ci.yml` is the PR gate.** Runs: backend (ruff **blocking** with `E`/`F`/`I`/`UP`; mypy **blocking** — plain `uv run mypy app/`; service-free pytest), frontend (eslint, `tsc --noEmit`, `next build`, jest), MCP pytest, backend integration (Mongo/Redis/LocalStack, `CI_REQUIRE_SERVICES=true` so services can't silently skip), and the `e2e-smoke` job (Playwright `@smoke` on the full stack).
 - The single aggregate **`CI Success`** status is the only required check for `main` — it transitively enforces all of the above (incl. e2e smoke). Advisory-only: `backend-typecheck`, the `@perf` job (`perf-tests.yml`), `security-audit`, and the Claude/GLM review bots.
-- `deploy.yml` ships `main` → staging over SSH (secret-gated). `integration-tests.yml`/`e2e-tests.yml` are manual (`workflow_dispatch`).
+- `deploy.yml` ships `main` → staging over SSH (secret-gated). **The VPS firewalls port 22 off the public internet** (`ufw` allows it only from the home subnet and `on tailscale0`), so the runner joins the tailnet first — `HOST` must be the box's **tailnet** name/`100.x` address, never `dev.briaanalytics.com`, and `SSH_KNOWN_HOSTS` must be labelled with that same value (#384). Humans on the home subnet still SSH to the public name directly. `integration-tests.yml`/`e2e-tests.yml` are manual (`workflow_dispatch`).
 - Guides: `apps/backend/docs/TEST_INFRASTRUCTURE.md`, `apps/backend/docs/TDD_GUIDE.md`.
 
 ## Environment Variables

--- a/docs/deployment/STAGING.md
+++ b/docs/deployment/STAGING.md
@@ -201,7 +201,9 @@ WantedBy=multi-user.target
 
 ### Prerequisites
 
-- SSH access to `dev.briaanalytics.com` as `narrative-deploy` user
+- SSH access to `dev.briaanalytics.com` as `narrative-deploy` user — port 22 is
+  firewalled to the home subnet and the tailnet, so connect from one of those
+  (CI uses the tailnet path; see the `deploy.yml` header and #384)
 - Docker and Docker Compose installed
 - Environment variables configured in `.env.staging`
 - GitHub repository access


### PR DESCRIPTION
Fixes #384.

## Corrected root cause

**The issue's original diagnosis was wrong, and I wrote it — worth stating plainly so the record is right.** #384 claimed the `HOST` secret held a stale IP. It doesn't; that was a red herring.

The actual cause: the VPS firewall was rewritten at **2026-07-30 01:11** (`/etc/ufw/user.rules` mtime) to close port 22 to the public internet.

```
Default: deny (incoming)
22/tcp            ALLOW IN  70.172.0.0/17   # home subnet — never block
22 on tailscale0  ALLOW IN  Anywhere
```

GitHub-hosted runners are on Azure ranges — in neither allowlist. So `ssh-keyscan "$HOST"` is dropped **regardless of what `HOST` contains**. Changing the secret could never have fixed it.

Timeline confirms it exactly:

| When | Event |
|---|---|
| 2026-07-25 03:50 | last successful deploy |
| 2026-07-30 01:11 | ufw rules rewritten — 22 closed publicly |
| 2026-07-30 02:32 → 03:29 | 6 consecutive `Configure SSH` failures |

**Why it fooled me:** the old `47.88.89.175` *is* also dead, and my WSL box sits inside `70.172.0.0/17`, so manual `ssh dev.briaanalytics.com` kept succeeding. Both facts pointed at "stale address" and neither was the blocker.

## The fix

Mirrors the working setup in `frankbria/codeframe` (`.github/workflows/deploy.yml`), as suggested:

1. **Join the tailnet before connecting** — `tailscale/github-action` with `tags: tag:ci`, so the runner arrives via `tailscale0` where ufw permits 22.
2. **Replace the live `ssh-keyscan` with a pinned `SSH_KNOWN_HOSTS` secret.** Two wins in one move: that step was **trust-on-first-use** (it accepted whatever answered, so a MITM on the path was never detectable), *and* it was the step failing opaquely. Deleting it closes a real security weakness and the outage together.
3. **`HOST` is now the tailnet address**, not `dev.briaanalytics.com`. The header says so explicitly, because setting it to the public name hangs and then fails — the exact trap I fell into.

Humans on the home subnet keep using `dev.briaanalytics.com` directly; only CI needs the tailnet.

## Secrets

I set two on the `Development` environment:

- **`SSH_KNOWN_HOSTS`** — built from the server's own `/etc/ssh/*_key.pub`, read over an authenticated session rather than a network scan, and labelled for **both** the MagicDNS name and the `100.x` address so either `HOST` form works. Cross-checked against a public `ssh-keyscan` of `dev.briaanalytics.com`: byte-identical, confirming the same host via two independent paths.
- **`HOST`** → `frankbria-localdev.tail919ab8.ts.net` (the box's tailnet DNS name; `tailscale status --json` reports `HostName: srv1276312`, `Tags: [tag:staging-server]`).

**Still needed from a human** (I can't derive these): `TS_OAUTH_CLIENT_ID` and `TS_OAUTH_SECRET`. `codeframe` already has them at repo level, so the same Tailscale OAuth client can be reused, or mint a new one scoped to `tag:ci`.

Until they're set, the preflight skips the deploy with a warning **naming the missing secrets** rather than failing — preserving the established "main stays green" behaviour instead of turning `main` red.

## Known limitations

- **The tailnet ACL must permit `tag:ci` → `tag:staging-server:22`.** I can't read the tailnet policy file, so this is unverified. If the deploy still fails after the OAuth secrets land, this is the next thing to check.
- The `Security Audit` failure on this PR is the pre-existing advisory-only dev-only `brace-expansion` chain, unrelated to this change.

## Verification

| Gate | Result |
|---|---|
| `actionlint .github/workflows/deploy.yml` | exit 0 |
| `actionlint` (all workflows) | exit 0 |
| YAML parse | 7 well-formed steps |
| `tailscale/github-action` SHA `6cae46e` | confirmed = tag `v3.3.0` upstream |
| tests asserting on `deploy.yml` | none (the `test_workflows.py` matches are the product's own workflow feature) |

**Not yet demonstrated: an actually-green deploy.** That's the real acceptance criterion for #384 and it's gated on the OAuth secrets. I'll run it and confirm `Health check` passes plus staging serving current `main` before this merges — staging is currently on `86122dc`, so it is **missing the critical Auth.js fix from #382** and is running the vulnerable `next-auth`.
