### PR TITLE
refactor(frontend): clear react-hooks/set-state-in-effect across 46 sites (#393)

### DIFF
--- a/apps/frontend/__tests__/hooks/useAsyncData.test.tsx
+++ b/apps/frontend/__tests__/hooks/useAsyncData.test.tsx
@@ -208,3 +208,62 @@ describe('useAsyncData', () => {
     expect(result.current.data).toBe('x')
   })
 })
+
+describe('useAsyncData keepPreviousData', () => {
+  function deferred2<T>() {
+    let resolve!: (v: T) => void
+    const promise = new Promise<T>((res) => {
+      resolve = res
+    })
+    return { promise, resolve }
+  }
+
+  it('drops previous data on a key change by default', async () => {
+    const first = deferred2<string>()
+    const second = deferred2<string>()
+    let current = first
+    const { result, rerender } = renderHook(
+      ({ id }: { id: string }) => useAsyncData(() => current.promise, [id]),
+      { initialProps: { id: 'a' } },
+    )
+    await act(async () => {
+      first.resolve('a-data')
+      await first.promise
+    })
+
+    current = second
+    rerender({ id: 'b' })
+
+    expect(result.current.loading).toBe(true)
+    expect(result.current.data).toBeUndefined()
+  })
+
+  it('keeps previous data under the spinner when opted in', async () => {
+    const first = deferred2<string>()
+    const second = deferred2<string>()
+    let current = first
+    const { result, rerender } = renderHook(
+      ({ id }: { id: string }) =>
+        useAsyncData(() => current.promise, [id], { keepPreviousData: true }),
+      { initialProps: { id: 'a' } },
+    )
+    await act(async () => {
+      first.resolve('a-data')
+      await first.promise
+    })
+
+    current = second
+    rerender({ id: 'b' })
+
+    // Still loading, but the old value stays on screen rather than blanking.
+    expect(result.current.loading).toBe(true)
+    expect(result.current.data).toBe('a-data')
+
+    await act(async () => {
+      second.resolve('b-data')
+      await second.promise
+    })
+    expect(result.current.loading).toBe(false)
+    expect(result.current.data).toBe('b-data')
+  })
+})

--- a/apps/frontend/__tests__/hooks/useAsyncData.test.tsx
+++ b/apps/frontend/__tests__/hooks/useAsyncData.test.tsx
@@ -1,0 +1,210 @@
+/**
+ * Contract for useAsyncData (#393).
+ *
+ * The hook exists to remove `react-hooks/set-state-in-effect` violations without
+ * losing the refetch spinner. Both halves matter, so both are asserted here:
+ *
+ *  - `loading` must return to true the moment a dependency changes, BEFORE the new
+ *    promise resolves. That is the behaviour the 46 hand-written `setLoading(true)`
+ *    calls provided, and the thing that silently disappears if the hook is wrong.
+ *  - It must do that WITHOUT calling setState during the effect — otherwise it
+ *    reintroduces the exact violation it is meant to remove, in one shared place.
+ *
+ * The second property is enforced by lint, not here. What this file guards is that
+ * the derived-loading mechanism actually behaves like the code it replaces.
+ */
+import { renderHook, act, waitFor } from '@testing-library/react'
+
+import { useAsyncData } from '@/lib/hooks/useAsyncData'
+
+/** A promise whose resolution we control, so we can observe the pending window. */
+function deferred<T>() {
+  let resolve!: (v: T) => void
+  let reject!: (e: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+describe('useAsyncData', () => {
+  it('starts in a loading state before anything resolves', () => {
+    const d = deferred<string>()
+    const { result } = renderHook(() => useAsyncData(() => d.promise, []))
+
+    expect(result.current.loading).toBe(true)
+    expect(result.current.data).toBeUndefined()
+    expect(result.current.error).toBeNull()
+  })
+
+  it('exposes data and clears loading once resolved', async () => {
+    const d = deferred<string>()
+    const { result } = renderHook(() => useAsyncData(() => d.promise, []))
+
+    await act(async () => {
+      d.resolve('hello')
+      await d.promise
+    })
+
+    expect(result.current.loading).toBe(false)
+    expect(result.current.data).toBe('hello')
+    expect(result.current.error).toBeNull()
+  })
+
+  it('surfaces a message and clears loading on rejection', async () => {
+    const d = deferred<string>()
+    const { result } = renderHook(() => useAsyncData(() => d.promise, []))
+
+    await act(async () => {
+      d.reject(new Error('boom'))
+      await d.promise.catch(() => {})
+    })
+
+    expect(result.current.loading).toBe(false)
+    expect(result.current.error).toBe('boom')
+    expect(result.current.data).toBeUndefined()
+  })
+
+  // The regression this whole refactor risks introducing.
+  it('returns to loading when a dependency changes, before the refetch resolves', async () => {
+    const first = deferred<string>()
+    const second = deferred<string>()
+    let current = first
+
+    const { result, rerender } = renderHook(
+      ({ tab }: { tab: string }) => useAsyncData(() => current.promise, [tab]),
+      { initialProps: { tab: 'all' } },
+    )
+
+    await act(async () => {
+      first.resolve('all-data')
+      await first.promise
+    })
+    expect(result.current.loading).toBe(false)
+    expect(result.current.data).toBe('all-data')
+
+    // Dependency changes: the spinner must come back immediately, while the
+    // previous result is still the only data we have.
+    current = second
+    rerender({ tab: 'running' })
+    expect(result.current.loading).toBe(true)
+
+    await act(async () => {
+      second.resolve('running-data')
+      await second.promise
+    })
+    expect(result.current.loading).toBe(false)
+    expect(result.current.data).toBe('running-data')
+  })
+
+  it('does not refetch when deps are unchanged across rerenders', async () => {
+    const loader = jest.fn().mockResolvedValue('x')
+    const { result, rerender } = renderHook(() => useAsyncData(loader, ['stable']))
+
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(loader).toHaveBeenCalledTimes(1)
+
+    rerender()
+    rerender()
+
+    expect(loader).toHaveBeenCalledTimes(1)
+  })
+
+  it('ignores a stale response that resolves after a newer request', async () => {
+    const slowFirst = deferred<string>()
+    const fastSecond = deferred<string>()
+    let current = slowFirst
+
+    const { result, rerender } = renderHook(
+      ({ id }: { id: string }) => useAsyncData(() => current.promise, [id]),
+      { initialProps: { id: 'a' } },
+    )
+
+    current = fastSecond
+    rerender({ id: 'b' })
+
+    await act(async () => {
+      fastSecond.resolve('b-data')
+      await fastSecond.promise
+    })
+    expect(result.current.data).toBe('b-data')
+
+    // The abandoned first request lands late. It must not overwrite 'b'.
+    await act(async () => {
+      slowFirst.resolve('a-data')
+      await slowFirst.promise
+    })
+
+    expect(result.current.data).toBe('b-data')
+    expect(result.current.loading).toBe(false)
+  })
+
+  it('reload() refetches and shows loading again', async () => {
+    const loader = jest.fn().mockResolvedValue('v1')
+    const { result } = renderHook(() => useAsyncData(loader, []))
+
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(loader).toHaveBeenCalledTimes(1)
+
+    loader.mockResolvedValue('v2')
+    act(() => {
+      result.current.reload()
+    })
+
+    expect(result.current.loading).toBe(true)
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.data).toBe('v2')
+    expect(loader).toHaveBeenCalledTimes(2)
+  })
+
+  it('uses the latest loader closure without refetching on every render', async () => {
+    // Call sites pass an inline arrow, so `loader` is a new function every render.
+    // Refetching on identity would loop forever; using a stale closure would read
+    // outdated props. It must do neither.
+    let captured = 'first'
+    const calls: string[] = []
+    const { result, rerender } = renderHook(
+      ({ token }: { token: string }) =>
+        useAsyncData(async () => {
+          calls.push(token)
+          return captured
+        }, ['fixed']),
+      { initialProps: { token: 'first' } },
+    )
+
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(calls).toEqual(['first'])
+
+    captured = 'second'
+    rerender({ token: 'second' })
+    rerender({ token: 'second' })
+    expect(calls).toEqual(['first']) // deps unchanged -> no refetch
+
+    act(() => {
+      result.current.reload()
+    })
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    expect(calls).toEqual(['first', 'second']) // reload used the CURRENT closure
+    expect(result.current.data).toBe('second')
+  })
+
+  it('skips the request when enabled is false and reports not-loading', async () => {
+    // Many call sites guard on session/id: `if (session && modelId) fetch()`.
+    const loader = jest.fn().mockResolvedValue('x')
+    const { result, rerender } = renderHook(
+      ({ on }: { on: boolean }) => useAsyncData(loader, ['k'], { enabled: on }),
+      { initialProps: { on: false } },
+    )
+
+    expect(loader).not.toHaveBeenCalled()
+    expect(result.current.loading).toBe(false)
+
+    rerender({ on: true })
+    expect(result.current.loading).toBe(true)
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(loader).toHaveBeenCalledTimes(1)
+    expect(result.current.data).toBe('x')
+  })
+})

--- a/apps/frontend/app/dashboard/page.tsx
+++ b/apps/frontend/app/dashboard/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import React, { useState, useEffect, useMemo } from 'react';
+import React, { useEffect, useMemo } from 'react';
+import { useAsyncData } from '@/lib/hooks/useAsyncData';
 import { useRouter } from 'next/navigation';
 import { useWorkflow } from '@/lib/contexts/WorkflowContext';
 import { WORKFLOW_STAGES, WorkflowStage } from '@/lib/types/workflow';
@@ -126,96 +127,44 @@ export default function DashboardPage() {
     }
   }, [onboardingComplete, onboardingLoading, onboardingError, user?.id, router]);
 
-  const [recentDatasets, setRecentDatasets] = useState<DatasetItem[]>([]);
-  const [recentModels, setRecentModels] = useState<ModelItem[]>([]);
-  const [isLoadingDatasets, setIsLoadingDatasets] = useState(true);
-  const [isLoadingModels, setIsLoadingModels] = useState(true);
-  const [datasetsError, setDatasetsError] = useState<string | null>(null);
-  const [modelsError, setModelsError] = useState<string | null>(null);
 
   // Calculate workflow progress
   const progressPercentage = useMemo(() => {
     return (state.completedStages.size / WORKFLOW_STAGES.length) * 100;
   }, [state.completedStages]);
 
-  const fetchRecentDatasets = async () => {
-    try {
-      setIsLoadingDatasets(true);
-      setDatasetsError(null);
-      const token = await getAuthToken();
-
-      const response = await fetch(`${API_URL}/datasets?page=1&limit=5`, {
-        headers: {
-          'Authorization': `Bearer ${token}`
-        }
-      });
-
-      if (!response.ok) {
-        throw new Error('Failed to fetch datasets');
-      }
-
-      const data = await response.json();
-
-      // Validate API response structure
-      if (!data || typeof data !== 'object') {
-        throw new Error('Invalid API response format');
-      }
-
-      const datasets = data.datasets;
-      if (datasets !== undefined && !Array.isArray(datasets)) {
-        throw new Error('Invalid datasets format: expected array');
-      }
-
-      setRecentDatasets(datasets || []);
-    } catch (error) {
-      console.error('Error fetching datasets:', error);
-      setDatasetsError('Unable to load datasets');
-    } finally {
-      setIsLoadingDatasets(false);
+  const fetchList = async <T,>(path: string, key: string, label: string): Promise<T[]> => {
+    const token = await getAuthToken();
+    const response = await fetch(`${API_URL}/${path}?page=1&limit=5`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!response.ok) {
+      throw new Error(`Failed to fetch ${label}`);
     }
+    const data = await response.json();
+    if (!data || typeof data !== 'object') {
+      throw new Error('Invalid API response format');
+    }
+    const items = data[key];
+    if (items !== undefined && !Array.isArray(items)) {
+      throw new Error(`Invalid ${label} format: expected array`);
+    }
+    return (items || []) as T[];
   };
 
-  const fetchRecentModels = async () => {
-    try {
-      setIsLoadingModels(true);
-      setModelsError(null);
-      const token = await getAuthToken();
+  const { data: datasetList, loading: isLoadingDatasets, error: datasetsError, reload: fetchRecentDatasets } = useAsyncData(
+    () => fetchList<DatasetItem>('datasets', 'datasets', 'datasets'),
+    [],
+    { errorMessage: 'Unable to load datasets' },
+  );
+  const recentDatasets = datasetList ?? [];
 
-      const response = await fetch(`${API_URL}/models?page=1&limit=5`, {
-        headers: {
-          'Authorization': `Bearer ${token}`
-        }
-      });
-
-      if (!response.ok) {
-        throw new Error('Failed to fetch models');
-      }
-
-      const data = await response.json();
-
-      // Validate API response structure
-      if (!data || typeof data !== 'object') {
-        throw new Error('Invalid API response format');
-      }
-
-      const models = data.models;
-      if (models !== undefined && !Array.isArray(models)) {
-        throw new Error('Invalid models format: expected array');
-      }
-
-      setRecentModels(models || []);
-    } catch (error) {
-      console.error('Error fetching models:', error);
-      setModelsError('Unable to load models');
-    } finally {
-      setIsLoadingModels(false);
-    }
-  };
-
-  useEffect(() => {
-    fetchRecentDatasets();
-    fetchRecentModels();
-  }, []);
+  const { data: modelList, loading: isLoadingModels, error: modelsError, reload: fetchRecentModels } = useAsyncData(
+    () => fetchList<ModelItem>('models', 'models', 'models'),
+    [],
+    { errorMessage: 'Unable to load models' },
+  );
+  const recentModels = modelList ?? [];
 
   const handleNavigateToStage = (route: string, stageId: WorkflowStage) => {
     if (canAccessStage(stageId)) {

--- a/apps/frontend/app/deploy/page.tsx
+++ b/apps/frontend/app/deploy/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useEffect, useState } from 'react';
+import { useAsyncData } from '@/lib/hooks/useAsyncData';
 import { useWorkflow } from '@/lib/contexts/WorkflowContext';
 import { WorkflowStage } from '@/lib/types/workflow';
 import { useStageGuard } from '@/lib/hooks/useStageGuard';
@@ -20,8 +21,40 @@ export default function DeployPage() {
   const router = useRouter();
   const { ready } = useStageGuard(WorkflowStage.DEPLOYMENT);
   const [loading, setLoading] = useState(false);
-  const [deployment, setDeployment] = useState<DeployResponse | null>(null);
-  const [deploymentStatus, setDeploymentStatus] = useState<'idle' | 'deploying' | 'deployed'>('idle');
+  const [localDeployment, setLocalDeployment] = useState<DeployResponse | null>(null);
+  const [localStatus, setLocalStatus] = useState<'idle' | 'deploying' | 'deployed' | null>(null);
+
+  // Reads existing deployment state for this model. Returns null when the call
+  // fails, matching the old behaviour of logging and leaving the page at 'idle'.
+  const { data: existingDeployment } = useAsyncData<ModelDeploymentView | null>(
+    async () => {
+      const token = await getAuthToken();
+      const response = await fetch(`${API_URL}/ml/${state.modelId}`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (!response.ok) return null;
+      return (await response.json()) as ModelDeploymentView;
+    },
+    [state.modelId],
+    { enabled: ready && !!state.modelId },
+  );
+
+  // The load seeds these; deploying overrides them. Keeping the action's value
+  // separate means the fetch result no longer has to be written into state.
+  const deployment = localDeployment ?? (
+    existingDeployment?.is_deployed
+      ? {
+          model_id: state.modelId ?? '',
+          status: 'deployed',
+          deployed_at: existingDeployment.deployed_at ?? '',
+          deployment_endpoint: existingDeployment.deployment_endpoint ?? null,
+          message: 'Model is deployed',
+        } as DeployResponse
+      : null
+  );
+  const deploymentStatus: 'idle' | 'deploying' | 'deployed' =
+    localStatus ?? (existingDeployment?.is_deployed ? 'deployed' : 'idle');
+
   // Real features for the example request (AC3). Empty until loaded.
   const [exampleFeatures, setExampleFeatures] = useState<ModelFeatureDescriptor[]>([]);
 
@@ -45,36 +78,6 @@ export default function DeployPage() {
   // includes the `/api/v1` prefix, so strip it to reach the docs page.
   const docsUrl = `${API_URL.replace(/\/api\/v1\/?$/, '')}/docs`;
 
-  const checkDeploymentStatus = async () => {
-    try {
-      const token = await getAuthToken();
-      // Real trained models are MLModel documents served at /ml/{id} (issue #84;
-      // the old /models/{id} ModelConfig surface is dead and 404s). Deployment
-      // state lives on the model record's top-level fields.
-      const response = await fetch(`${API_URL}/ml/${state.modelId}`, {
-        headers: {
-          'Authorization': `Bearer ${token}`
-        }
-      });
-
-      if (response.ok) {
-        const data = (await response.json()) as ModelDeploymentView;
-        if (data.is_deployed) {
-          setDeployment({
-            model_id: state.modelId ?? '',
-            status: 'deployed',
-            deployed_at: data.deployed_at ?? '',
-            deployment_endpoint: data.deployment_endpoint ?? null,
-            message: 'Model is deployed'
-          });
-          setDeploymentStatus('deployed');
-        }
-      }
-    } catch (error) {
-      console.error('Failed to check deployment status:', error);
-    }
-  };
-
   useEffect(() => {
     // Stage access (with a helpful redirect) is handled by useStageGuard.
     if (!ready) return;
@@ -83,16 +86,13 @@ export default function DeployPage() {
         WorkflowStage.MODEL_TRAINING,
         'Train a model before deploying it.'
       );
-      return;
     }
-    // Check if already deployed
-    checkDeploymentStatus();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [ready, state.modelId]);
 
   const handleDeploy = async () => {
     setLoading(true);
-    setDeploymentStatus('deploying');
+    setLocalStatus('deploying');
 
     try {
       const token = await getAuthToken();
@@ -112,8 +112,8 @@ export default function DeployPage() {
 
       if (response.ok) {
         const data = (await response.json()) as DeployResponse;
-        setDeployment(data);
-        setDeploymentStatus('deployed');
+        setLocalDeployment(data);
+        setLocalStatus('deployed');
 
         completeStage(WorkflowStage.DEPLOYMENT, {
           deploymentId: data.model_id,
@@ -123,11 +123,11 @@ export default function DeployPage() {
       } else {
         // A 4xx/5xx does not throw; without this the spinner would hang forever.
         console.error(`Failed to deploy model: ${response.status} ${response.statusText}`);
-        setDeploymentStatus('idle');
+        setLocalStatus('idle');
       }
     } catch (error) {
       console.error('Failed to deploy model:', error);
-      setDeploymentStatus('idle');
+      setLocalStatus('idle');
     } finally {
       setLoading(false);
     }

--- a/apps/frontend/app/evaluate/page.tsx
+++ b/apps/frontend/app/evaluate/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
+import { useAsyncData } from '@/lib/hooks/useAsyncData';
 import { useWorkflow } from '@/lib/contexts/WorkflowContext';
 import { WorkflowStage } from '@/lib/types/workflow';
 import { useStageGuard } from '@/lib/hooks/useStageGuard';
@@ -276,30 +277,30 @@ export default function EvaluatePage() {
   const { state, completeStage, requestStageRedirect } = useWorkflow();
   const router = useRouter();
   const { ready } = useStageGuard(WorkflowStage.MODEL_EVALUATION);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const [evaluation, setEvaluation] = useState<ModelEvaluationResponse | null>(null);
-  const [shap, setShap] = useState<ShapSummaryResponse | null>(null);
 
-  const loadEvaluation = useCallback(async (modelId: string) => {
-    setLoading(true);
-    setError(null);
-    try {
-      const data = await modelService.getEvaluation(modelId);
-      setEvaluation(data);
+  const {
+    data: evaluationData,
+    loading,
+    error,
+  } = useAsyncData(
+    async () => {
+      const data = await modelService.getEvaluation(state.modelId as string);
       // SHAP summary is best-effort enrichment (issue #80): a failure (or a
       // model with no SHAP support) must never block the evaluation view.
+      let shapData: ShapSummaryResponse | null = null;
       try {
-        setShap(await modelService.getShapSummary(modelId));
+        shapData = await modelService.getShapSummary(state.modelId as string);
       } catch {
-        setShap(null);
+        shapData = null;
       }
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Unknown error');
-    } finally {
-      setLoading(false);
-    }
-  }, []);
+      return { evaluation: data, shap: shapData };
+    },
+    [state.modelId],
+    { enabled: ready && !!state.modelId },
+  );
+
+  const evaluation = evaluationData?.evaluation ?? null;
+  const shap = evaluationData?.shap ?? null;
 
   // Stage access (with a helpful redirect) is handled by useStageGuard above.
   useEffect(() => {
@@ -310,10 +311,8 @@ export default function EvaluatePage() {
         WorkflowStage.MODEL_TRAINING,
         'Train a model before evaluating it.'
       );
-      return;
     }
-    loadEvaluation(state.modelId);
-  }, [ready, state.modelId, loadEvaluation, requestStageRedirect]);
+  }, [ready, state.modelId, requestStageRedirect]);
 
   const handleProceedToPrediction = () => {
     completeStage(WorkflowStage.MODEL_EVALUATION, {

--- a/apps/frontend/app/experiments/[id]/page.tsx
+++ b/apps/frontend/app/experiments/[id]/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState } from "react";
+import { useAsyncData } from "@/lib/hooks/useAsyncData";
 import { useParams, useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
@@ -31,7 +32,7 @@ import {
   Pie,
   Cell
 } from "recharts";
-import { abTestingService, ABTest, ExperimentMetrics } from "@/lib/services/abTesting";
+import { abTestingService } from "@/lib/services/abTesting";
 import { formatDistanceToNow } from "date-fns";
 
 export default function ExperimentDetailsPage() {
@@ -39,41 +40,31 @@ export default function ExperimentDetailsPage() {
   const router = useRouter();
   const experimentId = params.id as string;
 
-  const [experiment, setExperiment] = useState<ABTest | null>(null);
-  const [metrics, setMetrics] = useState<ExperimentMetrics | null>(null);
-  const [loading, setLoading] = useState(true);
   const [actionLoading, setActionLoading] = useState(false);
-  const [error, setError] = useState("");
+  const [actionError, setActionError] = useState("");
 
-  const loadExperiment = async () => {
-    try {
-      const data = await abTestingService.getExperiment(experimentId);
-      setExperiment(data);
-    } catch (error) {
-      console.error("Failed to load experiment:", error);
-      setError("Failed to load experiment");
-    }
-  };
+  const {
+    data: experiment,
+    error: experimentError,
+    reload: loadExperiment,
+  } = useAsyncData(
+    () => abTestingService.getExperiment(experimentId),
+    [experimentId],
+    { enabled: !!experimentId, errorMessage: "Failed to load experiment" },
+  );
 
-  const loadMetrics = async () => {
-    try {
-      setLoading(true);
-      const data = await abTestingService.getExperimentMetrics(experimentId);
-      setMetrics(data);
-    } catch (error) {
-      console.error("Failed to load metrics:", error);
-    } finally {
-      setLoading(false);
-    }
-  };
+  const {
+    data: metrics,
+    loading,
+    reload: loadMetrics,
+  } = useAsyncData(
+    () => abTestingService.getExperimentMetrics(experimentId),
+    [experimentId],
+    // Metrics failures were only logged, never surfaced — keep that.
+    { enabled: !!experimentId },
+  );
 
-  useEffect(() => {
-    if (experimentId) {
-      loadExperiment();
-      loadMetrics();
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [experimentId]);
+  const error = actionError || experimentError || "";
 
   const handleStart = async () => {
     try {
@@ -82,7 +73,7 @@ export default function ExperimentDetailsPage() {
       await loadExperiment();
     } catch (error) {
       console.error("Failed to start experiment:", error);
-      setError("Failed to start experiment");
+      setActionError("Failed to start experiment");
     } finally {
       setActionLoading(false);
     }
@@ -95,7 +86,7 @@ export default function ExperimentDetailsPage() {
       await loadExperiment();
     } catch (error) {
       console.error("Failed to pause experiment:", error);
-      setError("Failed to pause experiment");
+      setActionError("Failed to pause experiment");
     } finally {
       setActionLoading(false);
     }
@@ -106,10 +97,10 @@ export default function ExperimentDetailsPage() {
       setActionLoading(true);
       await abTestingService.completeExperiment(experimentId);
       await loadExperiment();
-      setError(""); // Show success message instead
+      setActionError(""); // Show success message instead
     } catch (error) {
       console.error("Failed to complete experiment:", error);
-      setError("Failed to complete experiment");
+      setActionError("Failed to complete experiment");
     } finally {
       setActionLoading(false);
     }

--- a/apps/frontend/app/experiments/new/page.tsx
+++ b/apps/frontend/app/experiments/new/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState } from "react";
+import { useAsyncData } from "@/lib/hooks/useAsyncData";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
@@ -24,7 +25,6 @@ interface VariantConfig {
 export default function NewExperimentPage() {
   const router = useRouter();
   const [loading, setLoading] = useState(false);
-  const [models, setModels] = useState<ModelInfo[]>([]);
   const [error, setError] = useState("");
 
   // Form state
@@ -40,20 +40,15 @@ export default function NewExperimentPage() {
   const [enableDuration, setEnableDuration] = useState(false);
   const [testDurationHours, setTestDurationHours] = useState(168); // 7 days
 
-  const loadModels = async () => {
-    try {
+  const { data: modelData, error: loadError } = useAsyncData(
+    async () => {
       const data = await modelService.listModels();
-      // Filter only active models
-      setModels(data.filter((model) => model.is_active));
-    } catch (error) {
-      console.error("Failed to load models:", error);
-      setError("Failed to load models");
-    }
-  };
-
-  useEffect(() => {
-    loadModels();
-  }, []);
+      return data.filter((model) => model.is_active);
+    },
+    [],
+    { errorMessage: "Failed to load models" },
+  );
+  const models = modelData ?? [];
 
   const addVariant = () => {
     const newVariant: VariantConfig = {

--- a/apps/frontend/app/experiments/page.tsx
+++ b/apps/frontend/app/experiments/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -18,35 +18,25 @@ import {
   Clock,
   Beaker
 } from "lucide-react";
+import { useAsyncData } from "@/lib/hooks/useAsyncData";
 import { abTestingService, ABTest } from "@/lib/services/abTesting";
 import { formatDistanceToNow } from "date-fns";
 
 export default function ExperimentsPage() {
   const router = useRouter();
-  const [experiments, setExperiments] = useState<ABTest[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState("all");
 
-  const loadExperiments = async () => {
-    try {
-      setLoading(true);
-      setError(null);
-      const status = activeTab === "all" ? undefined : activeTab;
-      const data = await abTestingService.listExperiments(status);
-      setExperiments(data);
-    } catch (err) {
-      console.error("Failed to load experiments:", err);
-      setError("Failed to load experiments. Please try again.");
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  useEffect(() => {
-    loadExperiments();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [activeTab]);
+  const {
+    data: experimentData,
+    loading,
+    error,
+    reload: loadExperiments,
+  } = useAsyncData(
+    () => abTestingService.listExperiments(activeTab === "all" ? undefined : activeTab),
+    [activeTab],
+    { errorMessage: "Failed to load experiments. Please try again." },
+  );
+  const experiments = experimentData ?? [];
 
   const getStatusBadge = (status: string) => {
     const statusConfig = {

--- a/apps/frontend/app/features/page.tsx
+++ b/apps/frontend/app/features/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
+import { useAsyncData } from '@/lib/hooks/useAsyncData';
 import { useWorkflow } from '@/lib/contexts/WorkflowContext';
 import { WorkflowStage } from '@/lib/types/workflow';
 import { useStageGuard } from '@/lib/hooks/useStageGuard';
@@ -24,59 +25,67 @@ interface AiSuggestions {
 export default function FeaturesPage() {
   const { state, completeStage } = useWorkflow();
   const router = useRouter();
-  const [loading, setLoading] = useState(true);
-  const [features, setFeatures] = useState<Feature[]>([]);
-  const [selectedFeatures, setSelectedFeatures] = useState<string[]>([]);
-  const [aiSuggestions, setAiSuggestions] = useState<AiSuggestions | null>(null);
 
   // Guard: redirect (with a message) if this stage is not accessible yet.
   const { ready } = useStageGuard(WorkflowStage.FEATURE_ENGINEERING);
 
-  const loadFeatures = async () => {
-    try {
+  const { data: featureData, loading: isLoadingFeatures } = useAsyncData(
+    async () => {
       const token = await getAuthToken();
       const response = await fetch(`${API_URL}/datasets/${state.datasetId}/features`, {
-        headers: {
-          'Authorization': `Bearer ${token}`
-        }
+        headers: { Authorization: `Bearer ${token}` },
       });
+      if (!response.ok) throw new Error('Failed to load features');
+      const data = await response.json();
 
-      if (response.ok) {
-        const data = await response.json();
-        setFeatures(data.features);
-        setSelectedFeatures(data.features.map((f: Feature) => f.name));
-        
-        // Get AI suggestions
+      // Suggestions are best-effort: a failure here left the page usable before.
+      let suggestions: AiSuggestions | null = null;
+      try {
         const suggestionsResponse = await fetch(
           `${API_URL}/datasets/${state.datasetId}/features/suggestions`,
-          {
-            headers: {
-              'Authorization': `Bearer ${token}`
-            }
-          }
+          { headers: { Authorization: `Bearer ${token}` } },
         );
-        
-        if (suggestionsResponse.ok) {
-          const suggestions = await suggestionsResponse.json();
-          setAiSuggestions(suggestions);
-        }
+        if (suggestionsResponse.ok) suggestions = await suggestionsResponse.json();
+      } catch {
+        /* leave suggestions null */
       }
-    } catch (error) {
-      console.error('Failed to load features:', error);
-    } finally {
-      setLoading(false);
-    }
-  };
 
-  useEffect(() => {
-    // Wait until the stage is accessible AND the dataset id has hydrated — on a
-    // direct /features load the provider sets datasetId after this page mounts,
-    // so loading too early would fetch /datasets/undefined/features once and
-    // never retry.
-    if (!ready || !state.datasetId) return;
-    loadFeatures();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [ready, state.datasetId]);
+      return { features: data.features as Feature[], suggestions };
+    },
+    [state.datasetId],
+    // Wait for the stage AND a hydrated dataset id — on a direct /features load
+    // the provider sets datasetId after this page mounts, so firing early would
+    // fetch /datasets/undefined/features once and never retry.
+    { enabled: ready && !!state.datasetId },
+  );
+
+  // Generating features is a user action with its own spinner; the view shows one
+  // busy state, but the two no longer share a setter.
+  const [generating, setGenerating] = useState(false);
+  const loading = isLoadingFeatures || generating;
+
+  const features = featureData?.features ?? [];
+  const aiSuggestions = featureData?.suggestions ?? null;
+
+  // Everything is selected by default once features load, but the user then
+  // edits that set — so the selection is an override on top of the derived
+  // default, tagged with the dataset it belongs to so it resets on change.
+  const [selectionOverride, setSelectionOverride] = useState<{
+    datasetId: string;
+    names: string[];
+  } | null>(null);
+  const defaultSelection = features.map((f) => f.name);
+  const selectedFeatures =
+    selectionOverride && selectionOverride.datasetId === state.datasetId
+      ? selectionOverride.names
+      : defaultSelection;
+  const setSelectedFeatures = (
+    update: string[] | ((prev: string[]) => string[]),
+  ) =>
+    setSelectionOverride({
+      datasetId: state.datasetId ?? '',
+      names: typeof update === 'function' ? update(selectedFeatures) : update,
+    });
 
   const handleFeatureToggle = (featureName: string) => {
     setSelectedFeatures(prev => 
@@ -87,7 +96,7 @@ export default function FeaturesPage() {
   };
 
   const handleGenerateFeatures = async () => {
-    setLoading(true);
+    setGenerating(true);
     try {
       const token = await getAuthToken();
       const response = await fetch(
@@ -118,7 +127,7 @@ export default function FeaturesPage() {
     } catch (error) {
       console.error('Failed to generate features:', error);
     } finally {
-      setLoading(false);
+      setGenerating(false);
     }
   };
 

--- a/apps/frontend/app/model/[id]/page.tsx
+++ b/apps/frontend/app/model/[id]/page.tsx
@@ -1,10 +1,11 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+
+import { useAsyncData } from '@/lib/hooks/useAsyncData'
 import { useParams } from 'next/navigation'
 import { useSession } from 'next-auth/react'
 import { getAuthToken } from '@/lib/auth-helpers'
-import { ModelService, ModelInfo } from '@/lib/services/model'
+import { ModelService } from '@/lib/services/model'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
@@ -37,29 +38,19 @@ export default function ModelDetailPage() {
   const router = useRouter()
   
   const modelId = params?.id as string
-  const [model, setModel] = useState<ModelInfo | null>(null)
-  const [isLoading, setIsLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
 
-  const fetchModel = async () => {
-    try {
-      setIsLoading(true)
+  const {
+    data: model,
+    loading: isLoading,
+    error,
+  } = useAsyncData(
+    async () => {
       const token = await getAuthToken()
-      const modelData = await ModelService.getModel(modelId, token || '')
-      setModel(modelData)
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to load model')
-    } finally {
-      setIsLoading(false)
-    }
-  }
-
-  useEffect(() => {
-    if (session && modelId) {
-      fetchModel()
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [session, modelId])
+      return ModelService.getModel(modelId, token || '')
+    },
+    [session, modelId],
+    { enabled: !!session && !!modelId },
+  )
 
   if (!session) {
     return (

--- a/apps/frontend/app/model/page.tsx
+++ b/apps/frontend/app/model/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useState } from 'react';
+import { useAsyncData } from '@/lib/hooks/useAsyncData';
 import { useWorkflow } from '@/lib/contexts/WorkflowContext';
 import { WorkflowStage } from '@/lib/types/workflow';
 import { useStageGuard } from '@/lib/hooks/useStageGuard';
@@ -41,7 +42,6 @@ export default function ModelPage() {
   const [modelConfig, setModelConfig] = useState<ModelConfig>({
     target_column: ''
   });
-  const [columns, setColumns] = useState<string[]>([]);
   const [trainingModelId, setTrainingModelId] = useState<string | null>(null);
   const [completedStatus, setCompletedStatus] = useState<TrainingStatus | null>(null);
   const [trainingError, setTrainingError] = useState<string | null>(null);
@@ -50,67 +50,55 @@ export default function ModelPage() {
   const [showLogs, setShowLogs] = useState(false);
   // Training mode (issue #101). Defaults to Quick; updated to the dataset-based
   // recommendation when it loads (before the user interacts).
-  const [trainingMode, setTrainingMode] = useState<TrainingMode>('quick');
-  const [recommendedMode, setRecommendedMode] = useState<TrainingMode | undefined>();
-  const [recommendationReason, setRecommendationReason] = useState<string | undefined>();
-  // Once the user picks a mode, a late-arriving recommendation must not override it.
-  const modeTouchedRef = useRef(false);
+  // A user pick beats the recommendation, including one that arrives later.
+  // Expressed as an override rather than a ref + conditional setState: null means
+  // "untouched", so a late recommendation simply shows through.
+  const [modeChoice, setModeChoice] = useState<TrainingMode | null>(null);
 
   const handleModeChange = (mode: TrainingMode) => {
-    modeTouchedRef.current = true;
-    setTrainingMode(mode);
+    setModeChoice(mode);
   };
 
   // Guard: redirect (with a message) if this stage is not accessible yet.
   useStageGuard(WorkflowStage.MODEL_TRAINING);
 
-  const loadDatasetColumns = async () => {
-    try {
+  // Two independent loads, deliberately NOT combined: the recommendation is
+  // advisory and can be slow, and folding it in with the columns would make the
+  // whole form wait on it. A test pins that — it defers the recommendation and
+  // still expects the column options to render.
+  const { data: columnData } = useAsyncData(
+    async () => {
       const token = await getAuthToken();
-      // state.datasetId is a UserData id (set by the upload flow), so read the
-      // column list from the UserData record. The /datasets/{id}/schema
-      // endpoint expects a DatasetMetadata id and 404s for uploads.
-      const response = await fetch(`${API_URL}/user_data/${state.datasetId}`, {
-        headers: {
-          'Authorization': `Bearer ${token}`
-        }
+      const response = await fetch(`${API_URL}/datasets/${state.datasetId}`, {
+        headers: { Authorization: `Bearer ${token}` },
       });
+      if (!response.ok) return [] as string[];
+      const body = await response.json();
+      return ((body.data_schema ?? []) as { field_name: string }[]).map(
+        (field) => field.field_name
+      );
+    },
+    [state.datasetId],
+    { enabled: !!state.datasetId },
+  );
 
-      if (response.ok) {
-        const data = await response.json();
-        setColumns(
-          (data.data_schema ?? []).map(
-            (field: { field_name: string }) => field.field_name
-          )
-        );
-      }
-    } catch (error) {
-      console.error('Failed to load columns:', error);
-    }
-  };
+  const { data: recommendation } = useAsyncData(
+    // Advisory only — a failure just leaves the Quick default in place.
+    () =>
+      modelService
+        .getModeRecommendation(state.datasetId as string)
+        .catch((error) => {
+          console.error('Failed to load mode recommendation:', error);
+          return null;
+        }),
+    [state.datasetId],
+    { enabled: !!state.datasetId },
+  );
 
-  const loadModeRecommendation = async () => {
-    if (!state.datasetId) return;
-    try {
-      const rec = await modelService.getModeRecommendation(state.datasetId);
-      setRecommendedMode(rec.recommended_mode);
-      setRecommendationReason(rec.reason);
-      // Preselect the recommendation only if the user hasn't already picked.
-      if (!modeTouchedRef.current) {
-        setTrainingMode(rec.recommended_mode);
-      }
-    } catch (error) {
-      // Recommendation is advisory — a failure just leaves the Quick default.
-      console.error('Failed to load mode recommendation:', error);
-    }
-  };
-
-  useEffect(() => {
-    if (!state.datasetId) return;
-    loadDatasetColumns();
-    loadModeRecommendation();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [state.datasetId]);
+  const columns = columnData ?? [];
+  const recommendedMode = recommendation?.recommended_mode;
+  const recommendationReason = recommendation?.reason;
+  const trainingMode: TrainingMode = modeChoice ?? recommendedMode ?? 'quick';
 
   const handleTrainModel = async () => {
     if (!state.datasetId) return;

--- a/apps/frontend/app/monitor/[id]/page.tsx
+++ b/apps/frontend/app/monitor/[id]/page.tsx
@@ -1,17 +1,12 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
+import { useAsyncData } from '@/lib/hooks/useAsyncData'
 import { useParams } from 'next/navigation'
 import { useSession } from 'next-auth/react'
 import { getAuthToken } from '@/lib/auth-helpers'
-import {
-  ProductionService,
-  ModelMetrics,
-  UsageTimeline,
-  DeploymentHealth,
-} from '@/lib/services/production'
-import { ModelService, ModelInfo } from '@/lib/services/model'
-import type { PredictionDistribution } from '@/lib/types/api'
+import { ProductionService } from '@/lib/services/production'
+import { ModelService } from '@/lib/services/model'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
@@ -44,35 +39,21 @@ import Link from 'next/link'
 import { LineChart } from '@/components/LineChart'
 import { BarChart } from '@/components/BarChart'
 
-interface PredictionLog {
-  prediction_id: string
-  timestamp: string
-  prediction: unknown
-  probability?: number
-  latency_ms: number
-  api_key_id?: string
-}
-
 export default function ModelMonitoringPage() {
   const params = useParams()
   const { data: session } = useSession()
   
   const modelId = params?.id as string
-  const [model, setModel] = useState<ModelInfo | null>(null)
-  const [metrics, setMetrics] = useState<ModelMetrics | null>(null)
-  const [predictionLogs, setPredictionLogs] = useState<PredictionLog[]>([])
-  const [distribution, setDistribution] = useState<PredictionDistribution | null>(null)
-  const [timeline, setTimeline] = useState<UsageTimeline | null>(null)
-  const [health, setHealth] = useState<DeploymentHealth | null>(null)
-  const [isLoading, setIsLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
   const [timeWindow, setTimeWindow] = useState('24')
 
-  const fetchModelData = async () => {
-    try {
-      setIsLoading(true)
+  const {
+    data: monitorData,
+    loading: isLoading,
+    error,
+    reload: fetchModelData,
+  } = useAsyncData(
+    async () => {
       const token = await getAuthToken()
-      
       const hours = parseInt(timeWindow)
       const [modelData, metricsData, logsData, distData, timelineData, healthData] =
         await Promise.all([
@@ -83,26 +64,25 @@ export default function ModelMonitoringPage() {
           ProductionService.getUsageTimeline(modelId, hours, token),
           ProductionService.getDeploymentHealth(modelId, hours, token),
         ])
+      return {
+        model: modelData,
+        metrics: metricsData,
+        predictionLogs: logsData.logs,
+        distribution: distData,
+        timeline: timelineData,
+        health: healthData,
+      }
+    },
+    [modelId, timeWindow],
+    { enabled: !!modelId, errorMessage: 'Failed to load model monitoring data' },
+  )
 
-      setModel(modelData)
-      setMetrics(metricsData)
-      setPredictionLogs(logsData.logs)
-      setDistribution(distData)
-      setTimeline(timelineData)
-      setHealth(healthData)
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to load model monitoring data')
-    } finally {
-      setIsLoading(false)
-    }
-  }
-
-  useEffect(() => {
-    if (modelId) {
-      fetchModelData()
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [modelId, timeWindow])
+  const model = monitorData?.model ?? null
+  const metrics = monitorData?.metrics ?? null
+  const predictionLogs = monitorData?.predictionLogs ?? []
+  const distribution = monitorData?.distribution ?? null
+  const timeline = monitorData?.timeline ?? null
+  const health = monitorData?.health ?? null
 
   const formatLatency = (ms: number) => {
     if (ms < 1) return '<1ms'

--- a/apps/frontend/app/monitor/page.tsx
+++ b/apps/frontend/app/monitor/page.tsx
@@ -1,9 +1,10 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
+import { useAsyncData } from '@/lib/hooks/useAsyncData'
 import { useSession } from 'next-auth/react'
 import { getAuthToken } from '@/lib/auth-helpers'
-import { ProductionService, UsageStats, APIKeyUsage } from '@/lib/services/production'
+import { ProductionService } from '@/lib/services/production'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
@@ -33,36 +34,27 @@ import { useRouter } from 'next/navigation'
 export default function MonitoringPage() {
   const { data: session } = useSession()
   const router = useRouter()
-  const [usageStats, setUsageStats] = useState<UsageStats | null>(null)
-  const [apiKeyUsage, setApiKeyUsage] = useState<APIKeyUsage[]>([])
-  const [isLoading, setIsLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
   const [activeTab, setActiveTab] = useState('overview')
 
-  const fetchMonitoringData = async () => {
-    try {
-      setIsLoading(true)
+  const {
+    data: monitoring,
+    loading: isLoading,
+    error,
+    reload: fetchMonitoringData,
+  } = useAsyncData(
+    async () => {
       const token = await getAuthToken()
-      
       const [stats, keyUsage] = await Promise.all([
         ProductionService.getUsageOverview(token),
-        ProductionService.getAPIKeyUsage(token)
+        ProductionService.getAPIKeyUsage(token),
       ])
-      
-      setUsageStats(stats)
-      setApiKeyUsage(keyUsage)
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to load monitoring data')
-    } finally {
-      setIsLoading(false)
-    }
-  }
-
-  useEffect(() => {
-    if (session) {
-      fetchMonitoringData()
-    }
-  }, [session])
+      return { stats, keyUsage }
+    },
+    [session],
+    { enabled: !!session },
+  )
+  const usageStats = monitoring?.stats ?? null
+  const apiKeyUsage = monitoring?.keyUsage ?? []
 
   const formatLatency = (ms: number) => {
     if (ms < 1) return '<1ms'

--- a/apps/frontend/app/onboarding/page.tsx
+++ b/apps/frontend/app/onboarding/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
+import { useAsyncData } from '@/lib/hooks/useAsyncData';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -69,49 +70,43 @@ interface Achievement {
 
 export default function OnboardingPage() {
   const router = useRouter();
-  const [status, setStatus] = useState<OnboardingStatus | null>(null);
-  const [steps, setSteps] = useState<StepInfo[]>([]);
-  const [currentStep, setCurrentStep] = useState<StepInfo | null>(null);
-  const [achievements, setAchievements] = useState<Achievement[]>([]);
-  const [loading, setLoading] = useState(true);
   const [completingStep, setCompletingStep] = useState(false);
   const [showCelebration, setShowCelebration] = useState(false);
 
-  const loadOnboardingData = async () => {
-    try {
-      setLoading(true);
-      
-      // Load onboarding status
-      const statusResponse = await fetch('/api/v1/onboarding/status');
-      const statusData = await statusResponse.json();
-      setStatus(statusData);
+  const {
+    data: onboarding,
+    loading,
+    reload: loadOnboardingData,
+  } = useAsyncData(async () => {
+    const statusResponse = await fetch('/api/v1/onboarding/status');
+    const statusData: OnboardingStatus = await statusResponse.json();
 
-      // Load steps
-      const stepsResponse = await fetch('/api/v1/onboarding/steps');
-      const stepsData = await stepsResponse.json();
-      setSteps(stepsData);
+    const stepsResponse = await fetch('/api/v1/onboarding/steps');
+    const stepsData: StepInfo[] = await stepsResponse.json();
 
-      // Set current step
-      if (statusData.current_step_id) {
-        const current = stepsData.find((s: StepInfo) => s.step_id === statusData.current_step_id);
-        setCurrentStep(current || null);
-      }
+    const achievementsResponse = await fetch('/api/v1/onboarding/achievements');
+    const achievementsData = await achievementsResponse.json();
 
-      // Load achievements
-      const achievementsResponse = await fetch('/api/v1/onboarding/achievements');
-      const achievementsData = await achievementsResponse.json();
-      setAchievements(achievementsData.achievements || []);
-
-    } catch (error) {
-      console.error('Failed to load onboarding data:', error);
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  useEffect(() => {
-    loadOnboardingData();
+    return {
+      status: statusData,
+      steps: stepsData,
+      // Derived from the two above rather than stored separately.
+      currentStep: statusData.current_step_id
+        ? stepsData.find((s) => s.step_id === statusData.current_step_id) || null
+        : null,
+      achievements: (achievementsData.achievements || []) as Achievement[],
+    };
   }, []);
+
+  // currentStep defaults to whatever the backend says is current, but the user can
+  // also click a step in the sidebar to view it, so a local selection overrides it.
+  const [selectedStep, setSelectedStep] = useState<StepInfo | null>(null);
+  const setCurrentStep = setSelectedStep;
+
+  const status = onboarding?.status ?? null;
+  const steps = onboarding?.steps ?? [];
+  const currentStep = selectedStep ?? onboarding?.currentStep ?? null;
+  const achievements = onboarding?.achievements ?? [];
 
   const completeStep = async (stepId: string, completionData?: Record<string, unknown>) => {
     try {

--- a/apps/frontend/app/predict/page.tsx
+++ b/apps/frontend/app/predict/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
+import { useAsyncData } from '@/lib/hooks/useAsyncData';
 import { useWorkflow } from '@/lib/contexts/WorkflowContext';
 import { WorkflowStage } from '@/lib/types/workflow';
 import { useStageGuard } from '@/lib/hooks/useStageGuard';
@@ -29,15 +30,13 @@ export default function PredictPage() {
 
   const [loading, setLoading] = useState(false);
   const [predictionMode, setPredictionMode] = useState<'single' | 'batch'>('single');
-  const [features, setFeatures] = useState<ModelFeatureDescriptor[]>([]);
-  const [predictionInput, setPredictionInput] = useState<PredictionInput>({});
   // Track which fields the user has interacted with so validation errors only
   // surface once "touched" — no red "Required" on a pristine form (issue #282).
   // (The submit button stays disabled until the form is valid, so blur is the
   // trigger that reveals what still needs filling.)
   const [touched, setTouched] = useState<Record<string, boolean>>({});
   const [prediction, setPrediction] = useState<PredictResponse | null>(null);
-  const [error, setError] = useState<string | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
 
   // Batch state
   const [batchFile, setBatchFile] = useState<File | null>(null);
@@ -46,10 +45,9 @@ export default function PredictPage() {
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const isMountedRef = useRef(true);
 
-  const loadModelFeatures = useCallback(async () => {
-    try {
+  const { data: featureData, error: featuresError } = useAsyncData(
+    async () => {
       const data = await modelService.getModelFeatures(state.modelId as string);
-      setFeatures(data.features);
       const defaultInput: PredictionInput = {};
       data.features.forEach((feature) => {
         defaultInput[feature.name] =
@@ -57,11 +55,37 @@ export default function PredictPage() {
             ? String(feature.options[0])
             : '';
       });
-      setPredictionInput(defaultInput);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to load model features');
-    }
-  }, [state.modelId]);
+      return { features: data.features, defaultInput };
+    },
+    [state.modelId],
+    // No errorMessage override: the original surfaced err.message, and only fell
+    // back to fixed copy for non-Error throws, which is the hook's default.
+    { enabled: ready && !!state.modelId },
+  );
+
+  // Prediction failures are the user's action; a schema-load failure is the
+  // page's. Displayed as one value, tracked apart.
+  const error = actionError ?? featuresError;
+
+  const features = featureData?.features ?? [];
+
+  // The form is seeded from the model's schema and then edited, so edits are an
+  // override tagged with the model they belong to — switching models resets it.
+  const [inputOverride, setInputOverride] = useState<{
+    modelId: string;
+    values: PredictionInput;
+  } | null>(null);
+  const predictionInput =
+    inputOverride && inputOverride.modelId === state.modelId
+      ? inputOverride.values
+      : featureData?.defaultInput ?? {};
+  const setPredictionInput = (
+    update: PredictionInput | ((prev: PredictionInput) => PredictionInput),
+  ) =>
+    setInputOverride({
+      modelId: state.modelId ?? '',
+      values: typeof update === 'function' ? update(predictionInput) : update,
+    });
 
   useEffect(() => {
     // Stage access (with a helpful redirect) is handled by useStageGuard, which
@@ -73,9 +97,7 @@ export default function PredictPage() {
         WorkflowStage.MODEL_TRAINING,
         'Train a model before making predictions.'
       );
-      return;
     }
-    loadModelFeatures();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [ready, state.modelId]);
 
@@ -116,7 +138,7 @@ export default function PredictPage() {
   const handleSinglePrediction = async () => {
     if (!formValid) return;
     setLoading(true);
-    setError(null);
+    setActionError(null);
     setPrediction(null);
     try {
       const result = await modelService.predict(state.modelId as string, {
@@ -133,7 +155,7 @@ export default function PredictPage() {
         });
       }
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Prediction failed');
+      setActionError(err instanceof Error ? err.message : 'Prediction failed');
     } finally {
       setLoading(false);
     }
@@ -149,7 +171,7 @@ export default function PredictPage() {
   const handleBatchPrediction = async () => {
     if (!batchFile) return;
     setLoading(true);
-    setError(null);
+    setActionError(null);
     setBatchJob(null);
     setBatchProgress(null);
     stopPolling();
@@ -187,11 +209,11 @@ export default function PredictPage() {
           stopPolling();
           if (!isMountedRef.current) return;
           setLoading(false);
-          setError('Lost connection to the batch job. Please refresh.');
+          setActionError('Lost connection to the batch job. Please refresh.');
         }
       }, BATCH_POLL_INTERVAL_MS);
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to start batch prediction');
+      setActionError(err instanceof Error ? err.message : 'Failed to start batch prediction');
       setLoading(false);
     }
   };
@@ -209,7 +231,7 @@ export default function PredictPage() {
       a.remove();
       window.URL.revokeObjectURL(url);
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to download results');
+      setActionError(err instanceof Error ? err.message : 'Failed to download results');
     }
   };
 

--- a/apps/frontend/app/review/page.tsx
+++ b/apps/frontend/app/review/page.tsx
@@ -3,7 +3,8 @@
 // apps/frontend/app/review/page.tsx
 import { useSession } from 'next-auth/react'
 import { getAuthToken } from '@/lib/auth-helpers'
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect } from 'react'
+import { useAsyncData } from '@/lib/hooks/useAsyncData'
 import { StatsCard } from '@/components/StatsCard'
 import { calculateDescriptiveStats, StatItem } from '@/lib/utils'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
@@ -54,61 +55,42 @@ interface AISummary {
 export default function ReviewPage() {
   const { data: session } = useSession()
   const router = useRouter()
-  const [data, setData] = useState<UserData | null>(null)
-  const [datasets, setDatasets] = useState<Dataset[]>([])
   const [selectedDatasetId, setSelectedDatasetId] = useState<string | null>(null)
-  const [stats, setStats] = useState<StatItem[]>([])
-  const [error, setError] = useState<string | null>(null)
-  const [isLoading, setIsLoading] = useState(true)
-  const { isLoading: isLoadingAISummary, error: aiSummaryError, isAvailable: isAISummaryAvailable } = useDatasetChatContext(data?.id || null);
   const [aiSummary, setAiSummary] = useState<AISummary | null>(null);
 
-  const fetchDatasets = useCallback(async () => {
-    if (!session?.user?.id) return
-
-    try {
+  const { data: datasetList, error: datasetsError } = useAsyncData<Dataset[]>(
+    async () => {
       const response = await fetch(`${API_URL}/user_data`, {
-        headers: {
-          'Authorization': `Bearer ${await getAuthToken()}`
-        }
+        headers: { Authorization: `Bearer ${await getAuthToken()}` },
       })
-
       if (!response.ok) {
         throw new Error('Failed to fetch datasets')
       }
+      return response.json()
+    },
+    [session],
+    { enabled: !!session?.user?.id },
+  )
+  const datasets = datasetList ?? []
 
-      const result = await response.json()
-      setDatasets(result)
-    } catch (err) {
-      console.error('Error fetching datasets:', err)
-      setError(err instanceof Error ? err.message : 'An error occurred')
-    }
-  }, [session])
-
-  const fetchPreviewData = useCallback(async () => {
-    if (!session?.user?.id || !selectedDatasetId) return
-
-    try {
-      setIsLoading(true)
-      setError(null)
-      
+  const {
+    data: preview,
+    loading: isLoading,
+    error: previewError,
+  } = useAsyncData(
+    async () => {
       const response = await fetch(`${API_URL}/user_data/preview/${selectedDatasetId}`, {
-        headers: {
-          'Authorization': `Bearer ${await getAuthToken()}`
-        }
+        headers: { Authorization: `Bearer ${await getAuthToken()}` },
       })
-
       if (!response.ok) {
         const errorText = await response.text()
         throw new Error(`Failed to fetch preview data: ${errorText}`)
       }
-
       const result = await response.json()
-      
-      // Transform the data to match our UserData interface
+
       const transformedData: UserData = {
         id: result.id,
-        user_id: session.user.id,
+        user_id: session!.user!.id,
         file_name: result.fileName,
         file_path: result.s3_url,
         file_size: 0, // Not provided by API
@@ -121,35 +103,29 @@ export default function ReviewPage() {
         previewData: result.previewData,
         headers: result.headers,
         ai_summary: '',
-        error: result.error
+        error: result.error,
       }
-      
-      setData(transformedData)
-      
-      // Calculate descriptive statistics
-      if (result.headers && result.previewData) {
-        const calculatedStats = calculateDescriptiveStats(result.previewData, result.headers)
-        setStats(calculatedStats)
+
+      // Stats are a pure function of the response, so they ride along with it
+      // instead of being a second piece of state.
+      return {
+        data: transformedData,
+        stats:
+          result.headers && result.previewData
+            ? calculateDescriptiveStats(result.previewData, result.headers)
+            : ([] as StatItem[]),
       }
-    } catch (err) {
-      console.error('Error fetching preview data:', err)
-      setError(err instanceof Error ? err.message : 'An error occurred')
-    } finally {
-      setIsLoading(false)
-    }
-  }, [session, selectedDatasetId])
+    },
+    [session, selectedDatasetId],
+    { enabled: !!session?.user?.id && !!selectedDatasetId },
+  )
 
-  useEffect(() => {
-    if (session) {
-      fetchDatasets()
-    }
-  }, [session, fetchDatasets])
+  const data = preview?.data ?? null
+  const stats = preview?.stats ?? []
+  const error = datasetsError ?? previewError
 
-  useEffect(() => {
-    if (selectedDatasetId) {
-      fetchPreviewData()
-    }
-  }, [selectedDatasetId, fetchPreviewData])
+  const { isLoading: isLoadingAISummary, error: aiSummaryError, isAvailable: isAISummaryAvailable } = useDatasetChatContext(data?.id || null);
+
 
   useEffect(() => {
     const fetchAISummary = async () => {

--- a/apps/frontend/app/settings/api/page.tsx
+++ b/apps/frontend/app/settings/api/page.tsx
@@ -1,9 +1,10 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
+import { useAsyncData } from '@/lib/hooks/useAsyncData'
 import { useSession } from 'next-auth/react'
 import { getAuthToken } from '@/lib/auth-helpers'
-import { ProductionService, APIKeyInfo, CreateAPIKeyRequest } from '@/lib/services/production'
+import { ProductionService, CreateAPIKeyRequest } from '@/lib/services/production'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -44,9 +45,7 @@ import {
 } from 'lucide-react'
 export default function APIKeysPage() {
   const { data: session } = useSession()
-  const [apiKeys, setApiKeys] = useState<APIKeyInfo[]>([])
-  const [isLoading, setIsLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
+  const [actionError, setActionError] = useState<string | null>(null)
   const [deleteKeyId, setDeleteKeyId] = useState<string | null>(null)
   
   // Create API Key Dialog
@@ -62,31 +61,26 @@ export default function APIKeysPage() {
   const [hasExpiry, setHasExpiry] = useState(false)
   const [expiryDays, setExpiryDays] = useState([30])
 
-  const fetchAPIKeys = async () => {
-    try {
-      setIsLoading(true)
-      const token = await getAuthToken()
-      const keys = await ProductionService.listAPIKeys(token)
-      setApiKeys(keys)
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to load API keys')
-    } finally {
-      setIsLoading(false)
-    }
-  }
-
-  useEffect(() => {
-    fetchAPIKeys()
+  const {
+    data: keyData,
+    loading: isLoading,
+    error: fetchError,
+    reload: fetchAPIKeys,
+  } = useAsyncData(async () => {
+    const token = await getAuthToken()
+    return ProductionService.listAPIKeys(token)
   }, [])
+  const apiKeys = keyData ?? []
+  const error = actionError ?? fetchError
 
   const handleCreateKey = async () => {
     if (!keyName.trim()) {
-      setError('Please provide a name for the API key')
+      setActionError('Please provide a name for the API key')
       return
     }
 
     setIsCreating(true)
-    setError(null)
+    setActionError(null)
 
     try {
       const token = await getAuthToken()
@@ -104,7 +98,7 @@ export default function APIKeysPage() {
       // Refresh the list
       await fetchAPIKeys()
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to create API key')
+      setActionError(err instanceof Error ? err.message : 'Failed to create API key')
     } finally {
       setIsCreating(false)
     }
@@ -116,7 +110,7 @@ export default function APIKeysPage() {
       await ProductionService.revokeAPIKey(keyId, token)
       await fetchAPIKeys()
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to revoke API key')
+      setActionError(err instanceof Error ? err.message : 'Failed to revoke API key')
     }
     setDeleteKeyId(null)
   }
@@ -127,7 +121,7 @@ export default function APIKeysPage() {
       setCopiedKey(true)
       setTimeout(() => setCopiedKey(false), 2000)
     } catch {
-      setError('Failed to copy to clipboard')
+      setActionError('Failed to copy to clipboard')
     }
   }
 

--- a/apps/frontend/app/training/page.tsx
+++ b/apps/frontend/app/training/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
+import { useAsyncData } from '@/lib/hooks/useAsyncData';
 import { useSession } from 'next-auth/react';
 import { modelService, TrainingJobStatus, TrainingJobSummary } from '@/lib/services/model';
 import { TrainingProgress, formatDuration } from '@/components/training/TrainingProgress';
@@ -58,95 +59,94 @@ function statusBadgeVariant(
  */
 export default function TrainingJobsPage() {
   const { data: session } = useSession();
-  const [inFlightJobs, setInFlightJobs] = useState<TrainingJobSummary[]>([]);
-  const [historyJobs, setHistoryJobs] = useState<TrainingJobSummary[]>([]);
-  const [historyTotal, setHistoryTotal] = useState(0);
-  const [historySkip, setHistorySkip] = useState(0);
   const [statusFilter, setStatusFilter] = useState<HistoryFilter>('all');
-  const [isLoading, setIsLoading] = useState(true);
   const [isLoadingMore, setIsLoadingMore] = useState(false);
-  const [error, setError] = useState<string | null>(null);
   // Monotonic id so an out-of-order history response (slow request for a
   // previous filter resolving late) can never overwrite newer rows.
-  const historyRequestSeq = useRef(0);
 
-  const fetchInFlight = useCallback(async () => {
-    try {
+  // `session` gets a fresh object identity on re-renders/session refreshes; the
+  // hooks must key off this stable flag or they re-fetch on every render.
+  const isAuthenticated = !!session;
+
+  const {
+    data: inFlightData,
+    loading: isLoadingInFlight,
+    error: inFlightError,
+    reload: fetchInFlight,
+  } = useAsyncData(
+    async () => {
       const [pending, running] = await Promise.all([
         modelService.listTrainingJobs({ status: 'pending', limit: IN_FLIGHT_FETCH_LIMIT }),
         modelService.listTrainingJobs({ status: 'running', limit: IN_FLIGHT_FETCH_LIMIT }),
       ]);
       // A job can transition pending->running between the two queries and
       // show up in both lists; dedupe by model_id (running wins).
-      const deduped = Array.from(
+      return Array.from(
         new Map(
           [...pending.jobs, ...running.jobs].map((job) => [job.model_id, job])
         ).values()
       );
-      setInFlightJobs(deduped);
-      setError(null);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to fetch training jobs');
-    }
-  }, []);
-
-  const fetchHistory = useCallback(
-    async (filter: HistoryFilter, skip: number, append: boolean) => {
-      const requestId = ++historyRequestSeq.current;
-      try {
-        const response = await modelService.listTrainingJobs({
-          status: filter === 'all' ? ALL_TERMINAL_FILTER : filter,
-          limit: HISTORY_PAGE_SIZE,
-          skip,
-        });
-        if (requestId !== historyRequestSeq.current) return;
-        setHistoryJobs((prev) =>
-          append ? [...prev, ...response.jobs] : response.jobs
-        );
-        setHistoryTotal(response.total_count);
-        setHistorySkip(skip);
-        setError(null);
-      } catch (err) {
-        if (requestId !== historyRequestSeq.current) return;
-        setError(err instanceof Error ? err.message : 'Failed to fetch training history');
-      }
     },
-    []
+    [isAuthenticated],
+    {
+      enabled: isAuthenticated,
+      errorMessage: 'Failed to fetch training jobs',
+      // Polling must not blank the list between ticks.
+      keepPreviousData: true,
+    },
   );
+  const inFlightJobs = inFlightData ?? [];
 
-  // `session` gets a fresh object identity on re-renders/session refreshes;
-  // effects must key off this stable flag or they re-fetch (and silently
-  // reset the filtered history back to "all") on every render.
-  const isAuthenticated = !!session;
-
-  // Initial in-flight load + periodic refresh.
+  // Periodic refresh: reload() runs from the timer callback, not the effect body.
   useEffect(() => {
     if (!isAuthenticated) return;
-
-    let isMounted = true;
-    fetchInFlight().finally(() => {
-      if (isMounted) setIsLoading(false);
-    });
-
     const intervalId = setInterval(fetchInFlight, IN_FLIGHT_REFRESH_MS);
-    return () => {
-      isMounted = false;
-      clearInterval(intervalId);
-    };
+    return () => clearInterval(intervalId);
   }, [isAuthenticated, fetchInFlight]);
 
-  // History load: initial and whenever the status filter changes.
-  useEffect(() => {
-    if (!isAuthenticated) return;
-    fetchHistory(statusFilter, 0, false);
-  }, [isAuthenticated, statusFilter, fetchHistory]);
+  // First page of history. Later pages are appended by the Load more handler
+  // below rather than by an effect, because paging is user-driven — which is
+  // also why the accumulating shape never fitted a keyed loader.
+  const {
+    data: historyPage,
+    error: historyError,
+    reload: reloadHistory,
+  } = useAsyncData(
+    () =>
+      modelService.listTrainingJobs({
+        status: statusFilter === 'all' ? ALL_TERMINAL_FILTER : statusFilter,
+        limit: HISTORY_PAGE_SIZE,
+        skip: 0,
+      }),
+    [isAuthenticated, statusFilter],
+    { enabled: isAuthenticated, errorMessage: 'Failed to fetch training history', keepPreviousData: true },
+  );
+
+  // Pages beyond the first, tagged with the filter they belong to so changing
+  // the filter discards them by derivation instead of a reset.
+  const [appended, setAppended] = useState<{
+    filter: HistoryFilter;
+    jobs: TrainingJobSummary[];
+    skip: number;
+  }>({ filter: statusFilter, jobs: [], skip: 0 });
+  const appendedForFilter =
+    appended.filter === statusFilter ? appended : { filter: statusFilter, jobs: [], skip: 0 };
+
+  const historyJobs = [...(historyPage?.jobs ?? []), ...appendedForFilter.jobs];
+  const historyTotal = historyPage?.total_count ?? 0;
+  const historySkip = appendedForFilter.skip;
+
+  const error = inFlightError ?? historyError;
+  const isLoading = isLoadingInFlight;
+
 
   // A card's job finished (completed/failed/cancelled): move it from the
   // in-flight section into the history table.
   const handleJobSettled = useCallback(() => {
     fetchInFlight();
-    fetchHistory(statusFilter, 0, false);
-  }, [fetchInFlight, fetchHistory, statusFilter]);
+    setAppended({ filter: statusFilter, jobs: [], skip: 0 });
+    reloadHistory();
+  }, [fetchInFlight, reloadHistory, statusFilter]);
 
   const hasMoreHistory = historySkip + HISTORY_PAGE_SIZE < historyTotal;
 
@@ -156,7 +156,17 @@ export default function TrainingJobsPage() {
     if (isLoadingMore) return;
     setIsLoadingMore(true);
     try {
-      await fetchHistory(statusFilter, historySkip + HISTORY_PAGE_SIZE, true);
+      const nextSkip = historySkip + HISTORY_PAGE_SIZE;
+      const response = await modelService.listTrainingJobs({
+        status: statusFilter === 'all' ? ALL_TERMINAL_FILTER : statusFilter,
+        limit: HISTORY_PAGE_SIZE,
+        skip: nextSkip,
+      });
+      setAppended((prev) => {
+        const base =
+          prev.filter === statusFilter ? prev : { filter: statusFilter, jobs: [], skip: 0 };
+        return { filter: statusFilter, jobs: [...base.jobs, ...response.jobs], skip: nextSkip };
+      });
     } finally {
       setIsLoadingMore(false);
     }

--- a/apps/frontend/components/AIChat.tsx
+++ b/apps/frontend/components/AIChat.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useRef, useEffect } from 'react'
+import { useState, useRef, useEffect, useMemo } from 'react'
 import { useDatasetChatContext } from '@/lib/hooks/useDatasetChatContext'
 import { useSession } from 'next-auth/react'
 import { Send, Loader2 } from 'lucide-react'
@@ -11,6 +11,35 @@ interface Message {
   content: string
 }
 
+
+// Welcome-message templates. Extracted so the message can be derived during
+// render instead of assembled inside an effect (#393).
+const WELCOME_ERROR = (contextError: string) => `Hello! I'm your AI data analysis assistant. I noticed there was an issue loading your dataset analysis. 
+
+${contextError}
+
+You can still ask me questions about your data, but I may not have all the context about your dataset.
+
+What would you like to know about your data?`
+
+const WELCOME_WITH_CONTEXT = (contextString: string) => `Hello! I'm your AI data analysis assistant. I've analyzed your dataset and can help you explore it further. 
+
+Here's what I've found so far:
+${contextString}
+
+How can I help you analyze this data? You can ask me questions about:
+- Specific patterns or trends
+- Data quality issues
+- Relationships between variables
+- Suggestions for further analysis
+- Or any other aspects of your dataset`
+
+const WELCOME_PLAIN = `Hello! I'm your AI data analysis assistant. I don't see any dataset analysis available yet.
+
+You can upload a dataset to get started, or you can ask me general questions about data analysis.
+
+How can I help you today?`
+
 export function AIChat() {
   const { data: session } = useSession()
   const [messages, setMessages] = useState<Message[]>([])
@@ -20,8 +49,6 @@ export function AIChat() {
   const messagesEndRef = useRef<HTMLDivElement>(null)
   const chatContainerRef = useRef<HTMLDivElement>(null)
   const { contextString, isLoading: isContextLoading, error: contextError, isAvailable } = useDatasetChatContext(session?.user?.id ?? null)
-  const initialMessageSetRef = useRef(false)
-  const contextUpdatedRef = useRef(false)
 
   const scrollToBottom = () => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' })
@@ -40,114 +67,24 @@ export function AIChat() {
     return () => clearTimeout(timer)
   }, [])
 
-  // Initialize chat with a welcome message when context is loaded
-  useEffect(() => {
-    // Don't set any messages while the page is loading
-    if (isPageLoading) return;
-    
-    // Don't set messages if we're still loading the context
-    if (isContextLoading) return;
-    
-    // Only set initial message once when context is loaded
-    if (initialMessageSetRef.current) return;
-    
+  // The welcome message is a pure function of the context state, so it is derived
+  // during render and prepended to the conversation rather than written into
+  // `messages` by an effect. That also removes the follow-up effect whose only
+  // job was to rewrite this message once the context finished loading, plus the
+  // two refs that existed to stop these effects fighting each other.
+  const welcomeMessage: Message | null = useMemo(() => {
+    if (isPageLoading || isContextLoading) return null;
     if (contextError) {
-      setMessages([
-        {
-          role: 'assistant',
-          content: `Hello! I'm your AI data analysis assistant. I noticed there was an issue loading your dataset analysis. 
-
-${contextError}
-
-You can still ask me questions about your data, but I may not have all the context about your dataset.
-
-What would you like to know about your data?`
-        }
-      ]);
-      initialMessageSetRef.current = true;
-      return;
+      return { role: 'assistant', content: WELCOME_ERROR(contextError) };
     }
-
-    // Only show "no dataset" message if we're not loading and there's no context
-    if (!contextString && !isAvailable) {
-      setMessages([
-        {
-          role: 'assistant',
-          content: `Hello! I'm your AI data analysis assistant. I don't see any dataset analysis available yet.
-
-You can upload a dataset to get started, or you can ask me general questions about data analysis.
-
-How can I help you today?`
-        }
-      ]);
-      initialMessageSetRef.current = true;
-      return;
-    }
-
-    // Show dataset context if available
     if (contextString && isAvailable) {
-      setMessages([
-        {
-          role: 'assistant',
-          content: `Hello! I'm your AI data analysis assistant. I've analyzed your dataset and can help you explore it further. 
-
-Here's what I've found so far:
-${contextString}
-
-How can I help you analyze this data? You can ask me questions about:
-- Specific patterns or trends
-- Data quality issues
-- Relationships between variables
-- Suggestions for further analysis
-- Or any other aspects of your dataset`
-        }
-      ]);
-      initialMessageSetRef.current = true;
+      return { role: 'assistant', content: WELCOME_WITH_CONTEXT(contextString) };
     }
-  }, [contextString, isContextLoading, contextError, isPageLoading, isAvailable]);
+    return { role: 'assistant', content: WELCOME_PLAIN };
+  }, [isPageLoading, isContextLoading, contextError, contextString, isAvailable]);
 
-  // Update messages when context changes after initial load
-  useEffect(() => {
-    // Skip if still loading or if initial message hasn't been set yet
-    if (isPageLoading || isContextLoading || !initialMessageSetRef.current) return;
-    
-    // Only update if we have a new context and it's available
-    if (contextString && isAvailable) {
-      // Use a ref to track if we've already updated for this context
-      if (!contextUpdatedRef.current) {
-        // Update the first message with the new context
-        setMessages(prev => {
-          // Only update if the first message is from the assistant (welcome message)
-          if (prev.length > 0 && prev[0].role === 'assistant') {
-            return [
-              {
-                role: 'assistant',
-                content: `Hello! I'm your AI data analysis assistant. I've analyzed your dataset and can help you explore it further. 
+  const displayedMessages = welcomeMessage ? [welcomeMessage, ...messages] : messages;
 
-Here's what I've found so far:
-${contextString}
-
-How can I help you analyze this data? You can ask me questions about:
-- Specific patterns or trends
-- Data quality issues
-- Relationships between variables
-- Suggestions for further analysis
-- Or any other aspects of your dataset`
-              },
-              ...prev.slice(1) // Keep all other messages
-            ];
-          }
-          return prev;
-        });
-        
-        // Mark that we've updated for this context
-        contextUpdatedRef.current = true;
-      }
-    } else {
-      // Reset the context updated flag when context is not available
-      contextUpdatedRef.current = false;
-    }
-  }, [contextString, isAvailable, isContextLoading, isPageLoading]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -224,7 +161,7 @@ How can I help you analyze this data? You can ask me questions about:
           </div>
         ) : (
           <>
-            {messages.map((message, index) => (
+            {displayedMessages.map((message, index) => (
               <div
                 key={index}
                 className={`flex ${message.role === 'user' ? 'justify-end' : 'justify-start'}`}

--- a/apps/frontend/components/AIInsightsPanel.tsx
+++ b/apps/frontend/components/AIInsightsPanel.tsx
@@ -1,6 +1,7 @@
 'use client'
 
-import React, { useState, useEffect } from 'react'
+import React, { useState } from 'react'
+import { useAsyncData } from '@/lib/hooks/useAsyncData'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
@@ -37,43 +38,51 @@ interface AIInsightsPanelProps {
 }
 
 export function AIInsightsPanel({ datasetId, initialSummary }: AIInsightsPanelProps) {
-  const [summary, setSummary] = useState<AISummary | null>(initialSummary || null)
-  const [loading, setLoading] = useState(false)
-  const [error, setError] = useState<string | null>(null)
   const [activeTab, setActiveTab] = useState('overview')
 
-  const generateSummary = async () => {
-    try {
-      setLoading(true)
-      setError(null)
-      
+  // The panel has a "regenerate" button, so a caller-supplied summary must
+  // suppress only the *automatic* first fetch, not manual ones. Flipping this
+  // enables the hook, and reload() covers every press after.
+  const [regenerateRequested, setRegenerateRequested] = useState(false)
+
+  const {
+    data: fetchedSummary,
+    loading,
+    error,
+    reload,
+  } = useAsyncData<AISummary>(
+    async () => {
       const response = await fetch(`/api/ai/summarize/${datasetId}`, {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
         credentials: 'include',
       })
-
       if (!response.ok) {
         throw new Error('Failed to generate AI summary')
       }
+      return response.json()
+    },
+    [datasetId],
+    // A caller-supplied summary means "don't generate", matching the old
+    // `if (!summary && !loading)` guard.
+    {
+      // Regenerating must not blank the panel the button lives in — the old code
+      // kept the previous summary rendered while the new one loaded.
+      enabled: !initialSummary || regenerateRequested,
+      keepPreviousData: true,
+    },
+  )
 
-      const data = await response.json()
-      setSummary(data)
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'An error occurred')
-    } finally {
-      setLoading(false)
-    }
+  // BEHAVIOUR CHANGE, deliberate: the old guard also blocked regeneration when
+  // datasetId changed, because `summary` was still set from the previous dataset —
+  // so switching datasets showed the wrong dataset's insights. Keying on datasetId
+  // fixes that. See #393.
+  const summary = fetchedSummary ?? initialSummary ?? null
+
+  const generateSummary = () => {
+    setRegenerateRequested(true)
+    reload()
   }
-
-  useEffect(() => {
-    if (!summary && !loading) {
-      generateSummary()
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [datasetId])
 
   if (loading && !summary) {
     return (

--- a/apps/frontend/components/DataPreviewTable.tsx
+++ b/apps/frontend/components/DataPreviewTable.tsx
@@ -1,6 +1,7 @@
 'use client'
 
-import React, { useState, useEffect } from 'react'
+import React, { useState } from 'react'
+import { useAsyncData } from '@/lib/hooks/useAsyncData'
 import {
   Table,
   TableBody,
@@ -27,75 +28,34 @@ interface PreviewData {
 }
 
 export function DataPreviewTable({ datasetId, onExport }: DataPreviewTableProps) {
-  const [previewData, setPreviewData] = useState<PreviewData | null>(null)
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
   const [currentPage, setCurrentPage] = useState(0)
   const rowsPerPage = 50
 
-  useEffect(() => {
-    if (!datasetId || datasetId === 'undefined') {
-      setError('Invalid dataset ID')
-      setLoading(false)
-      return
+  const validId = !!datasetId && datasetId !== 'undefined'
+
+  const {
+    data: previewData,
+    loading,
+    error: fetchError,
+  } = useAsyncData<PreviewData>(async () => {
+    const response = await fetch(
+      `/api/data/${datasetId}/preview?rows=${rowsPerPage}&offset=${currentPage * rowsPerPage}`,
+      {
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+      },
+    )
+    if (!response.ok) {
+      throw new Error('Failed to fetch preview data')
     }
+    return response.json()
+  }, [datasetId, currentPage], { enabled: validId })
 
-    // AbortController to cancel fetch on cleanup
-    const abortController = new AbortController()
-    let isMounted = true
+  // The old effect set this synchronously before returning early; it is a plain
+  // property of the props now. AbortController is gone because the hook already
+  // discards a superseded request's result.
+  const error = validId ? fetchError : 'Invalid dataset ID'
 
-    const fetchPreviewData = async () => {
-      if (!isMounted) return
-
-      try {
-        if (isMounted) {
-          setLoading(true)
-        }
-
-        const response = await fetch(
-          `/api/data/${datasetId}/preview?rows=${rowsPerPage}&offset=${currentPage * rowsPerPage}`,
-          {
-            headers: {
-              'Content-Type': 'application/json',
-            },
-            credentials: 'include',
-            signal: abortController.signal,
-          }
-        )
-
-        if (!response.ok) {
-          throw new Error('Failed to fetch preview data')
-        }
-
-        const data = await response.json()
-
-        if (isMounted) {
-          setPreviewData(data)
-        }
-      } catch (err) {
-        // Ignore abort errors
-        if (err instanceof Error && err.name === 'AbortError') {
-          return
-        }
-
-        if (isMounted) {
-          setError(err instanceof Error ? err.message : 'An error occurred')
-        }
-      } finally {
-        if (isMounted) {
-          setLoading(false)
-        }
-      }
-    }
-
-    fetchPreviewData()
-
-    // Cleanup function
-    return () => {
-      isMounted = false
-      abortController.abort()
-    }
-  }, [datasetId, currentPage])
 
   const totalPages = previewData ? Math.ceil(previewData.total_rows / rowsPerPage) : 0
 

--- a/apps/frontend/components/EndpointTester.tsx
+++ b/apps/frontend/components/EndpointTester.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
+import { useAsyncData } from '@/lib/hooks/useAsyncData';
 import { modelService } from '@/lib/services/model';
 import type { ModelFeatureDescriptor } from '@/lib/services/model';
 import { Play, AlertCircle, CheckCircle } from 'lucide-react';
@@ -15,36 +16,41 @@ import { Play, AlertCircle, CheckCircle } from 'lucide-react';
  * `${API_URL}/production/v1/models/{id}` base); the predict URL is `${endpoint}/predict`.
  */
 export function EndpointTester({ modelId, endpoint }: { modelId: string; endpoint: string }) {
-  const [features, setFeatures] = useState<ModelFeatureDescriptor[]>([]);
-  const [values, setValues] = useState<Record<string, string>>({});
   const [apiKey, setApiKey] = useState('');
   const [loading, setLoading] = useState(false);
   const [result, setResult] = useState<{ prediction: unknown; confidence?: number } | null>(null);
-  const [error, setError] = useState<string | null>(null);
+  const [testError, setTestError] = useState<string | null>(null);
 
-  useEffect(() => {
-    let active = true;
-    // Drop any stale schema/inputs from a previous model before refetching.
-    setFeatures([]);
-    setValues({});
-    modelService
-      .getModelFeatures(modelId)
-      .then((data) => {
-        if (active) setFeatures(data.features);
-      })
-      .catch(() => {
-        if (active) setError('Could not load the model input schema.');
-      });
-    return () => {
-      active = false;
-    };
-  }, [modelId]);
+  const { data: schema, error: schemaError } = useAsyncData(
+    () => modelService.getModelFeatures(modelId),
+    [modelId],
+    { errorMessage: 'Could not load the model input schema.' },
+  );
+  const features: ModelFeatureDescriptor[] = schema?.features ?? [];
+
+  // The old effect cleared the typed-in values whenever modelId changed. Tagging
+  // the state with the model it belongs to gets the same reset by deriving during
+  // render, instead of a setState the effect has to fire.
+  const [valueState, setValueState] = useState<{
+    modelId: string;
+    values: Record<string, string>;
+  }>({ modelId, values: {} });
+  const values = valueState.modelId === modelId ? valueState.values : {};
+  const setValues = (
+    update: Record<string, string> | ((prev: Record<string, string>) => Record<string, string>),
+  ) =>
+    setValueState((prev) => {
+      const base = prev.modelId === modelId ? prev.values : {};
+      return { modelId, values: typeof update === 'function' ? update(base) : update };
+    });
+
+  const error = testError ?? schemaError;
 
   const runTest = async () => {
-    setError(null);
+    setTestError(null);
     setResult(null);
     if (!apiKey.trim()) {
-      setError('Enter an API key to call the endpoint.');
+      setTestError('Enter an API key to call the endpoint.');
       return;
     }
     setLoading(true);
@@ -62,13 +68,13 @@ export function EndpointTester({ modelId, endpoint }: { modelId: string; endpoin
       });
       if (!response.ok) {
         const detail = await response.text();
-        setError(`Request failed (${response.status}). ${detail.slice(0, 200)}`);
+        setTestError(`Request failed (${response.status}). ${detail.slice(0, 200)}`);
         return;
       }
       const data = await response.json();
       setResult({ prediction: data.predictions?.[0], confidence: data.confidence?.[0] });
     } catch (e) {
-      setError(`Request error: ${e instanceof Error ? e.message : String(e)}`);
+      setTestError(`Request error: ${e instanceof Error ? e.message : String(e)}`);
     } finally {
       setLoading(false);
     }

--- a/apps/frontend/components/ErrorAnalysisDashboard.tsx
+++ b/apps/frontend/components/ErrorAnalysisDashboard.tsx
@@ -1,11 +1,9 @@
 'use client'
 
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useMemo, useState } from 'react'
+import { useAsyncData } from '@/lib/hooks/useAsyncData'
 import { modelService } from '@/lib/services/model'
-import type {
-  ConfusionPair,
-  ErrorAnalysisResponse
-} from '@/lib/types/evaluation'
+import type { ConfusionPair } from '@/lib/types/evaluation'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { Alert, AlertDescription } from '@/components/ui/alert'
@@ -25,26 +23,13 @@ const pct = (value: number) => `${(value * 100).toFixed(1)}%`
  * `partial` models (no feature matrix → no segments/clusters/patterns).
  */
 export function ErrorAnalysisDashboard({ modelId }: ErrorAnalysisDashboardProps) {
-  const [analysis, setAnalysis] = useState<ErrorAnalysisResponse | null>(null)
-  const [isLoading, setIsLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
   const [pairFilter, setPairFilter] = useState<ConfusionPair | null>(null)
 
-  const load = useCallback(async () => {
-    setIsLoading(true)
-    setError(null)
-    try {
-      setAnalysis(await modelService.getErrorAnalysis(modelId))
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to load error analysis')
-    } finally {
-      setIsLoading(false)
-    }
-  }, [modelId])
-
-  useEffect(() => {
-    void load()
-  }, [load])
+  const {
+    data: analysis,
+    loading: isLoading,
+    error,
+  } = useAsyncData(() => modelService.getErrorAnalysis(modelId), [modelId])
 
   const filteredCases = useMemo(() => {
     if (!analysis) return []

--- a/apps/frontend/components/HealthMonitor.tsx
+++ b/apps/frontend/components/HealthMonitor.tsx
@@ -1,6 +1,7 @@
 'use client'
 
-import React, { useState, useEffect } from 'react'
+import React, { useEffect } from 'react'
+import { useAsyncData } from '@/lib/hooks/useAsyncData'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Activity, AlertCircle, CheckCircle2, Clock, Database, Server } from 'lucide-react'
 
@@ -42,45 +43,37 @@ export function HealthMonitor({
   backendUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000/api/v1',
   refreshInterval = 30000 // 30 seconds
 }: HealthMonitorProps) {
-  const [status, setStatus] = useState<HealthStatus | null>(null)
-  const [metrics, setMetrics] = useState<HealthMetrics | null>(null)
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
-  const [lastUpdate, setLastUpdate] = useState<Date>(new Date())
 
-  const fetchHealthData = async () => {
-    try {
-      setError(null)
-      
-      // Fetch health status
+  const {
+    data: health,
+    loading,
+    error,
+    reload,
+  } = useAsyncData(
+    async () => {
       const statusResponse = await fetch(`${backendUrl}/health/status`)
       if (!statusResponse.ok) throw new Error('Failed to fetch health status')
-      const statusData = await statusResponse.json()
-      setStatus(statusData)
+      const statusData: HealthStatus = await statusResponse.json()
 
-      // Fetch health metrics
       const metricsResponse = await fetch(`${backendUrl}/health/metrics`)
       if (!metricsResponse.ok) throw new Error('Failed to fetch health metrics')
-      const metricsData = await metricsResponse.json()
-      setMetrics(metricsData)
+      const metricsData: HealthMetrics = await metricsResponse.json()
 
-      setLastUpdate(new Date())
-    } catch (err) {
-      console.error('Health check error:', err)
-      setError(err instanceof Error ? err.message : 'Unknown error')
-      setStatus(null)
-      setMetrics(null)
-    } finally {
-      setLoading(false)
-    }
-  }
+      return { status: statusData, metrics: metricsData, lastUpdate: new Date() }
+    },
+    [backendUrl],
+  )
 
+  const status = health?.status ?? null
+  const metrics = health?.metrics ?? null
+  const lastUpdate = health?.lastUpdate ?? null
+
+  // Polling stays an effect, but reload() runs from the interval callback rather
+  // than synchronously in the effect body, which is the pattern the rule allows.
   useEffect(() => {
-    fetchHealthData()
-    const interval = setInterval(fetchHealthData, refreshInterval)
+    const interval = setInterval(reload, refreshInterval)
     return () => clearInterval(interval)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [backendUrl, refreshInterval])
+  }, [reload, refreshInterval])
 
   const getStatusIcon = () => {
     if (loading) return <Activity className="h-5 w-5 animate-pulse" />
@@ -130,7 +123,7 @@ export function HealthMonitor({
                 <p className="text-sm text-muted-foreground">Last Update</p>
                 <p className="text-sm font-medium flex items-center gap-1">
                   <Clock className="h-3 w-3" />
-                  {lastUpdate.toLocaleTimeString()}
+                  {lastUpdate ? lastUpdate.toLocaleTimeString() : "—"}
                 </p>
               </div>
             </div>

--- a/apps/frontend/components/HistogramChart.tsx
+++ b/apps/frontend/components/HistogramChart.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useAsyncData } from '@/lib/hooks/useAsyncData';
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts';
 import { HistogramData, getHistogram } from '@/lib/services/visualization';
 import { getAuthToken } from '@/lib/auth-helpers';
@@ -17,37 +17,22 @@ interface HistogramChartProps {
 }
 
 export function HistogramChart({ data, datasetId, column, bins = 50, height = 300 }: HistogramChartProps) {
-  const [fetchedData, setFetchedData] = useState<HistogramData | null>(data ?? null);
-  const [fetchError, setFetchError] = useState(false);
 
-  useEffect(() => {
-    if (data) {
-      setFetchedData(data);
-      return;
-    }
-
-    if (datasetId && column) {
-      let cancelled = false;
-      setFetchError(false);
+  const { data: fetched, error } = useAsyncData(
+    async () => {
       // The histogram route requires auth (get_current_user_id) — resolve and
       // forward the bearer token or every request 401s.
-      getAuthToken()
-        .then((token) => getHistogram(datasetId, column, bins, token ?? undefined))
-        .then((result) => {
-          if (!cancelled) setFetchedData(result);
-        })
-        .catch(() => {
-          // A failed request must be distinguishable from a column with no data.
-          if (!cancelled) {
-            setFetchedData(null);
-            setFetchError(true);
-          }
-        });
-      return () => {
-        cancelled = true;
-      };
-    }
-  }, [data, datasetId, column, bins]);
+      const token = await getAuthToken();
+      return getHistogram(datasetId!, column!, bins, token ?? undefined);
+    },
+    [datasetId, column, bins],
+    { enabled: !data && !!datasetId && !!column },
+  );
+
+  // A supplied `data` prop always wins; only then does the fetch matter.
+  const fetchedData = data ?? fetched ?? null;
+  // A failed request must stay distinguishable from a column with no data.
+  const fetchError = !data && error !== null;
 
   if (fetchError) {
     return (

--- a/apps/frontend/components/InteractiveTutorial.tsx
+++ b/apps/frontend/components/InteractiveTutorial.tsx
@@ -49,7 +49,9 @@ export function InteractiveTutorial({
   const [currentStepIndex, setCurrentStepIndex] = useState(0);
   const [isActive, setIsActive] = useState(autoStart);
   const [completedSteps, setCompletedSteps] = useState<Set<string>>(new Set());
-  const [isHighlighting, setIsHighlighting] = useState(false);
+  // Derived, not stored: highlighting is on exactly when the tutorial is active
+  // and the current step names a target. Storing it duplicated that condition and
+  // required an effect to keep the copy in sync.
 
   const currentStep = steps[currentStepIndex];
   const progress = (currentStepIndex / steps.length) * 100;
@@ -60,8 +62,6 @@ export function InteractiveTutorial({
     
     if (overlay) overlay.remove();
     if (highlight) highlight.remove();
-    
-    setIsHighlighting(false);
   };
 
   const highlightElement = (selector: string) => {
@@ -119,8 +119,6 @@ export function InteractiveTutorial({
         behavior: 'smooth',
         block: 'center'
       });
-
-      setIsHighlighting(true);
     }
   };
 
@@ -134,6 +132,8 @@ export function InteractiveTutorial({
     return () => removeHighlight();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentStepIndex, isActive, currentStep]);
+
+  const isHighlighting = isActive && !!currentStep?.target;
 
   const nextStep = () => {
     if (currentStep) {

--- a/apps/frontend/components/InteractiveVisualizationDashboard.tsx
+++ b/apps/frontend/components/InteractiveVisualizationDashboard.tsx
@@ -13,10 +13,9 @@ import { ChartControls, ChartFilter } from './ChartControls'
 import { HistogramChart } from './HistogramChart'
 import { BoxplotChart } from './BoxplotChart'
 import { CorrelationHeatmap } from './CorrelationHeatmap'
-import { ScatterPlotChart, ScatterPlotData } from './ScatterPlotChart'
-import { LineChart, LineChartData } from './LineChart'
+import { ScatterPlotChart } from './ScatterPlotChart'
+import { LineChart } from './LineChart'
 import {
-  BoxPlotData,
   getBoxPlot,
   getScatterPlot,
   getLineChart,
@@ -48,15 +47,10 @@ export function InteractiveVisualizationDashboard({
   const [activeChart, setActiveChart] = useState('histogram')
   const [rawSelectedColumns, setSelectedColumns] = useState<string[]>([])
   const [filters, setFilters] = useState<ChartFilter[]>([])
-  const [loading, setLoading] = useState(false)
-  const [error, setError] = useState<string | null>(null)
 
   // Real chart data fetched from the backend (issue #170). Histogram fetches
   // itself via HistogramChart's datasetId/column mode; correlation is derived
   // from the `statistics` prop, so only these three need local state here.
-  const [boxplotData, setBoxplotData] = useState<BoxPlotData | null>(null)
-  const [scatterData, setScatterData] = useState<ScatterPlotData | null>(null)
-  const [lineData, setLineData] = useState<LineChartData | null>(null)
   // Bumping this re-runs the fetch effect and remounts HistogramChart.
   const [refreshKey, setRefreshKey] = useState(0)
 
@@ -97,84 +91,69 @@ export function InteractiveVisualizationDashboard({
   // Fetch real data for the active chart from the backend. Histogram and
   // correlation are handled elsewhere (HistogramChart fetch mode / statistics
   // prop), so this only drives boxplot, scatter, and line.
-  useEffect(() => {
-    if (activeChart !== 'boxplot' && activeChart !== 'scatter' && activeChart !== 'line') {
-      setLoading(false)
-      setError(null)
-      return
-    }
+  const numericNames = useMemo(
+    () => new Set(columns.filter(col => col.type === 'numeric').map(col => col.name)),
+    [columns],
+  )
+  const numericSelected = useMemo(
+    () => selectedColumns.filter(name => numericNames.has(name)),
+    [selectedColumns, numericNames],
+  )
+  // Line charts plot a numeric Y series against any-type X (e.g. a date), so
+  // X is the first selected column and Y is the remaining numeric columns.
+  const lineX = selectedColumns[0]
+  const lineY = useMemo(
+    () => selectedColumns.slice(1).filter(name => numericNames.has(name)),
+    [selectedColumns, numericNames],
+  )
 
-    const numericNames = new Set(
-      columns.filter(col => col.type === 'numeric').map(col => col.name)
-    )
-    const numericSelected = selectedColumns.filter(name => numericNames.has(name))
-    // Line charts plot a numeric Y series against any-type X (e.g. a date), so
-    // X is the first selected column and Y is the remaining numeric columns.
-    const lineX = selectedColumns[0]
-    const lineY = selectedColumns.slice(1).filter(name => numericNames.has(name))
+  const isFetchedChart =
+    activeChart === 'boxplot' || activeChart === 'scatter' || activeChart === 'line'
 
-    // Requirements per chart — renderChart() shows matching guidance and we
-    // never fabricate data. Clear any previously fetched data so a now-invalid
-    // selection can't be exported.
-    const canFetch =
-      activeChart === 'boxplot'
-        ? numericSelected.length >= 1
-        : activeChart === 'scatter'
-          ? numericSelected.length >= 2
-          : lineX !== undefined && lineY.length >= 1
-    if (!datasetId || !canFetch) {
-      setLoading(false)
-      setError(null)
-      if (activeChart === 'boxplot') setBoxplotData(null)
-      else if (activeChart === 'scatter') setScatterData(null)
-      else setLineData(null)
-      return
-    }
+  // Requirements per chart — renderChart() shows matching guidance and we
+  // never fabricate data.
+  const canFetch =
+    activeChart === 'boxplot'
+      ? numericSelected.length >= 1
+      : activeChart === 'scatter'
+        ? numericSelected.length >= 2
+        : lineX !== undefined && lineY.length >= 1
 
-    let cancelled = false
-    setLoading(true)
-    setError(null)
-    // Clear the active chart's previous data up front so an in-flight refetch or
-    // a failed request can't be exported as the current selection's data.
-    if (activeChart === 'boxplot') setBoxplotData(null)
-    else if (activeChart === 'scatter') setScatterData(null)
-    else setLineData(null)
-
-    const run = async () => {
-      try {
-        const token = (await getAuthToken()) ?? undefined
-        if (activeChart === 'boxplot') {
-          const result = await getBoxPlot(datasetId, numericSelected[0], token)
-          if (!cancelled) setBoxplotData(result)
-        } else if (activeChart === 'scatter') {
-          const result = await getScatterPlot(
-            datasetId,
-            numericSelected[0],
-            numericSelected[1],
-            filters,
-            token
-          )
-          if (!cancelled) setScatterData(result)
-        } else {
-          const result = await getLineChart(datasetId, lineX, lineY, filters, token)
-          if (!cancelled) setLineData(result)
-        }
-      } catch (err) {
-        // Data was cleared above and stays cleared on failure, so export sees no
-        // stale data for the current chart.
-        if (!cancelled) {
-          setError(err instanceof Error ? err.message : 'Failed to load chart data')
-        }
-      } finally {
-        if (!cancelled) setLoading(false)
+  const {
+    data: chartData,
+    loading,
+    error: fetchError,
+  } = useAsyncData(
+    async () => {
+      const token = (await getAuthToken()) ?? undefined
+      if (activeChart === 'boxplot') {
+        return { kind: 'boxplot' as const, data: await getBoxPlot(datasetId!, numericSelected[0], token) }
       }
-    }
+      if (activeChart === 'scatter') {
+        return {
+          kind: 'scatter' as const,
+          data: await getScatterPlot(datasetId!, numericSelected[0], numericSelected[1], filters, token),
+        }
+      }
+      return {
+        kind: 'line' as const,
+        data: await getLineChart(datasetId!, lineX, lineY, filters, token),
+      }
+    },
+    [activeChart, datasetId, selectedColumns, filters, columns, refreshKey],
+    { enabled: isFetchedChart && !!datasetId && canFetch, errorMessage: 'Failed to load chart data' },
+  )
 
-    run()
-    return () => {
-      cancelled = true
-    }
-  }, [activeChart, datasetId, selectedColumns, filters, columns, refreshKey])
+  // Keyed on the active chart, so an in-flight refetch or a failed request can
+  // never surface the previous selection's data — which is what the old code's
+  // up-front setXData(null) calls were for.
+  // Export failures are the user's action, not the chart load's.
+  const [exportError, setExportError] = useState<string | null>(null)
+  const error = exportError ?? fetchError
+
+  const boxplotData = chartData?.kind === 'boxplot' ? chartData.data : null
+  const scatterData = chartData?.kind === 'scatter' ? chartData.data : null
+  const lineData = chartData?.kind === 'line' ? chartData.data : null
 
   const handleColumnToggle = (columnName: string) => {
     // Base the toggle on the derived selection so un-picking the auto-selected
@@ -213,7 +192,7 @@ export function InteractiveVisualizationDashboard({
       }
 
       if (exportData == null) {
-        setError('No chart data available to export yet')
+        setExportError('No chart data available to export yet')
         return
       }
 
@@ -227,12 +206,12 @@ export function InteractiveVisualizationDashboard({
       URL.revokeObjectURL(url)
     } catch (err) {
       console.error('Export failed:', err)
-      setError(err instanceof Error ? err.message : 'Export failed')
+      setExportError(err instanceof Error ? err.message : 'Export failed')
     }
   }
 
   const handleRefreshChart = () => {
-    setError(null)
+    setExportError(null)
     setRefreshKey(key => key + 1)
   }
 

--- a/apps/frontend/components/InteractiveVisualizationDashboard.tsx
+++ b/apps/frontend/components/InteractiveVisualizationDashboard.tsx
@@ -1,6 +1,7 @@
 'use client'
 
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useMemo } from 'react'
+import { useAsyncData } from '@/lib/hooks/useAsyncData'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
@@ -45,7 +46,7 @@ export function InteractiveVisualizationDashboard({
 }: InteractiveVisualizationDashboardProps) {
   const [activeTab, setActiveTab] = useState('configure')
   const [activeChart, setActiveChart] = useState('histogram')
-  const [selectedColumns, setSelectedColumns] = useState<string[]>([])
+  const [rawSelectedColumns, setSelectedColumns] = useState<string[]>([])
   const [filters, setFilters] = useState<ChartFilter[]>([])
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -64,21 +65,34 @@ export function InteractiveVisualizationDashboard({
   const [showAnimations, setShowAnimations] = useState(true)
   const [binCount, setBinCount] = useState(50)
 
-  const numericColumns = columns.filter(col => col.type === 'numeric')
+  // Memoised because selectedColumns derives from it and that feeds an effect's
+  // dependency list; a fresh array per render would refetch forever.
+  const numericColumns = useMemo(
+    () => columns.filter(col => col.type === 'numeric'),
+    [columns],
+  )
   const categoricalColumns = columns.filter(col => col.type === 'categorical')
   const datetimeColumns = columns.filter(col => col.type === 'datetime')
+
+  // Auto-select the first numeric column when nothing is chosen. Derived during
+  // render rather than written back by an effect: the default is a function of
+  // the columns, so storing it only creates a second source of truth.
+  // Memoised, not just derived: this feeds the chart-fetch effect's dependency
+  // list, so returning a fresh array each render would refetch forever.
+  const selectedColumns = useMemo(
+    () =>
+      rawSelectedColumns.length === 0 && numericColumns.length > 0
+        ? [numericColumns[0].name]
+        : rawSelectedColumns,
+    [rawSelectedColumns, numericColumns],
+  )
 
   // The numeric columns the user has currently selected, in selection order.
   const selectedNumeric = selectedColumns.filter(name =>
     numericColumns.some(col => col.name === name)
   )
 
-  // Auto-select first numeric column if none selected
-  useEffect(() => {
-    if (selectedColumns.length === 0 && numericColumns.length > 0) {
-      setSelectedColumns([numericColumns[0].name])
-    }
-  }, [columns, selectedColumns.length, numericColumns])
+
 
   // Fetch real data for the active chart from the backend. Histogram and
   // correlation are handled elsewhere (HistogramChart fetch mode / statistics
@@ -163,7 +177,10 @@ export function InteractiveVisualizationDashboard({
   }, [activeChart, datasetId, selectedColumns, filters, columns, refreshKey])
 
   const handleColumnToggle = (columnName: string) => {
-    setSelectedColumns(prev => {
+    // Base the toggle on the derived selection so un-picking the auto-selected
+    // column behaves the way it did when that default was stored.
+    setSelectedColumns(() => {
+      const prev = selectedColumns
       if (prev.includes(columnName)) {
         return prev.filter(name => name !== columnName)
       } else {

--- a/apps/frontend/components/ModelVersions.tsx
+++ b/apps/frontend/components/ModelVersions.tsx
@@ -9,13 +9,13 @@
  * side-by-side comparison of 2+ selected versions reusing {@link ModelComparisonTable}.
  */
 
-import { useCallback, useEffect, useState } from 'react'
+import { useState } from 'react'
+import { useAsyncData } from '@/lib/hooks/useAsyncData'
 import Link from 'next/link'
 import { getAuthToken } from '@/lib/auth-helpers'
 import { ModelService } from '@/lib/services/model'
 import type {
   ModelVersionEntry,
-  ModelVersionListResponse,
   ModelEvaluationSummary,
 } from '@/lib/types/evaluation'
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card'
@@ -30,42 +30,60 @@ interface ModelVersionsProps {
 }
 
 export function ModelVersions({ modelId }: ModelVersionsProps) {
-  const [data, setData] = useState<ModelVersionListResponse | null>(null)
-  const [isLoading, setIsLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
   const [promoting, setPromoting] = useState<string | null>(null)
-  const [selected, setSelected] = useState<string[]>([])
-  const [comparison, setComparison] = useState<ModelEvaluationSummary[] | null>(null)
+  const [selectionState, setSelectionState] = useState<{
+    modelId: string
+    selected: string[]
+    comparison: ModelEvaluationSummary[] | null
+  }>({ modelId, selected: [], comparison: null })
 
-  const load = useCallback(async () => {
-    try {
-      setIsLoading(true)
-      setError(null)
+  const {
+    data,
+    loading: isLoading,
+    error: loadError,
+    reload: load,
+  } = useAsyncData(
+    async () => {
       const token = await getAuthToken()
-      setData(await ModelService.getModelVersions(modelId, token || ''))
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to load versions')
-    } finally {
-      setIsLoading(false)
-    }
-  }, [modelId])
+      return ModelService.getModelVersions(modelId, token || '')
+    },
+    [modelId],
+    { errorMessage: undefined },
+  )
 
-  useEffect(() => {
-    // Reset per-model selection/comparison when navigating between models.
-    setSelected([])
-    setComparison(null)
-    load()
-  }, [load])
+  // Promote/compare failures are user actions, kept apart from the load error.
+  const [actionError, setActionError] = useState<string | null>(null)
+  const error = actionError ?? loadError
+
+  // Selection and comparison used to be cleared by the same effect that loaded.
+  // Tagging them with the model they belong to gets the identical reset by
+  // deriving during render.
+  const selected = selectionState.modelId === modelId ? selectionState.selected : []
+  const comparison = selectionState.modelId === modelId ? selectionState.comparison : null
+  const setSelected = (update: string[] | ((prev: string[]) => string[])) =>
+    setSelectionState((prev) => {
+      const base = prev.modelId === modelId ? prev : { modelId, selected: [], comparison: null }
+      return {
+        ...base,
+        modelId,
+        selected: typeof update === 'function' ? update(base.selected) : update,
+      }
+    })
+  const setComparison = (value: ModelEvaluationSummary[] | null) =>
+    setSelectionState((prev) => {
+      const base = prev.modelId === modelId ? prev : { modelId, selected: [], comparison: null }
+      return { ...base, modelId, comparison: value }
+    })
 
   const handlePromote = async (id: string) => {
     try {
       setPromoting(id)
-      setError(null)
+      setActionError(null)
       const token = await getAuthToken()
       await ModelService.promoteModelVersion(id, token || '')
       await load()
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to promote version')
+      setActionError(err instanceof Error ? err.message : 'Failed to promote version')
     } finally {
       setPromoting(null)
     }
@@ -85,12 +103,12 @@ export function ModelVersions({ modelId }: ModelVersionsProps) {
 
   const handleCompare = async () => {
     try {
-      setError(null)
+      setActionError(null)
       const token = await getAuthToken()
       const result = await ModelService.compareModels(selected, token || '')
       setComparison(result.models)
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to compare versions')
+      setActionError(err instanceof Error ? err.message : 'Failed to compare versions')
     }
   }
 

--- a/apps/frontend/components/RecipeBrowser.tsx
+++ b/apps/frontend/components/RecipeBrowser.tsx
@@ -1,4 +1,5 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
+import { useAsyncData } from '@/lib/hooks/useAsyncData';
 import { useSession } from 'next-auth/react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -26,46 +27,31 @@ interface RecipeBrowserProps {
 
 export function RecipeBrowser({ datasetId, onApplyRecipe }: RecipeBrowserProps) {
   const { data: session } = useSession();
-  const [recipes, setRecipes] = useState<Recipe[]>([]);
-  const [popularRecipes, setPopularRecipes] = useState<Recipe[]>([]);
-  const [loading, setLoading] = useState(true);
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedRecipe, setSelectedRecipe] = useState<Recipe | null>(null);
   const [activeTab, setActiveTab] = useState('my-recipes');
 
-  const fetchPopularRecipes = async () => {
-    if (!session) return;
-    
-    try {
-      const token = await getAuthToken();
-      const response = await TransformationService.getPopularRecipes(token, 10);
-      setPopularRecipes(response.recipes);
-    } catch (error) {
-      console.error('Failed to fetch popular recipes:', error);
-    }
-  };
-
-  const fetchRecipes = async () => {
-    if (!session) return;
-    
-    try {
+  const { data: recipeData, loading } = useAsyncData(
+    async () => {
       const token = await getAuthToken();
       const response = await TransformationService.listRecipes(token);
-      setRecipes(response.recipes);
-    } catch (error) {
-      console.error('Failed to fetch recipes:', error);
-    } finally {
-      setLoading(false);
-    }
-  };
+      return response.recipes;
+    },
+    [session],
+    { enabled: !!session },
+  );
+  const recipes = recipeData ?? [];
 
-  useEffect(() => {
-    if (session) {
-      fetchRecipes();
-      fetchPopularRecipes();
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [session]);
+  const { data: popularData } = useAsyncData(
+    async () => {
+      const token = await getAuthToken();
+      const response = await TransformationService.getPopularRecipes(token, 10);
+      return response.recipes;
+    },
+    [session],
+    { enabled: !!session },
+  );
+  const popularRecipes = popularData ?? [];
 
   const handleApplyRecipe = async (recipe: Recipe) => {
     if (!session) return;

--- a/apps/frontend/components/SampleDatasetSelector.tsx
+++ b/apps/frontend/components/SampleDatasetSelector.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
+import { useAsyncData } from '@/lib/hooks/useAsyncData';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -41,27 +42,15 @@ interface SampleDatasetSelectorProps {
 }
 
 export function SampleDatasetSelector({ onDatasetSelected }: SampleDatasetSelectorProps) {
-  const [datasets, setDatasets] = useState<SampleDataset[]>([]);
-  const [loading, setLoading] = useState(true);
   const [selectedDataset, setSelectedDataset] = useState<SampleDataset | null>(null);
   const [loadingDataset, setLoadingDataset] = useState<string | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
 
-  const loadSampleDatasets = async () => {
-    try {
-      const response = await fetch('/api/v1/onboarding/sample-datasets');
-      const data = await response.json();
-      setDatasets(data);
-    } catch (error) {
-      console.error('Failed to load sample datasets:', error);
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  useEffect(() => {
-    loadSampleDatasets();
+  const { data: datasetData, loading } = useAsyncData<SampleDataset[]>(async () => {
+    const response = await fetch('/api/v1/onboarding/sample-datasets');
+    return response.json();
   }, []);
+  const datasets = datasetData ?? [];
 
   const loadDataset = async (datasetId: string) => {
     try {

--- a/apps/frontend/components/StatisticsDashboard.tsx
+++ b/apps/frontend/components/StatisticsDashboard.tsx
@@ -1,6 +1,7 @@
 'use client'
 
-import React, { useState, useEffect } from 'react'
+import React from 'react'
+import { useAsyncData } from '@/lib/hooks/useAsyncData'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { Progress } from '@/components/ui/progress'
@@ -55,36 +56,30 @@ interface StatisticsDashboardProps {
 }
 
 export function StatisticsDashboard({ datasetId, statistics: initialStats }: StatisticsDashboardProps) {
-  const [statistics, setStatistics] = useState<StatisticsData | null>(initialStats || null)
-  const [loading, setLoading] = useState(false)
-  const [error, setError] = useState<string | null>(null)
 
-  const fetchStatistics = async () => {
-    try {
-      setLoading(true)
+  const {
+    data: fetched,
+    loading,
+    error,
+  } = useAsyncData<StatisticsData>(
+    async () => {
       const response = await fetch(`/api/data/${datasetId}/statistics`, {
         credentials: 'include',
       })
-
       if (!response.ok) {
         throw new Error('Failed to fetch statistics')
       }
-
       const data = await response.json()
-      setStatistics(data.statistics)
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'An error occurred')
-    } finally {
-      setLoading(false)
-    }
-  }
-
-  useEffect(() => {
-    if (!statistics) {
-      fetchStatistics()
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [datasetId])
+      return data.statistics
+    },
+    [datasetId],
+    // Caller-supplied stats mean "don't fetch", matching the old `if (!statistics)`.
+    // Keying on datasetId also fixes the same latent bug as AIInsightsPanel: the old
+    // guard blocked refetching on dataset change because `statistics` was still set
+    // from the previous one. See #393.
+    { enabled: !initialStats },
+  )
+  const statistics = fetched ?? initialStats ?? null
 
   if (loading && !statistics) {
     return (

--- a/apps/frontend/components/feature-builder/FeatureBuilder.tsx
+++ b/apps/frontend/components/feature-builder/FeatureBuilder.tsx
@@ -78,8 +78,12 @@ export default function FeatureBuilder({
   // Use ref for node ID counter to avoid stale closure issues with rapid calls
   const nodeIdCounterRef = useRef(1);
 
-  // Load initial feature if editing
-  useEffect(() => {
+  // Seed the editor from the feature being edited. React's documented way to
+  // reset state when a prop changes is during render, not in an effect — which
+  // also means the canvas is correct on first paint instead of after a second one.
+  const [seededFrom, setSeededFrom] = useState<typeof initialFeature | null>(null);
+  if (seededFrom !== initialFeature) {
+    setSeededFrom(initialFeature);
     if (initialFeature) {
       setFeatureName(String(initialFeature.name || ''));
       setFeatureDescription(String(initialFeature.description || ''));
@@ -90,7 +94,7 @@ export default function FeatureBuilder({
         setEdges((canvasState.edges as Edge[]) || []);
       }
     }
-  }, [initialFeature, setNodes, setEdges]);
+  }
 
   // Generate unique node IDs using ref to avoid duplicate IDs when called rapidly
   const generateNodeId = useCallback(() => {

--- a/apps/frontend/components/feature-builder/FeatureList.tsx
+++ b/apps/frontend/components/feature-builder/FeatureList.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState } from 'react';
+import { useAsyncData } from '@/lib/hooks/useAsyncData';
 import { API_URL } from '@/lib/constants';
 import { getAuthToken } from '@/lib/auth-helpers';
 import { Pencil, Trash2, Copy, Check, AlertCircle, Plus, Search, Tag } from 'lucide-react';
@@ -50,47 +51,39 @@ export default function FeatureList({
   onCreate,
   onApply,
 }: FeatureListProps) {
-  const [features, setFeatures] = useState<Feature[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
   const [searchTerm, setSearchTerm] = useState('');
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
   const [deletingId, setDeletingId] = useState<string | null>(null);
 
-  // Memoize loadFeatures to ensure stable reference for useEffect dependency
-  const loadFeatures = useCallback(async () => {
-    setLoading(true);
-    setError(null);
+  const {
+    data: featureData,
+    loading,
+    error,
+    reload: loadFeatures,
+  } = useAsyncData<Feature[]>(async () => {
+    let response: Response;
     try {
       const token = await getAuthToken();
-      const response = await fetch(
-        `${API_URL}/datasets/${datasetId}/features`,
-        {
-          headers: {
-            Authorization: `Bearer ${token}`,
-          },
-        }
-      );
-
-      if (response.ok) {
-        const data = await response.json();
-        setFeatures(data.features || []);
-      } else {
-        const errData = await response.json();
-        setError(errData.detail || 'Failed to load features');
-      }
+      response = await fetch(`${API_URL}/datasets/${datasetId}/features`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
     } catch (err) {
-      setError('Failed to load features');
+      // Network/auth failure: the old code reported fixed copy here, not err.message.
       console.error('Error loading features:', err);
-    } finally {
-      setLoading(false);
+      throw new Error('Failed to load features');
     }
+    if (!response.ok) {
+      const errData = await response.json().catch(() => ({}));
+      throw new Error(errData.detail || 'Failed to load features');
+    }
+    const data = await response.json();
+    return (data.features || []) as Feature[];
   }, [datasetId]);
-
-  // Load features when datasetId changes
-  useEffect(() => {
-    loadFeatures();
-  }, [loadFeatures]);
+  // The delete handler removed the row optimistically via setFeatures. The list is
+  // owned by the hook now, so track removals separately and filter during render —
+  // same instant feedback, without refetching or reintroducing an effect.
+  const [deletedIds, setDeletedIds] = useState<string[]>([]);
+  const features = (featureData ?? []).filter((f) => !deletedIds.includes(f.feature_id));
 
   const handleDelete = async (featureId: string) => {
     if (!confirm('Are you sure you want to delete this feature?')) return;
@@ -109,7 +102,7 @@ export default function FeatureList({
       );
 
       if (response.ok) {
-        setFeatures((prev) => prev.filter((f) => f.feature_id !== featureId));
+        setDeletedIds((prev) => [...prev, featureId]);
       } else {
         const errData = await response.json();
         alert(errData.detail || 'Failed to delete feature');

--- a/apps/frontend/components/quality/QualityDashboard.tsx
+++ b/apps/frontend/components/quality/QualityDashboard.tsx
@@ -1,6 +1,7 @@
 'use client'
 
-import React, { useEffect, useState } from 'react'
+import React from 'react'
+import { useAsyncData } from '@/lib/hooks/useAsyncData'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Progress } from '@/components/ui/progress'
 import { Badge } from '@/components/ui/badge'
@@ -9,8 +10,6 @@ import { CheckCircle2, AlertCircle, XCircle, Wrench, TrendingUp } from 'lucide-r
 import { LineChart } from '@/components/LineChart'
 import { QualityService } from '@/lib/services/quality'
 import type {
-  QualityReportResponse,
-  QualityTrendResponse,
 } from '@/lib/types/quality'
 
 interface QualityDashboardProps {
@@ -34,43 +33,24 @@ const severityColor: Record<string, string> = {
 }
 
 export function QualityDashboard({ fileId, datasetId }: QualityDashboardProps) {
-  const [report, setReport] = useState<QualityReportResponse | null>(null)
-  const [trend, setTrend] = useState<QualityTrendResponse | null>(null)
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
 
-  useEffect(() => {
-    let cancelled = false
-    setLoading(true)
-    setError(null)
-    setTrend(null)  // avoid rendering the previous dataset's trend during a new load
+  const {
+    data: report,
+    loading,
+    error,
+  } = useAsyncData(() => QualityService.getQualityReport(fileId), [fileId], {
+    errorMessage: undefined,
+  })
 
-    QualityService.getQualityReport(fileId)
-      .then((r) => {
-        if (!cancelled) setReport(r)
-      })
-      .catch((e) => {
-        if (!cancelled) setError(e instanceof Error ? e.message : 'Failed to load quality report')
-      })
-      .finally(() => {
-        if (!cancelled) setLoading(false)
-      })
-
-    // Trend is best-effort — a dataset without versions just hides the chart.
-    if (datasetId) {
-      QualityService.getQualityTrend(datasetId)
-        .then((t) => {
-          if (!cancelled) setTrend(t)
-        })
-        .catch(() => {
-          /* no trend available — ignore */
-        })
-    }
-
-    return () => {
-      cancelled = true
-    }
-  }, [fileId, datasetId])
+  // Best-effort: a dataset without versions just hides the chart, so failures are
+  // swallowed rather than surfaced. Re-keying on datasetId also replaces the old
+  // explicit `setTrend(null)`, which existed to stop the previous dataset's trend
+  // rendering during a load — `data` is simply undefined until this key resolves.
+  const { data: trend } = useAsyncData(
+    () => QualityService.getQualityTrend(datasetId!).catch(() => null),
+    [datasetId],
+    { enabled: !!datasetId },
+  )
 
   if (loading) {
     return <div data-testid="quality-dashboard-loading" className="text-sm text-muted-foreground">Loading quality report…</div>

--- a/apps/frontend/components/recipes/RecipeExportDialog.tsx
+++ b/apps/frontend/components/recipes/RecipeExportDialog.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
+import { useAsyncData } from '@/lib/hooks/useAsyncData';
 import {
   Dialog,
   DialogContent,
@@ -29,32 +30,21 @@ export function RecipeExportDialog({
   recipeId,
   recipeName
 }: RecipeExportDialogProps) {
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [jsonData, setJsonData] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
+  const [copyError, setCopyError] = useState<string | null>(null);
 
-  const loadRecipeJSON = async () => {
-    setLoading(true);
-    setError(null);
-
-    try {
+  const { data: jsonData, loading, error: loadError } = useAsyncData(
+    async () => {
       const token = await getAuthToken();
       const result = await TransformationService.exportRecipeAsJSON(recipeId, token);
-      setJsonData(JSON.stringify(result, null, 2));
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to export recipe');
-    } finally {
-      setLoading(false);
-    }
-  };
+      return JSON.stringify(result, null, 2);
+    },
+    [open, recipeId],
+    // Only fetch while the dialog is open, replacing `if (open && !jsonData)`.
+    { enabled: open },
+  );
 
-  useEffect(() => {
-    if (open && !jsonData) {
-      loadRecipeJSON();
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open, recipeId]);
+  const error = copyError ?? loadError;
 
   const handleDownload = () => {
     if (!jsonData) return;
@@ -78,13 +68,14 @@ export function RecipeExportDialog({
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     } catch {
-      setError('Failed to copy to clipboard');
+      setCopyError('Failed to copy to clipboard');
     }
   };
 
   const handleClose = () => {
-    setJsonData(null);
-    setError(null);
+    // jsonData and the load error used to be cleared here; both are keyed on
+    // `open` now, so closing discards them without an explicit reset.
+    setCopyError(null);
     setCopied(false);
     onOpenChange(false);
   };

--- a/apps/frontend/components/recipes/RecipeLibrary.tsx
+++ b/apps/frontend/components/recipes/RecipeLibrary.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useMemo } from 'react';
+import { useAsyncData } from '@/lib/hooks/useAsyncData';
 import { useSession } from 'next-auth/react';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
@@ -35,55 +36,46 @@ export function RecipeLibrary({
   includePublic = true
 }: RecipeLibraryProps) {
   const { data: session } = useSession();
-  const [recipes, setRecipes] = useState<Recipe[]>([]);
-  const [filteredRecipes, setFilteredRecipes] = useState<Recipe[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
   const [sortBy, setSortBy] = useState<SortBy>('recent');
   const [viewMode, setViewMode] = useState<ViewMode>('grid');
   const [page, setPage] = useState(1);
-  const [totalPages, setTotalPages] = useState(1);
 
   const perPage = 12;
 
-  const loadRecipes = async () => {
-    if (!session) return;
-
-    setLoading(true);
-    setError(null);
-
-    try {
+  const {
+    data: recipeResponse,
+    loading,
+    error: loadError,
+    reload: loadRecipes,
+  } = useAsyncData(
+    async () => {
       const token = await getAuthToken();
-      const response = await TransformationService.listRecipes(
+      return TransformationService.listRecipes(
         token,
         page,
         perPage,
         includePublic,
         selectedTags.length > 0 ? selectedTags : undefined
       );
+    },
+    [session, page, selectedTags],
+    { enabled: !!session },
+  );
+  // Duplicate/delete failures are the user's action, not a load failure, so they
+  // get their own slot rather than overwriting the list's error.
+  const [actionError, setActionError] = useState<string | null>(null);
+  const error = actionError ?? loadError;
+  const recipes = useMemo(() => recipeResponse?.recipes ?? [], [recipeResponse]);
+  const totalPages = recipeResponse ? Math.ceil(recipeResponse.total / perPage) : 0;
 
-      setRecipes(response.recipes);
-      setTotalPages(Math.ceil(response.total / perPage));
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to load recipes');
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  useEffect(() => {
-    if (session) {
-      loadRecipes();
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [session, page, selectedTags]);
-
-  const applyFiltersAndSort = useCallback(() => {
+  // Pure derivation of props/state — computed during render rather than pushed
+  // into state by an effect, which is both a render cheaper and one less way for
+  // the list to disagree with its inputs.
+  const filteredRecipes = useMemo(() => {
     let filtered = [...recipes];
 
-    // Apply search filter
     if (searchQuery.trim()) {
       const query = searchQuery.toLowerCase();
       filtered = filtered.filter(
@@ -94,7 +86,6 @@ export function RecipeLibrary({
       );
     }
 
-    // Apply sorting
     filtered.sort((a, b) => {
       switch (sortBy) {
         case 'popular':
@@ -107,12 +98,7 @@ export function RecipeLibrary({
       }
     });
 
-    setFilteredRecipes(filtered);
-  }, [recipes, searchQuery, sortBy]);
-
-  useEffect(() => {
-    applyFiltersAndSort();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    return filtered;
   }, [recipes, searchQuery, sortBy]);
 
   const handleDuplicate = async (recipe: Recipe) => {
@@ -122,7 +108,7 @@ export function RecipeLibrary({
       await TransformationService.duplicateRecipe(recipe.id, newName, token);
       await loadRecipes();
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to duplicate recipe');
+      setActionError(err instanceof Error ? err.message : 'Failed to duplicate recipe');
     }
   };
 
@@ -132,7 +118,7 @@ export function RecipeLibrary({
       await TransformationService.deleteRecipe(recipe.id, token);
       await loadRecipes();
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to delete recipe');
+      setActionError(err instanceof Error ? err.message : 'Failed to delete recipe');
     }
   };
 

--- a/apps/frontend/components/transformation/PreviewControls.tsx
+++ b/apps/frontend/components/transformation/PreviewControls.tsx
@@ -29,14 +29,22 @@ export function PreviewControls({
   onExport,
   loading = false,
 }: PreviewControlsProps) {
-  const [lastUpdated, setLastUpdated] = React.useState<Date | null>(null);
+  // Seeded, not null: the old effect ran on mount too, so a component that mounts
+  // already-loaded shows a timestamp immediately rather than only after the next load.
+  const [lastUpdated, setLastUpdated] = React.useState<Date | null>(() =>
+    loading ? null : new Date(),
+  );
+  const [wasLoading, setWasLoading] = React.useState(loading);
 
-  // Update timestamp on load completion
-  React.useEffect(() => {
+  // Not a data load — this stamps the time a load finished. React's documented
+  // way to adjust state from a prop change is to do it during render rather than
+  // in an effect, which also avoids the extra render pass the effect caused.
+  if (wasLoading !== loading) {
+    setWasLoading(loading);
     if (!loading) {
       setLastUpdated(new Date());
     }
-  }, [loading]);
+  }
 
   const handleExport = () => {
     onExport?.();

--- a/apps/frontend/components/transformation/RecipeManager.tsx
+++ b/apps/frontend/components/transformation/RecipeManager.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
+import { useAsyncData } from '@/lib/hooks/useAsyncData';
 import { X, Save, BookOpen, Users, Star, Clock } from 'lucide-react';
 import { API_URL } from '@/lib/constants';
 import { getAuthToken } from '@/lib/auth-helpers';
@@ -27,39 +28,26 @@ export default function RecipeManager({ onClose, onSave, onLoad, datasetId }: Re
   const [activeTab, setActiveTab] = useState<'save' | 'browse'>('browse');
   const [recipeName, setRecipeName] = useState('');
   const [recipeDescription, setRecipeDescription] = useState('');
-  const [recipes, setRecipes] = useState<Recipe[]>([]);
-  const [loading, setLoading] = useState(false);
   const [filter, setFilter] = useState<'all' | 'mine' | 'popular'>('all');
 
-  const loadRecipes = async () => {
-    setLoading(true);
-    try {
+  const { data: recipeData, loading } = useAsyncData(
+    async () => {
       const token = await getAuthToken();
       const response = await fetch(
         `${API_URL}/recipes?filter=${filter}&dataset_id=${datasetId}`,
-        {
-          headers: {
-            'Authorization': `Bearer ${token}`
-          }
-        }
+        { headers: { Authorization: `Bearer ${token}` } },
       );
-
-      if (response.ok) {
-        const data = await response.json();
-        setRecipes(data.recipes);
-      }
-    } catch (error) {
-      console.error('Failed to load recipes:', error);
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  useEffect(() => {
-    if (activeTab === 'browse') {
-      loadRecipes();
-    }
-  }, [activeTab, filter]);
+      // Non-OK was silently ignored before, leaving the previous list in place.
+      // Throwing plus keepPreviousData reproduces that: the old list stays and
+      // nothing is surfaced, since this component never rendered an error.
+      if (!response.ok) throw new Error('Failed to load recipes');
+      const data = await response.json();
+      return data.recipes as Recipe[];
+    },
+    [activeTab, filter, datasetId],
+    { enabled: activeTab === 'browse', keepPreviousData: true },
+  );
+  const recipes = recipeData ?? [];
 
   const handleSave = () => {
     if (recipeName && recipeDescription) {

--- a/apps/frontend/components/transformation/TransformationConfigDialog.tsx
+++ b/apps/frontend/components/transformation/TransformationConfigDialog.tsx
@@ -92,23 +92,28 @@ export function TransformationConfigDialog({
       .join(' ');
   };
 
-  // Reset form when dialog opens/closes or transformation changes
-  useEffect(() => {
+  // Resetting form state when the dialog opens (or its subject changes) is a
+  // prop-driven reset, so it happens during render rather than in an effect.
+  const [formSubject, setFormSubject] = useState({ open, transformationType, existingConfig });
+  if (
+    formSubject.open !== open ||
+    formSubject.transformationType !== transformationType ||
+    formSubject.existingConfig !== existingConfig
+  ) {
+    setFormSubject({ open, transformationType, existingConfig });
     if (open) {
-      if (existingConfig?.parameters) {
-        setParameters({ ...existingConfig.parameters });
-      } else {
-        setParameters({});
-      }
+      setParameters(existingConfig?.parameters ? { ...existingConfig.parameters } : {});
       setErrors({});
-      // Focus first input after dialog is rendered
-      const timeoutId = setTimeout(() => {
-        firstInputRef.current?.focus();
-      }, 0);
-
-      // Cleanup timeout on unmount to prevent React warnings
-      return () => clearTimeout(timeoutId);
     }
+  }
+
+  // The focus call is a real DOM side effect and stays an effect.
+  useEffect(() => {
+    if (!open) return;
+    const timeoutId = setTimeout(() => {
+      firstInputRef.current?.focus();
+    }, 0);
+    return () => clearTimeout(timeoutId);
   }, [open, transformationType, existingConfig]);
 
   /**

--- a/apps/frontend/components/transformation/TransformationPipeline.tsx
+++ b/apps/frontend/components/transformation/TransformationPipeline.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState, useCallback, useEffect, useMemo, useRef } from 'react';
+import { useAsyncData } from '@/lib/hooks/useAsyncData';
 import {
   ReactFlow,
   Edge,
@@ -64,7 +65,6 @@ export default function TransformationPipeline({
   const [nodes, setNodes, onNodesChange] = useNodesState<TransformationFlowNode>([]);
   const [edges, setEdges, onEdgesChange] = useEdgesState<Edge>([]);
   const [selectedNode, setSelectedNode] = useState<string | null>(null);
-  const [preview, setPreview] = useState<any>(null);
   const [loading, setLoading] = useState(false);
   // Undo/redo history over structural snapshots of the pipeline (#281).
   const [history, setHistory] = useState<
@@ -92,90 +92,94 @@ export default function TransformationPipeline({
     showViewToggle ? 'chain' : 'visual'
   );
   const [editingIndex, setEditingIndex] = useState<number | null>(null);
-  const [transformationTypes, setTransformationTypes] = useState<TransformationTypeMeta[]>([]);
-  const [availableColumns, setAvailableColumns] = useState<string[]>([]);
   // Monotonic counter for collision-free node IDs (mirrors FeatureBuilder);
   // Date.now()+length can collide on rapid adds within the same millisecond.
   const nodeIdCounterRef = useRef(0);
 
-  const loadPreview = async () => {
-    try {
+  const { data: previewData } = useAsyncData(
+    async () => {
       const token = await getAuthToken();
-      const response = await fetch(
-        `${API_URL}/datasets/${datasetId}/preview?rows=100`,
-        {
-          headers: {
-            'Authorization': `Bearer ${token}`
-          }
-        }
-      );
-      
-      if (response.ok) {
-        const data = await response.json();
-        setPreview(data);
+      const response = await fetch(`${API_URL}/datasets/${datasetId}/preview?rows=100`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      // A failed preview was only logged before; the pipeline stays usable.
+      if (!response.ok) return null;
+      return response.json();
+    },
+    [datasetId],
+    { enabled: !!datasetId },
+  );
+  // Running a transformation preview replaces the initial dataset preview, so
+  // the action's result is held separately and tagged with its dataset — the
+  // load shows through until an action overrides it, and switching datasets
+  // discards the override by derivation.
+  const [previewOverride, setPreviewOverride] = useState<{
+    datasetId: string;
+    data: unknown;
+  } | null>(null);
+  const preview =
+    previewOverride && previewOverride.datasetId === datasetId
+      ? previewOverride.data
+      : previewData ?? null;
+  const setPreview = (data: unknown) => setPreviewOverride({ datasetId, data });
+
+  // Transformation-type metadata + column names so the Chain view's Edit action
+  // can open a keyboard-accessible parameter dialog (mirrors the wiring in
+  // app/datasets/[id]/prepare/page.tsx). Best-effort: the pipeline still works
+  // without it (dialog degrades to "no parameters needed").
+  const { data: metadata } = useAsyncData(
+    async () => {
+      const token = await getAuthToken();
+
+      let types: TransformationTypeMeta[] = [];
+      const typesResponse = await fetch(`${API_URL}/transformations/available`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (typesResponse.ok) {
+        types = (await typesResponse.json()).transformations || [];
       }
-    } catch (error) {
-      console.error('Failed to load preview:', error);
-    }
-  };
 
-  // Load initial data preview
-  useEffect(() => {
-    loadPreview();
-  }, [datasetId]);
-
-  // Load transformation-type metadata + column names so the Chain view's Edit
-  // action can open a keyboard-accessible parameter dialog (mirrors the wiring
-  // in app/datasets/[id]/prepare/page.tsx). Best-effort: the pipeline still
-  // works without it (dialog degrades to "no parameters needed").
-  useEffect(() => {
-    const fetchMetadata = async () => {
-      try {
-        const token = await getAuthToken();
-        const typesResponse = await fetch(`${API_URL}/transformations/available`, {
-          headers: { Authorization: `Bearer ${token}` },
-        });
-        if (typesResponse.ok) {
-          const typesData = await typesResponse.json();
-          setTransformationTypes(typesData.transformations || []);
+      let columns: string[] = [];
+      const columnsResponse = await fetch(`${API_URL}/data/${datasetId}/preview`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (columnsResponse.ok) {
+        const columnsData = await columnsResponse.json();
+        if (Array.isArray(columnsData.columns)) {
+          columns = columnsData.columns.map((col: { name: string }) => col.name);
         }
-
-        const columnsResponse = await fetch(`${API_URL}/data/${datasetId}/preview`, {
-          headers: { Authorization: `Bearer ${token}` },
-        });
-        if (columnsResponse.ok) {
-          const columnsData = await columnsResponse.json();
-          if (Array.isArray(columnsData.columns)) {
-            setAvailableColumns(
-              columnsData.columns.map((col: { name: string }) => col.name)
-            );
-          }
-        }
-      } catch (error) {
-        console.error('Failed to load transformation metadata:', error);
       }
-    };
 
-    if (datasetId) {
-      fetchMetadata();
-    }
-  }, [datasetId]);
+      return { types, columns };
+    },
+    [datasetId],
+    { enabled: !!datasetId },
+  );
+  const transformationTypes = metadata?.types ?? [];
+  const availableColumns = metadata?.columns ?? [];
 
   // Reset the pipeline + undo history when the dataset changes, so switching
   // datasets on a reused component instance (the /prepare routes key only on
   // the route, not datasetId) can't leak one dataset's steps/history into
   // another via Undo (#281 — undo/redo is now live, so this leak is reachable).
-  useEffect(() => {
+  // Split deliberately: the state half is a prop-driven reset, which React's
+  // docs put in render, while the ref half must stay in an effect — writing refs
+  // during render is what react-hooks/refs forbids. Both still key on datasetId,
+  // so they run for the same change.
+  const [pipelineDataset, setPipelineDataset] = useState(datasetId);
+  if (pipelineDataset !== datasetId) {
+    setPipelineDataset(datasetId);
     setNodes([]);
     setEdges([]);
     setHistory([]);
-    historyIndexRef.current = -1;
     setHistoryIndex(-1);
+  }
+
+  useEffect(() => {
+    historyIndexRef.current = -1;
     lastRecordedSignatureRef.current = null;
     isRestoringHistoryRef.current = false;
     nodeIdCounterRef.current = 0;
-    // setNodes/setEdges are stable; keyed on datasetId only.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [datasetId]);
 
   // Notify parent of unsaved changes

--- a/apps/frontend/components/transformation/TransformationPreview.tsx
+++ b/apps/frontend/components/transformation/TransformationPreview.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
+import { useAsyncData } from '@/lib/hooks/useAsyncData';
 import { useDebounce } from '@/lib/hooks/useDebounce';
 import type { TransformationStep, ParameterValue } from '@/lib/types/recipe';
 import { getAuthToken } from '@/lib/auth-helpers';
@@ -91,100 +92,53 @@ export function TransformationPreview({
   onSampleSizeChange,
 }: TransformationPreviewProps) {
   // State management
-  const [previewData, setPreviewData] = useState<PreviewResponse | null>(null);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
   const [localSampleSize, setLocalSampleSize] = useState(sampleSize);
 
   // Debounce operations changes (300ms)
   const debouncedOperations = useDebounce(operations, 300);
   const debouncedSampleSize = useDebounce(localSampleSize, 300);
 
-  // Fetch preview when debounced values change
-  useEffect(() => {
-    if (!datasetId || debouncedOperations.length === 0) {
-      setPreviewData(null);
-      return;
-    }
+  // Fetch preview when debounced values change. AbortController and the
+  // isMounted flag are gone: the hook already discards a superseded request.
+  const {
+    data: previewData,
+    loading,
+    error,
+    reload,
+  } = useAsyncData<PreviewResponse>(
+    async () => {
+      const token = await getAuthToken();
+      const transformations = debouncedOperations.map((op) => ({
+        type: op.type,
+        parameters: op.parameters || {},
+      }));
 
-    // AbortController to cancel fetch on cleanup
-    const abortController = new AbortController();
-    let isMounted = true;
-
-    const fetchPreview = async () => {
-      if (!isMounted) return;
-
-      setLoading(true);
-      setError(null);
-
-      try {
-        const token = await getAuthToken();
-
-        // Build transformation steps for the API
-        const transformations = debouncedOperations.map((op) => ({
-          type: op.type,
-          parameters: op.parameters || {},
-        }));
-
-        // Call the service method with abort signal
-        const response = await fetch(
-          `${process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000/api/v1'}/transformations/pipeline/preview`,
-          {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-              ...(token && { Authorization: `Bearer ${token}` }),
-            },
-            body: JSON.stringify({
-              dataset_id: datasetId,
-              transformations,
-              sample_size: debouncedSampleSize,
-            }),
-            signal: abortController.signal,
-          }
-        );
-
-        if (!response.ok) {
-          const errorData = await response.json();
-          throw new Error(
-            errorData.detail || 'Failed to generate preview'
-          );
+      const response = await fetch(
+        `${process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000/api/v1'}/transformations/pipeline/preview`,
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            ...(token && { Authorization: `Bearer ${token}` }),
+          },
+          body: JSON.stringify({
+            dataset_id: datasetId,
+            transformations,
+            sample_size: debouncedSampleSize,
+          }),
         }
+      );
 
-        const data = (await response.json()) as PreviewResponse;
-
-        // Only update state if component is still mounted
-        if (isMounted) {
-          setPreviewData(data);
-        }
-      } catch (err) {
-        // Ignore abort errors
-        if (err instanceof Error && err.name === 'AbortError') {
-          return;
-        }
-
-        // Only update state if component is still mounted
-        if (isMounted) {
-          setError(
-            err instanceof Error ? err.message : 'Failed to generate preview'
-          );
-          setPreviewData(null);
-        }
-      } finally {
-        if (isMounted) {
-          setLoading(false);
-        }
+      if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.detail || 'Failed to generate preview');
       }
-    };
 
-    fetchPreview();
-
-    // Cleanup function
-    return () => {
-      isMounted = false;
-      abortController.abort();
-    };
-  }, [datasetId, debouncedOperations, debouncedSampleSize]);
+      return (await response.json()) as PreviewResponse;
+    },
+    [datasetId, debouncedOperations, debouncedSampleSize],
+    { enabled: !!datasetId && debouncedOperations.length > 0 },
+  );
 
   // Handle sample size change
   const handleSampleSizeChange = (newSize: number) => {
@@ -194,9 +148,9 @@ export function TransformationPreview({
 
   // Handle retry on error
   const handleRetry = () => {
-    setError(null);
-    // Re-trigger useEffect by updating state
-    setLocalSampleSize((prev) => prev);
+    // Previously cleared the error and nudged state to re-run the effect; the
+    // hook exposes the refetch directly.
+    reload();
   };
 
   // Export the current transformed preview as a CSV.

--- a/apps/frontend/eslint.config.mjs
+++ b/apps/frontend/eslint.config.mjs
@@ -23,31 +23,7 @@ const eslintConfig = defineConfig([
       "no-console": ["error", { allow: ["warn", "error"] }],
     },
   },
-  {
-    // React Compiler rules, new in eslint-plugin-react-hooks v7 — which arrives
-    // transitively with eslint-config-next 16, not from any change in this app.
-    // #333 demoted all five to warnings; #373 burns them down. Four are now at
-    // zero and enforced as errors, so a regression fails the build outright.
-    //
-    // set-state-in-effect is the one still pending. Clearing the other four let
-    // the compiler analyse components it had been bailing out of early, which
-    // raised this rule's count from 26 to 46 — those 20 were always present,
-    // just unreachable behind the earlier errors. Every remaining site is the
-    // same shape: an effect calls a loader that runs setLoading(true)/
-    // setError(null) synchronously before its first await. Fixing it means
-    // moving each spinner reset to the interaction that triggers the refetch
-    // (or seeding it as initial state), i.e. a data-fetching refactor across
-    // every page, not a lint edit. Tracked separately — see #393.
-    name: "react-compiler-rules-pending-burndown",
-    rules: {
-      "react-hooks/immutability": "error",
-      "react-hooks/static-components": "error",
-      "react-hooks/refs": "error",
-      "react-hooks/preserve-manual-memoization": "error",
-      "react-hooks/set-state-in-effect": "warn",
-    },
-  },
-  {
+    {
     // Tests and setup may use console freely, and may use require() for the
     // lazy/isolated module loading that jest module-mocking needs. e2e/ is
     // Playwright test code plus its helpers and fixtures — same allowance, and

--- a/apps/frontend/lib/contexts/FeatureEngineeringContext.tsx
+++ b/apps/frontend/lib/contexts/FeatureEngineeringContext.tsx
@@ -91,7 +91,7 @@ export function FeatureEngineeringProvider({
   // exactly the documented pattern for browser-only storage. Clearing the lint
   // error would mean introducing a real bug to satisfy a rule that cannot see
   // the constraint, so the suppression is the honest option.
-  // eslint-disable-next-line react-hooks/set-state-in-effect -- SSR-safe localStorage hydration; see above
+  /* eslint-disable react-hooks/set-state-in-effect -- SSR-safe localStorage hydration; see above */
   useEffect(() => {
     try {
       const savedFeatures = localStorage.getItem(`feature_engineering_${datasetId}_selected`);
@@ -118,6 +118,7 @@ export function FeatureEngineeringProvider({
       console.error('Failed to load persisted feature engineering state:', err);
     }
   }, [datasetId]);
+  /* eslint-enable react-hooks/set-state-in-effect */
 
   // Persist selected features
   useEffect(() => {

--- a/apps/frontend/lib/contexts/FeatureEngineeringContext.tsx
+++ b/apps/frontend/lib/contexts/FeatureEngineeringContext.tsx
@@ -79,6 +79,19 @@ export function FeatureEngineeringProvider({
   const [expandedSuggestionId, setExpandedSuggestionId] = useState<string | null>(null);
 
   // Load persisted state from localStorage
+  // The one site in #393 that keeps its setState-in-effect, deliberately.
+  //
+  // This hydrates from localStorage, which does not exist during SSR — and this
+  // is a 'use client' component, which Next still prerenders on the server. The
+  // rule's remedies both break here: reading during render throws server-side,
+  // and guarding with `typeof window` makes the server render empty while the
+  // client renders populated, which is a hydration mismatch.
+  //
+  // Deferring to an effect so the first client render matches the server's is
+  // exactly the documented pattern for browser-only storage. Clearing the lint
+  // error would mean introducing a real bug to satisfy a rule that cannot see
+  // the constraint, so the suppression is the honest option.
+  // eslint-disable-next-line react-hooks/set-state-in-effect -- SSR-safe localStorage hydration; see above
   useEffect(() => {
     try {
       const savedFeatures = localStorage.getItem(`feature_engineering_${datasetId}_selected`);

--- a/apps/frontend/lib/contexts/WorkflowContext.tsx
+++ b/apps/frontend/lib/contexts/WorkflowContext.tsx
@@ -181,17 +181,17 @@ export function WorkflowProvider({
   }, [state]);
 
   // Update current stage based on current route
-  useEffect(() => {
-    const currentStageConfig = WORKFLOW_STAGES.find(stage => 
-      pathname?.includes(stage.route)
-    );
-    if (currentStageConfig && currentStageConfig.id !== state.currentStage) {
-      setState(prev => ({
-        ...prev,
-        currentStage: currentStageConfig.id
-      }));
-    }
-  }, [pathname, state.currentStage]);
+  // Keeping currentStage in step with the route is a prop-driven adjustment, so
+  // React's documented place for it is during render rather than in an effect.
+  // Doing it here also means the first paint after a navigation already has the
+  // right stage, instead of rendering the previous one and correcting it.
+  const routeStage = WORKFLOW_STAGES.find(stage => pathname?.includes(stage.route));
+  if (routeStage && routeStage.id !== state.currentStage) {
+    setState(prev => ({
+      ...prev,
+      currentStage: routeStage.id
+    }));
+  }
 
   const canAccessStage = useCallback((stage: WorkflowStage): boolean => {
     const stageConfig = WORKFLOW_STAGES.find(s => s.id === stage);

--- a/apps/frontend/lib/hooks/useAsyncData.ts
+++ b/apps/frontend/lib/hooks/useAsyncData.ts
@@ -1,0 +1,124 @@
+import { useCallback, useEffect, useState, type DependencyList } from 'react'
+
+/**
+ * Keyed async loading with a derived `loading` flag (#393).
+ *
+ * ## Why this exists
+ *
+ * The app had 46 copies of this shape:
+ *
+ * ```ts
+ * const load = async () => {
+ *   setLoading(true)        // synchronous setState inside an effect
+ *   setError(null)
+ *   const d = await svc.get(id)
+ *   setData(d)
+ * }
+ * useEffect(() => { load() }, [id])
+ * ```
+ *
+ * `react-hooks/set-state-in-effect` is right to flag it: render → effect →
+ * `setLoading(true)` → render is a cascading render on every mount and refetch.
+ *
+ * The naive fix — delete `setLoading(true)` and rely on `useState(true)` — passes
+ * lint and quietly removes the spinner on every *refetch*, since the initial value
+ * only covers mount. That regression is invisible to a test suite that asserts on
+ * resolved states.
+ *
+ * ## How it avoids both
+ *
+ * `loading` is **derived during render**, never assigned in an effect. Each result
+ * records the deps it was fetched for, and a request is outstanding exactly while
+ * the recorded deps do not match the current ones:
+ *
+ * ```
+ * loading = enabled && !(resolved matches current deps)
+ * ```
+ *
+ * So a dep change makes `loading` true in the same render that changed it, with no
+ * state update at all. The effect only ever sets state from inside the promise
+ * continuation, which the rule permits.
+ */
+export interface UseAsyncDataOptions {
+  /** Skip the request while false. Mirrors the `if (session && id)` guards at call sites. */
+  enabled?: boolean
+  /** Shown instead of the thrown error's message. Call sites usually want fixed copy. */
+  errorMessage?: string
+}
+
+export interface UseAsyncDataResult<T> {
+  data: T | undefined
+  loading: boolean
+  error: string | null
+  /** Refetch with the current loader closure. Sets `loading` immediately. */
+  reload: () => void
+}
+
+interface Resolved<T> {
+  /** The deps snapshot this result was fetched for. */
+  deps: DependencyList
+  token: number
+  data?: T
+  error?: string
+}
+
+/** Shallow Object.is comparison, the same identity rule React uses for hook deps. */
+function sameDeps(a: DependencyList, b: DependencyList): boolean {
+  if (a.length !== b.length) return false
+  return a.every((v, i) => Object.is(v, b[i]))
+}
+
+export function useAsyncData<T>(
+  loader: () => Promise<T>,
+  deps: DependencyList,
+  options: UseAsyncDataOptions = {},
+): UseAsyncDataResult<T> {
+  const { enabled = true, errorMessage } = options
+
+  const [reloadToken, setReloadToken] = useState(0)
+  const [resolved, setResolved] = useState<Resolved<T> | null>(null)
+
+  // `loader` is deliberately NOT a dependency. Call sites pass an inline arrow, so
+  // it has a new identity every render and keying on it would refetch forever.
+  // Omitting it is safe rather than stale: the effect is recreated whenever
+  // `requestKey` changes, so the closure it captures is always from the render that
+  // requested the fetch. (An earlier draft held `loader` in a ref for this; a
+  // mutation check showed the ref changed no behaviour, so it is gone.)
+  useEffect(() => {
+    if (!enabled) return
+
+    let cancelled = false
+    loader()
+      .then((data) => {
+        if (!cancelled) setResolved({ deps, token: reloadToken, data })
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return
+        setResolved({
+          deps,
+          token: reloadToken,
+          error: errorMessage ?? (err instanceof Error ? err.message : String(err)),
+        })
+      })
+
+    // Guards against a superseded request landing after a newer one.
+    return () => {
+      cancelled = true
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- caller's deps, spread by contract; loader intentionally excluded
+  }, [...deps, reloadToken, enabled, errorMessage])
+
+  const reload = useCallback(() => {
+    setReloadToken((t) => t + 1)
+  }, [])
+
+  const settled =
+    resolved && resolved.token === reloadToken && sameDeps(resolved.deps, deps) ? resolved : null
+
+  return {
+    data: settled?.data,
+    loading: enabled && !settled,
+    error: settled?.error ?? null,
+    reload,
+  }
+}

--- a/apps/frontend/lib/hooks/useAsyncData.ts
+++ b/apps/frontend/lib/hooks/useAsyncData.ts
@@ -44,6 +44,17 @@ export interface UseAsyncDataOptions {
   enabled?: boolean
   /** Shown instead of the thrown error's message. Call sites usually want fixed copy. */
   errorMessage?: string
+  /**
+   * Keep the last successful result visible while a new key loads, instead of
+   * dropping to `undefined`.
+   *
+   * Off by default because it is not universally safe: showing the previous
+   * dataset's numbers under a new dataset's heading is worse than showing nothing,
+   * which is why some call sites explicitly cleared their state before loading.
+   * Opt in where the old code kept rendering data under a spinner (a "Regenerate"
+   * button that should not blank the panel it sits in).
+   */
+  keepPreviousData?: boolean
 }
 
 export interface UseAsyncDataResult<T> {
@@ -73,7 +84,7 @@ export function useAsyncData<T>(
   deps: DependencyList,
   options: UseAsyncDataOptions = {},
 ): UseAsyncDataResult<T> {
-  const { enabled = true, errorMessage } = options
+  const { enabled = true, errorMessage, keepPreviousData = false } = options
 
   const [reloadToken, setReloadToken] = useState(0)
   const [resolved, setResolved] = useState<Resolved<T> | null>(null)
@@ -116,7 +127,9 @@ export function useAsyncData<T>(
     resolved && resolved.token === reloadToken && sameDeps(resolved.deps, deps) ? resolved : null
 
   return {
-    data: settled?.data,
+    // With keepPreviousData, fall back to the previous key's result while the new
+    // one is in flight. `loading` is unaffected, so callers can still show a spinner.
+    data: settled ? settled.data : keepPreviousData ? resolved?.data : undefined,
     loading: enabled && !settled,
     error: settled?.error ?? null,
     reload,

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -7,7 +7,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint . --max-warnings 278",
+    "lint": "eslint . --max-warnings 233",
     "type-check": "tsc --noEmit",
     "test": "jest",
     "test:watch": "jest --watch",


### PR DESCRIPTION
Closes #393. Closes #373 (this was the last of its five React Compiler rules).

**46 → 0 violations.** The rule is `"error"`, the `react-compiler-rules-pending-burndown` block is deleted, and `--max-warnings` ratchets 280 → 233.

## The trap this was avoiding

All 46 sites were an effect calling a loader that sets state. The obvious fix — delete `setLoading(true)` and lean on `useState(true)` — passes lint, passes every test, and **silently removes the spinner on every refetch**, because the initial value only covers mount. Switching tab or dataset would show stale rows with no loading indicator.

The jest suite cannot catch that: it mocks `fetch` and asserts on resolved states, not loading transitions. So green CI means unusually little here.

## `useAsyncData`

`loading` is **derived during render**, never assigned in an effect. Each result records the deps it was fetched for; a request is outstanding precisely while those deps don't match the current ones. A dep change makes `loading` true in the same render that changed it, with **no state update at all**, and the effect only ever calls `setState` inside the promise continuation.

Options that emerged from real call sites, not speculation:
- `enabled` — replaces `if (session && id)` guards inside effects.
- `errorMessage` — an **override**, not a fallback. A test caught me using it where the original surfaced `err.message`.
- `keepPreviousData` — off by default, because retaining stale data is not universally safe.

Every assertion is mutation-checked: ignoring the deps snapshot fails 3 tests, dropping the stale-response guard fails 1.

## Six real regressions the existing suites caught

Worth listing, because the issue predicted the tests *couldn't* help. They can't see a missing spinner — but they caught everything else:

| # | What broke | How |
|---|---|---|
| 1 | The hook blanked panels on refetch | `AIInsightsPanel` — Regenerate dropped to a full-page loading card |
| 2 | Refetch **loop**, 4 calls where 1 expected | IVD — derived array had a fresh identity each render and fed an effect's deps |
| 3 | Mount-timing change | `PreviewControls` — the old effect stamped on mount; my render-phase version only fired on transitions |
| 4 | Error text swapped | `predict` — `errorMessage` overrode `err.message` |
| 5 | Coupled two independent loads | `model` — a deferred recommendation blocked the column options |
| 6 | Lost a behaviour outright | `model` — recommendation no longer preselected the training mode |

#1 is the important one: it was a defect in the **hook**, surfacing at site 7. Left undetected it would have been replicated across all 46.

## Pre-existing bugs fixed

- `AIInsightsPanel` and `StatisticsDashboard` guarded with `if (!data) fetch()`, which also blocked refetching when `datasetId` changed — so switching datasets showed the **previous dataset's numbers**.
- IVD's `numericColumns` was an unmemoised `columns.filter()` feeding an effect's deps; harmless only because a length guard sat in front of it.

## What this deleted

Not just moved — removed:

- Two hand-rolled `AbortController` + `isMounted` pairs (`DataPreviewTable`, `TransformationPreview`); the hook already discards superseded requests.
- A request-sequence ref in `training` that existed to stop a stale filter's response landing in the list.
- Two refs in `AIChat` whose only job was stopping two effects fighting over the same message.
- Several pieces of state that were duplicates of values already computable during render.

A meaningful share of these were never data-loading bugs. `RecipeLibrary`'s filtered list, `InteractiveTutorial`'s `isHighlighting`, IVD's auto-selection, `PreviewControls`' timestamp — the fix deletes state and an effect rather than substituting a hook. The rule was flagging genuine redundancy.

The recurring shape: **one effect doing two jobs.** `TransformationConfigDialog` reset form state *and* focused an input. `TransformationPipeline` cleared state *and* reset refs — and refs must stay in an effect, since writing them during render is what `react-hooks/refs` forbids. Splitting on that seam is what makes each half legal.

## ⚠️ One violation is suppressed, not fixed

`FeatureEngineeringContext` keeps its `setState`-in-effect behind a documented block disable.

It hydrates from `localStorage`, which doesn't exist during SSR, and Next prerenders `'use client'` components on the server. Reading during render throws there; guarding with `typeof window` makes the server render empty while the client renders populated — a hydration mismatch. Deferring to an effect is the documented pattern for browser-only storage.

Clearing that lint error would mean **introducing a real bug to satisfy a rule that can't see the constraint**. Flagging it rather than absorbing it into the count: this deviates from the issue's "all 46 cleared" wording and should be reviewed as a judgement call.

## ⚠️ Not done: the browser pass

The acceptance criteria require hand-verifying loading and error UI on the tab-driven (`/experiments`), route-driven (`/model/[id]`) and session-driven (`/monitor`) refetch paths. **That has not happened.**

This is the one gap automation cannot close, for the reason in the first section. I'd treat it as required before merge, not optional.

## Verification

| check | result |
|---|---|
| `react-hooks/set-state-in-effect` | **0** |
| eslint | 0 errors, 233 warnings (ceiling 233) |
| `tsc --noEmit` | clean |
| jest | 106 suites, 1336 passed, 3 skipped |
| `npm audit` | 0 vulnerabilities (via #401) |

```bash
cd apps/frontend && npx eslint . -f json \
  | jq '[.[].messages[] | select(.ruleId == "react-hooks/set-state-in-effect")] | length'
```

## Follow-up

`reactCompiler: true` in `next.config.mjs` was the point of the burndown and is now unblocked. Deliberately **not** included here — it changes how every component compiles and deserves its own PR and its own visual pass.
