### PR TITLE
fix(security): patch brace-expansion so Security Audit stops failing

### DIFF
--- a/apps/frontend/package-lock.json
+++ b/apps/frontend/package-lock.json
@@ -6270,9 +6270,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9032,9 +9032,9 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## What

`npm audit --audit-level=high` has been failing on **main** for a while, which turns the Security Audit job red on every PR — including #400, which is what surfaced it.

Two vulnerable copies of `brace-expansion` ([GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg), DoS via unbounded expansion), both transitive and both **dev-only**:

```
1.1.16  <- minimatch@3 <- @eslint/config-array <- eslint
2.1.2   <- minimatch@9 <- glob <- jest
```

The advisory covers `<1.1.17 || >=2.0.0 <2.1.3`, so both sit just inside it. Bumped to **1.1.18** and **2.1.4**.

## Scope

Lockfile only — 6 insertions, 6 deletions. `package.json` is untouched and no direct dependency moves.

## Why bother, given it's dev-only

Nothing here reaches users, so the runtime risk is nil. The reason to fix it is that a permanently-red security job is one everybody learns to scroll past — which is exactly how a genuine advisory gets missed. `pip-audit` already reports clean, so this is the last thing standing between the job and a signal that means something.

## A trap worth recording

`npm audit fix --package-lock-only` produces a lockfile that **`npm ci` rejects**:

```
Invalid: lock file's @emnapi/wasi-threads@1.0.2 does not satisfy @emnapi/wasi-threads@1.2.3
```

CI runs `npm ci`, so that shortcut converts one red job into a completely broken build. A real `npm audit fix` is required, verified with a clean `rm -rf node_modules && npm ci`.

## Verified

| check | result |
|---|---|
| `npm ci` from clean | OK |
| `npm audit --audit-level=high` | **0 vulnerabilities** |
| eslint | 278/280, 0 errors |
| `tsc --noEmit` | clean |
| jest | 1325 passed, 3 skipped |