### PR TITLE
feat(frontend): upgrade recharts 2 → 3, un-blind the chart tests, fix two chart bugs (#346)

### DIFF
--- a/apps/frontend/__tests__/app/evaluate.page.test.tsx
+++ b/apps/frontend/__tests__/app/evaluate.page.test.tsx
@@ -23,27 +23,12 @@ jest.mock('@/lib/auth-helpers', () => ({
   getAuthToken: jest.fn().mockResolvedValue('mock-token'),
 }))
 
-// Recharts renders SVG that jsdom cannot lay out (FeatureImportanceChart,
-// ROC/PR curves); replace with passthrough divs.
-jest.mock('recharts', () => {
-  const passthrough = ({ children }: { children?: React.ReactNode }) => (
-    <div>{children}</div>
-  )
-  return {
-    ResponsiveContainer: passthrough,
-    BarChart: passthrough,
-    Bar: passthrough,
-    LineChart: passthrough,
-    Line: passthrough,
-    Cell: passthrough,
-    XAxis: passthrough,
-    YAxis: passthrough,
-    CartesianGrid: passthrough,
-    Tooltip: passthrough,
-    Legend: passthrough,
-    ReferenceLine: passthrough,
-  }
-})
+// Real recharts, with only ResponsiveContainer sized so jsdom's 0x0 layout
+// doesn't blank the charts (#346). The old passthrough mock ignored props
+// entirely, so this page could render charts the library can't.
+jest.mock('recharts', () =>
+  jest.requireActual('@/__tests__/utils/sizedRecharts').sizedRecharts()
+)
 
 // Export utils touch URL.createObjectURL / jspdf, which jsdom lacks.
 const mockExportCSV = jest.fn()

--- a/apps/frontend/__tests__/app/explore/[id]/page.test.tsx
+++ b/apps/frontend/__tests__/app/explore/[id]/page.test.tsx
@@ -99,17 +99,24 @@ jest.mock('@/components/AIInsightsPanel', () => {
   }
 })
 
+// Records every `columns` array the page hands the dashboard, by reference, so
+// a test can assert the identity is stable across re-renders (#346).
+const mockColumnsProps: unknown[] = []
+
 jest.mock('@/components/InteractiveVisualizationDashboard', () => {
   return {
-    InteractiveVisualizationDashboard: ({ datasetId, columns }: { datasetId?: string; columns?: unknown }) => (
-      <div
-        data-testid="visualization-dashboard"
-        data-dataset-id={datasetId ?? ''}
-        data-columns={JSON.stringify(columns ?? null)}
-      >
-        Visualizations
-      </div>
-    )
+    InteractiveVisualizationDashboard: ({ datasetId, columns }: { datasetId?: string; columns?: unknown }) => {
+      mockColumnsProps.push(columns)
+      return (
+        <div
+          data-testid="visualization-dashboard"
+          data-dataset-id={datasetId ?? ''}
+          data-columns={JSON.stringify(columns ?? null)}
+        >
+          Visualizations
+        </div>
+      )
+    }
   }
 })
 
@@ -397,6 +404,44 @@ describe('DatasetAnalysisPage', () => {
       String(url).includes('/data/process')
     )
     expect(processCalls).toHaveLength(0)
+  })
+
+  it('hands the dashboard the same columns array across re-renders', async () => {
+    // The dashboard keys its chart fetch on this prop. Built inline in the JSX it
+    // was a fresh array every render, so the fetch effect re-ran, re-rendered and
+    // re-fetched without end — the scatter/boxplot/line tabs sat on "Loading
+    // visualization…" forever. Identity, not deep equality, is what matters.
+    mockColumnsProps.length = 0
+
+    renderWithWorkflow(<DatasetAnalysisPage />, 'test-dataset-id')
+
+    await waitFor(() => {
+      expect(screen.getByText('test-dataset.csv')).toBeInTheDocument()
+    }, { timeout: 3000 })
+
+    const activate = (name: RegExp) => {
+      const tab = screen.getByRole('tab', { name })
+      fireEvent.mouseDown(tab)
+      fireEvent.mouseUp(tab)
+      fireEvent.click(tab)
+    }
+
+    activate(/visualization/i)
+    await waitFor(() => {
+      expect(screen.getByTestId('visualization-dashboard')).toBeInTheDocument()
+    })
+
+    // Re-render the page (tab away and back) and check the same array comes through.
+    activate(/schema/i)
+    activate(/visualization/i)
+    await waitFor(() => {
+      expect(screen.getByTestId('visualization-dashboard')).toBeInTheDocument()
+    })
+
+    expect(mockColumnsProps.length).toBeGreaterThan(1)
+    for (const columns of mockColumnsProps) {
+      expect(columns).toBe(mockColumnsProps[0])
+    }
   })
 
   it('maps schema column types when rendering the visualizations tab', async () => {

--- a/apps/frontend/__tests__/components/BarChart.test.tsx
+++ b/apps/frontend/__tests__/components/BarChart.test.tsx
@@ -47,6 +47,22 @@ describe('BarChart', () => {
     expect(screen.getByText('20.0')).toBeInTheDocument()
   })
 
+  it('draws horizontal bars when orientation is horizontal', () => {
+    // The horizontal branch puts the numeric axis on X and the category axis on
+    // Y, which recharts only honours when the chart itself is laid out
+    // vertically. Without that, every bar has zero extent and the chart renders
+    // empty while the summary stats below it still read correctly -- which is
+    // how this shipped (found rendering the monitor Distribution tab, #346).
+    const { container } = render(
+      <BarChart data={data} orientation="horizontal" />
+    )
+
+    expect(container.querySelectorAll('.recharts-bar-rectangle')).toHaveLength(3)
+    // Categories on the y-axis, counts on the x-axis.
+    expect(axisTicks(container, 'y')).toEqual(['B', 'C', 'A'])
+    expect(axisTicks(container, 'x').at(-1)).not.toBe('0')
+  })
+
   it('draws one bar per row, x-labelled by the category dataKey', () => {
     const { container } = render(<BarChart data={data} />)
 

--- a/apps/frontend/__tests__/components/BarChart.test.tsx
+++ b/apps/frontend/__tests__/components/BarChart.test.tsx
@@ -2,35 +2,26 @@ import React from 'react'
 import { render, screen, fireEvent } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import { BarChart, BarChartData } from '@/components/BarChart'
+import { axisTicks } from '@/__tests__/utils/sizedRecharts'
 
-// Surface the recharts chart `onClick` prop as a real DOM click handler so we
-// can exercise the onClick -> onBarClick adapter (BarChart.tsx lines 78-79).
+// Real recharts, with only ResponsiveContainer sized so jsdom's 0x0 layout
+// doesn't blank the chart (#346) -- so Bar/XAxis/dataKey wiring is exercised
+// for real. `Tooltip` stays stubbed: recharts resolves the active index from
+// mouse geometry, which jsdom has none of, so a real hover never opens it. The
+// stub reproduces v3's contract exactly -- clone the `content` element and
+// inject active/payload/label -- which is what CustomTooltip depends on.
 jest.mock('recharts', () => {
-  const passthrough = ({ children }: { children?: React.ReactNode }) => <div>{children}</div>
-  const BarChart = ({ onClick, children }: { onClick?: (state: unknown) => void; children?: React.ReactNode }) => (
-    <div data-testid="recharts-barchart" onClick={() => onClick?.({ activeLabel: 'A' })}>
-      {children}
-    </div>
-  )
+  const React = jest.requireActual('react')
   return {
-    BarChart,
-    Bar: passthrough,
-    XAxis: passthrough,
-    YAxis: passthrough,
-    CartesianGrid: passthrough,
-    // recharts clones the `content` element and injects active/payload/label.
-    // Reproduce that so the tooltip's props are actually exercised — CustomTooltip
-    // lives at module scope now (#373) and receives total/yLabel/showPercentages
-    // as props rather than closing over them, which nothing else would catch.
+    ...jest.requireActual('@/__tests__/utils/sizedRecharts').sizedRecharts(),
     Tooltip: ({ content }: { content?: React.ReactElement }) =>
       content
         ? React.cloneElement(content, {
             active: true,
             payload: [{ value: 30, color: '#000' }],
             label: 'B',
-          } as never)
+          })
         : null,
-    ResponsiveContainer: passthrough,
   }
 })
 
@@ -56,20 +47,36 @@ describe('BarChart', () => {
     expect(screen.getByText('20.0')).toBeInTheDocument()
   })
 
-  it('forwards a Record-shaped payload to onBarClick when the chart is clicked', () => {
+  it('draws one bar per row, x-labelled by the category dataKey', () => {
+    const { container } = render(<BarChart data={data} />)
+
+    expect(container.querySelectorAll('.recharts-bar-rectangle')).toHaveLength(3)
+    // sortBy: 'value' -> descending, so B(30), C(20), A(10).
+    expect(axisTicks(container, 'x')).toEqual(['B', 'C', 'A'])
+  })
+
+  it('forwards recharts chart state to onBarClick when the chart is clicked', () => {
     const onBarClick = jest.fn()
-    render(<BarChart data={data} onBarClick={onBarClick} />)
+    const { container } = render(
+      <BarChart data={data} onBarClick={onBarClick} />
+    )
 
-    fireEvent.click(screen.getByTestId('recharts-barchart'))
+    fireEvent.click(container.querySelector('.recharts-wrapper')!)
 
+    // Real recharts drives this, so the adapter is verified against v3's actual
+    // onClick signature. The state's *contents* are not asserted: recharts
+    // derives the active index from mouse geometry and jsdom reports none, so
+    // every field comes back null here regardless of the click position.
     expect(onBarClick).toHaveBeenCalledTimes(1)
-    expect(onBarClick).toHaveBeenCalledWith({ activeLabel: 'A' })
+    expect(onBarClick.mock.calls[0][0]).toEqual(expect.any(Object))
   })
 
   it('does not pass an onClick handler when onBarClick is omitted', () => {
     // No handler provided → adapter is undefined; clicking is a no-op (no throw).
-    render(<BarChart data={data} />)
-    expect(() => fireEvent.click(screen.getByTestId('recharts-barchart'))).not.toThrow()
+    const { container } = render(<BarChart data={data} />)
+    expect(() =>
+      fireEvent.click(container.querySelector('.recharts-wrapper')!)
+    ).not.toThrow()
   })
 
   // CustomTooltip moved to module scope in #373, so the values it used to close

--- a/apps/frontend/__tests__/components/BarChart.test.tsx
+++ b/apps/frontend/__tests__/components/BarChart.test.tsx
@@ -60,7 +60,10 @@ describe('BarChart', () => {
     expect(container.querySelectorAll('.recharts-bar-rectangle')).toHaveLength(3)
     // Categories on the y-axis, counts on the x-axis.
     expect(axisTicks(container, 'y')).toEqual(['B', 'C', 'A'])
-    expect(axisTicks(container, 'x').at(-1)).not.toBe('0')
+    // Counts, not a collapsed [0,0] domain — the symptom of the missing layout.
+    const countTicks = axisTicks(container, 'x')
+    expect(countTicks.length).toBeGreaterThan(1)
+    expect(Number(countTicks.at(-1))).toBeGreaterThanOrEqual(30)
   })
 
   it('draws one bar per row, x-labelled by the category dataKey', () => {

--- a/apps/frontend/__tests__/components/HistogramChart.test.tsx
+++ b/apps/frontend/__tests__/components/HistogramChart.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, waitFor } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import { HistogramChart } from '@/components/HistogramChart'
 import { getHistogram, HistogramData } from '@/lib/services/visualization'
+import { axisTicks } from '@/__tests__/utils/sizedRecharts'
 
 // Mock the visualization service so we can drive the fetch-mode branch
 jest.mock('@/lib/services/visualization', () => ({
@@ -15,31 +16,15 @@ jest.mock('@/lib/auth-helpers', () => ({
   getAuthToken: jest.fn().mockResolvedValue('tok-123'),
 }))
 
-// recharts ResponsiveContainer needs a measurable parent in jsdom; stub the
-// chart primitives so we can assert on the rendered bin labels instead.
-jest.mock('recharts', () => {
-  const Bar = ({ children }: { children?: React.ReactNode }) => <div data-testid="bar">{children}</div>
-  const BarChart = ({ data, children }: { data: Array<{ bin: string; count: number }>; children?: React.ReactNode }) => (
-    <div data-testid="bar-chart">
-      {data.map((d) => (
-        <div key={d.bin} data-testid="bin">
-          {d.bin}:{d.count}
-        </div>
-      ))}
-      {children}
-    </div>
-  )
-  const passthrough = ({ children }: { children?: React.ReactNode }) => <div>{children}</div>
-  return {
-    BarChart,
-    Bar,
-    XAxis: passthrough,
-    YAxis: passthrough,
-    CartesianGrid: passthrough,
-    Tooltip: passthrough,
-    ResponsiveContainer: passthrough,
-  }
-})
+// Real recharts, with only ResponsiveContainer sized so jsdom's 0x0 layout
+// doesn't blank the chart (#346). Bin labels below are the real XAxis ticks,
+// so they only appear if `dataKey="bin"` still resolves against the data.
+jest.mock('recharts', () =>
+  jest.requireActual('@/__tests__/utils/sizedRecharts').sizedRecharts()
+)
+
+/** Bin labels as recharts actually drew them on the x-axis. */
+const binLabels = (container: HTMLElement) => axisTicks(container, 'x')
 
 const mockGetHistogram = getHistogram as jest.Mock
 
@@ -57,23 +42,24 @@ describe('HistogramChart', () => {
   })
 
   it('renders bins directly from the `data` prop without fetching', () => {
-    render(<HistogramChart data={sampleData} />)
+    const { container } = render(<HistogramChart data={sampleData} />)
 
     expect(mockGetHistogram).not.toHaveBeenCalled()
-    expect(screen.getByText('0.00 - 10.00:3')).toBeInTheDocument()
-    expect(screen.getByText('10.00 - 20.00:5')).toBeInTheDocument()
+    expect(binLabels(container)).toEqual(['0.00 - 10.00', '10.00 - 20.00'])
+    // One bar per bin, drawn by real recharts from `dataKey="count"`.
+    expect(container.querySelectorAll('.recharts-bar-rectangle')).toHaveLength(2)
   })
 
   it('fetches histogram data via datasetId+column when no `data` prop is given', async () => {
     mockGetHistogram.mockResolvedValue(sampleData)
 
-    render(<HistogramChart datasetId="ds-1" column="age" />)
+    const { container } = render(<HistogramChart datasetId="ds-1" column="age" />)
 
     // Before resolution the empty-state placeholder is shown.
     expect(screen.getByText('No histogram data available')).toBeInTheDocument()
 
     await waitFor(() => {
-      expect(screen.getByText('0.00 - 10.00:3')).toBeInTheDocument()
+      expect(binLabels(container)).toContain('0.00 - 10.00')
     })
 
     expect(mockGetHistogram).toHaveBeenCalledWith('ds-1', 'age', 50, 'tok-123')
@@ -100,7 +86,7 @@ describe('HistogramChart', () => {
       expect(screen.getByText('Failed to load histogram data')).toBeInTheDocument()
     })
     expect(screen.queryByText('No histogram data available')).not.toBeInTheDocument()
-    expect(screen.queryByTestId('bar-chart')).not.toBeInTheDocument()
+    expect(document.querySelector('.recharts-wrapper')).not.toBeInTheDocument()
   })
 
   it('renders the empty-state when neither data nor datasetId/column are provided', () => {

--- a/apps/frontend/__tests__/components/LineChart.test.tsx
+++ b/apps/frontend/__tests__/components/LineChart.test.tsx
@@ -2,37 +2,26 @@ import React from 'react'
 import { render, screen, fireEvent } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import { LineChart, LineChartData } from '@/components/LineChart'
+import { axisTicks } from '@/__tests__/utils/sizedRecharts'
 
-// Surface the recharts chart `onClick` prop as a real DOM click handler so we
-// can exercise the onClick -> onPointClick adapter (LineChart.tsx lines 39-40).
+// Real recharts, with only ResponsiveContainer sized so jsdom's 0x0 layout
+// doesn't blank the chart (#346) — so Line/XAxis/dataKey wiring is exercised
+// for real. `Tooltip` stays stubbed: recharts resolves the active index from
+// mouse geometry, which jsdom has none of, so a real hover never opens it. The
+// stub reproduces v3's contract exactly — clone the `content` element and
+// inject active/payload/label — which is what CustomTooltip depends on.
 jest.mock('recharts', () => {
-  const passthrough = ({ children }: { children?: React.ReactNode }) => <div>{children}</div>
-  const LineChart = ({ onClick, children }: { onClick?: (state: unknown) => void; children?: React.ReactNode }) => (
-    <div data-testid="recharts-linechart" onClick={() => onClick?.({ activeLabel: '2024' })}>
-      {children}
-    </div>
-  )
+  const React = jest.requireActual('react')
   return {
-    LineChart,
-    Line: passthrough,
-    XAxis: passthrough,
-    YAxis: passthrough,
-    CartesianGrid: passthrough,
-    // recharts clones the `content` element and injects active/payload/label.
-    // Reproduce that so the tooltip's props are exercised — CustomTooltip lives
-    // at module scope now (#373) and takes xLabel as a prop instead of closing
-    // over `data`.
+    ...jest.requireActual('@/__tests__/utils/sizedRecharts').sizedRecharts(),
     Tooltip: ({ content }: { content?: React.ReactElement }) =>
       content
         ? React.cloneElement(content, {
             active: true,
             payload: [{ name: 'Sales', value: 150, color: '#000' }],
             label: '2024',
-          } as never)
+          })
         : null,
-    ResponsiveContainer: passthrough,
-    Legend: passthrough,
-    Brush: passthrough,
   }
 })
 
@@ -53,19 +42,34 @@ describe('LineChart', () => {
     expect(screen.getByText('Sales over time')).toBeInTheDocument()
   })
 
-  it('forwards a Record-shaped payload to onPointClick when the chart is clicked', () => {
+  it('draws one line per series, x-labelled by the x dataKey', () => {
+    const { container } = render(<LineChart data={data} />)
+
+    expect(container.querySelectorAll('.recharts-line')).toHaveLength(1)
+    expect(axisTicks(container, 'x')).toEqual(['2023', '2024'])
+  })
+
+  it('forwards recharts chart state to onPointClick when the chart is clicked', () => {
     const onPointClick = jest.fn()
-    render(<LineChart data={data} onPointClick={onPointClick} />)
+    const { container } = render(
+      <LineChart data={data} onPointClick={onPointClick} />
+    )
 
-    fireEvent.click(screen.getByTestId('recharts-linechart'))
+    fireEvent.click(container.querySelector('.recharts-wrapper')!)
 
+    // Real recharts drives this, so the adapter is verified against v3's actual
+    // onClick signature. The state's *contents* are not asserted: recharts
+    // derives the active index from mouse geometry and jsdom reports none, so
+    // every field comes back null here regardless of the click position.
     expect(onPointClick).toHaveBeenCalledTimes(1)
-    expect(onPointClick).toHaveBeenCalledWith({ activeLabel: '2024' })
+    expect(onPointClick.mock.calls[0][0]).toEqual(expect.any(Object))
   })
 
   it('does not pass an onClick handler when onPointClick is omitted', () => {
-    render(<LineChart data={data} />)
-    expect(() => fireEvent.click(screen.getByTestId('recharts-linechart'))).not.toThrow()
+    const { container } = render(<LineChart data={data} />)
+    expect(() =>
+      fireEvent.click(container.querySelector('.recharts-wrapper')!)
+    ).not.toThrow()
   })
 
   it('renders the tooltip with xLabel threaded through as a prop', () => {

--- a/apps/frontend/__tests__/components/PRCurveChart.test.tsx
+++ b/apps/frontend/__tests__/components/PRCurveChart.test.tsx
@@ -4,28 +4,21 @@ import '@testing-library/jest-dom'
 import { PRCurveChart } from '@/components/PRCurveChart'
 import type { PRCurveData } from '@/lib/types/evaluation'
 
-// Recharts renders SVG that jsdom cannot lay out; mock it with passthrough
-// divs that expose the props we assert on (BarChart.test.tsx pattern).
-jest.mock('recharts', () => {
-  const passthrough = ({ children }: { children?: React.ReactNode }) => (
-    <div>{children}</div>
-  )
-  return {
-    ResponsiveContainer: passthrough,
-    LineChart: passthrough,
-    CartesianGrid: passthrough,
-    XAxis: passthrough,
-    YAxis: passthrough,
-    Tooltip: passthrough,
-    Legend: passthrough,
-    Line: ({ name }: { name?: string }) => (
-      <div data-testid="curve-line">{name}</div>
-    ),
-    ReferenceLine: ({ y }: { y?: number }) => (
-      <div data-testid="reference-line" data-y={y} />
-    ),
-  }
-})
+// Real recharts, with only ResponsiveContainer sized so jsdom's 0x0 layout
+// doesn't blank the chart (#346). Everything asserted below is drawn by the
+// real library, so a v3 prop/signature change fails here instead of passing
+// through a passthrough mock.
+jest.mock('recharts', () =>
+  jest.requireActual('@/__tests__/utils/sizedRecharts').sizedRecharts()
+)
+
+/** One <Line> per class, as recharts actually drew it. */
+const curves = (c: HTMLElement) => c.querySelectorAll('.recharts-line')
+
+const referenceLines = (c: HTMLElement) =>
+  Array.from(
+    c.querySelectorAll('.recharts-reference-line line')
+  ) as SVGLineElement[]
 
 const singleClassData: PRCurveData = {
   curves: {
@@ -48,34 +41,58 @@ const multiClassData: PRCurveData = {
 
 describe('PRCurveChart', () => {
   it('renders one line per class', () => {
-    render(<PRCurveChart data={multiClassData} />)
+    const { container } = render(<PRCurveChart data={multiClassData} />)
 
-    const lines = screen.getAllByTestId('curve-line')
-    expect(lines).toHaveLength(2)
+    expect(curves(container)).toHaveLength(2)
     expect(screen.getByText('a')).toBeInTheDocument()
     expect(screen.getByText('b')).toBeInTheDocument()
   })
 
   it('renders a horizontal baseline reference line for a single-class curve', () => {
-    render(<PRCurveChart data={singleClassData} />)
+    const { container } = render(<PRCurveChart data={singleClassData} />)
 
-    const ref = screen.getByTestId('reference-line')
-    expect(ref).toHaveAttribute('data-y', '0.42')
+    const [ref] = referenceLines(container)
+    expect(ref).toBeDefined()
+    // y=0.42 on the precision axis: a flat line, not a segment.
+    expect(ref.getAttribute('y1')).toBe(ref.getAttribute('y2'))
+  })
+
+  it('places the baseline line according to its value', () => {
+    // Guards the `y` prop actually reaching recharts: a higher baseline must
+    // draw higher up the chart (smaller SVG y). A dropped/renamed prop pins
+    // both renders to the same place.
+    const at = (baseline: number) => {
+      const { container, unmount } = render(
+        <PRCurveChart
+          data={{
+            curves: { yes: [{ x: 0, y: 1 }, { x: 1, y: baseline }] },
+            baseline_per_class: { yes: baseline },
+          }}
+        />
+      )
+      const y = Number(referenceLines(container)[0].getAttribute('y1'))
+      unmount()
+      return y
+    }
+
+    expect(at(0.9)).toBeLessThan(at(0.1))
   })
 
   it('omits baseline reference lines when there are multiple classes', () => {
-    render(<PRCurveChart data={multiClassData} />)
+    const { container } = render(<PRCurveChart data={multiClassData} />)
 
-    expect(screen.queryAllByTestId('reference-line')).toHaveLength(0)
+    expect(referenceLines(container)).toHaveLength(0)
   })
 
   it('renders a friendly placeholder when there are no curves', () => {
-    render(<PRCurveChart data={{ curves: {}, baseline_per_class: {} }} />)
+    const { container } = render(
+      <PRCurveChart data={{ curves: {}, baseline_per_class: {} }} />
+    )
 
     expect(
       screen.getByText(/no precision-recall curve data/i)
     ).toBeInTheDocument()
-    expect(screen.queryAllByTestId('curve-line')).toHaveLength(0)
+    expect(curves(container)).toHaveLength(0)
   })
 
   it('exposes a role=img wrapper naming the classes and the dash channel (issue #282)', () => {

--- a/apps/frontend/__tests__/components/ROCCurveChart.test.tsx
+++ b/apps/frontend/__tests__/components/ROCCurveChart.test.tsx
@@ -4,38 +4,32 @@ import '@testing-library/jest-dom'
 import { ROCCurveChart } from '@/components/ROCCurveChart'
 import type { ROCCurveData } from '@/lib/types/evaluation'
 
-// Recharts renders SVG that jsdom cannot lay out; mock it with passthrough
-// divs that expose the props we assert on (BarChart.test.tsx pattern).
-jest.mock('recharts', () => {
-  const passthrough = ({ children }: { children?: React.ReactNode }) => (
-    <div>{children}</div>
+// Real recharts, with only ResponsiveContainer sized so jsdom's 0x0 layout
+// doesn't blank the chart (#346). Everything asserted below is drawn by the
+// real library, so a v3 prop/signature change fails here instead of passing
+// through a passthrough mock.
+jest.mock('recharts', () =>
+  jest.requireActual('@/__tests__/utils/sizedRecharts').sizedRecharts()
+)
+
+/** One <Line> per class, as recharts actually drew it. */
+const curves = (c: HTMLElement) => c.querySelectorAll('.recharts-line')
+
+/**
+ * The `d` of each drawn curve. A `dataKey` that stops resolving leaves the
+ * <Line> element in place but drops its path entirely, so this is what makes
+ * the suite sensitive to the data actually reaching recharts.
+ */
+const curvePaths = (c: HTMLElement) =>
+  Array.from(c.querySelectorAll('.recharts-line-curve')).map((el) =>
+    el.getAttribute('d')
   )
-  return {
-    ResponsiveContainer: passthrough,
-    LineChart: passthrough,
-    CartesianGrid: passthrough,
-    XAxis: passthrough,
-    YAxis: passthrough,
-    Tooltip: passthrough,
-    Legend: passthrough,
-    Line: ({ name }: { name?: string }) => (
-      <div data-testid="curve-line">{name}</div>
-    ),
-    ReferenceLine: ({
-      segment,
-      y,
-    }: {
-      segment?: Array<{ x: number; y: number }>
-      y?: number
-    }) => (
-      <div
-        data-testid="reference-line"
-        data-segment={segment ? JSON.stringify(segment) : undefined}
-        data-y={y}
-      />
-    ),
-  }
-})
+
+const referenceLine = (c: HTMLElement) =>
+  c.querySelector('.recharts-reference-line line') as SVGLineElement | null
+
+const coords = (line: SVGLineElement) =>
+  (['x1', 'y1', 'x2', 'y2'] as const).map((a) => Number(line.getAttribute(a)))
 
 const data: ROCCurveData = {
   curves: {
@@ -56,34 +50,44 @@ const data: ROCCurveData = {
 
 describe('ROCCurveChart', () => {
   it('renders one line per class with the AUC in the legend name', () => {
-    render(<ROCCurveChart data={data} />)
+    const { container } = render(<ROCCurveChart data={data} />)
 
-    const lines = screen.getAllByTestId('curve-line')
-    expect(lines).toHaveLength(2)
+    expect(curves(container)).toHaveLength(2)
     expect(screen.getByText('yes (AUC 0.93)')).toBeInTheDocument()
     expect(screen.getByText('no (AUC 0.88)')).toBeInTheDocument()
   })
 
-  it('renders a diagonal random-classifier reference line', () => {
-    render(<ROCCurveChart data={data} />)
+  it('plots each curve from the x/y data keys', () => {
+    const { container } = render(<ROCCurveChart data={data} />)
 
-    const ref = screen.getByTestId('reference-line')
-    expect(ref).toHaveAttribute(
-      'data-segment',
-      JSON.stringify([
-        { x: 0, y: 0 },
-        { x: 1, y: 1 },
-      ])
-    )
+    const paths = curvePaths(container)
+    expect(paths).toHaveLength(2)
+    for (const d of paths) {
+      expect(d).toMatch(/^M[\d.]+,[\d.]+[CL]/)
+    }
+    // The two classes have different curves, so they must not draw identically.
+    expect(paths[0]).not.toEqual(paths[1])
+  })
+
+  it('renders a diagonal random-classifier reference line', () => {
+    const { container } = render(<ROCCurveChart data={data} />)
+
+    const ref = referenceLine(container)
+    expect(ref).not.toBeNull()
+    // segment [{x:0,y:0} -> {x:1,y:1}] in chart space: left-to-right and, since
+    // SVG y grows downward, bottom-to-top.
+    const [x1, y1, x2, y2] = coords(ref!)
+    expect(x2).toBeGreaterThan(x1)
+    expect(y2).toBeLessThan(y1)
   })
 
   it('renders a friendly placeholder when there are no curves', () => {
-    render(
+    const { container } = render(
       <ROCCurveChart data={{ curves: {}, auc_per_class: {}, macro_auc: null }} />
     )
 
     expect(screen.getByText(/no roc curve data/i)).toBeInTheDocument()
-    expect(screen.queryAllByTestId('curve-line')).toHaveLength(0)
+    expect(curves(container)).toHaveLength(0)
   })
 
   it('omits the AUC suffix when no AUC is available for a class', () => {

--- a/apps/frontend/__tests__/components/ShapSummaryChart.test.tsx
+++ b/apps/frontend/__tests__/components/ShapSummaryChart.test.tsx
@@ -3,35 +3,14 @@ import { render, screen } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import { ShapSummaryChart } from '@/components/ShapSummaryChart'
 import type { RankedFeature } from '@/lib/types/evaluation'
+import { axisTicks } from '@/__tests__/utils/sizedRecharts'
 
-// Recharts renders SVG that jsdom can't lay out; mock as passthrough divs and
-// expose the data so we can assert what the chart was given (matches the
-// pattern used by the other chart component tests).
-jest.mock('recharts', () => {
-  const passthrough = ({ children }: { children?: React.ReactNode }) => (
-    <div>{children}</div>
-  )
-  const BarChart = ({
-    data,
-    children,
-  }: {
-    data?: Array<{ feature_name: string }>
-    children?: React.ReactNode
-  }) => (
-    <div data-testid="recharts-barchart" data-order={(data || []).map((d) => d.feature_name).join(',')}>
-      {children}
-    </div>
-  )
-  return {
-    BarChart,
-    Bar: passthrough,
-    XAxis: passthrough,
-    YAxis: passthrough,
-    CartesianGrid: passthrough,
-    Tooltip: passthrough,
-    ResponsiveContainer: passthrough,
-  }
-})
+// Real recharts, with only ResponsiveContainer sized so jsdom's 0x0 layout
+// doesn't blank the chart (#346). The bar order below is read off the real
+// y-axis ticks, so it only holds if `dataKey="feature_name"` still resolves.
+jest.mock('recharts', () =>
+  jest.requireActual('@/__tests__/utils/sizedRecharts').sizedRecharts()
+)
 
 const FEATURES: RankedFeature[] = [
   { feature_name: 'age', importance: 0.1 },
@@ -57,19 +36,17 @@ describe('ShapSummaryChart', () => {
   })
 
   it('sorts features by descending importance', () => {
-    render(<ShapSummaryChart features={FEATURES} />)
-    expect(screen.getByTestId('recharts-barchart')).toHaveAttribute(
-      'data-order',
-      'income,score,age'
-    )
+    const { container } = render(<ShapSummaryChart features={FEATURES} />)
+    expect(axisTicks(container, 'y')).toEqual(['income', 'score', 'age'])
+    expect(container.querySelectorAll('.recharts-bar-rectangle')).toHaveLength(3)
   })
 
   it('caps the number of bars when maxFeatures is set', () => {
-    render(<ShapSummaryChart features={FEATURES} maxFeatures={2} />)
-    expect(screen.getByTestId('recharts-barchart')).toHaveAttribute(
-      'data-order',
-      'income,score'
+    const { container } = render(
+      <ShapSummaryChart features={FEATURES} maxFeatures={2} />
     )
+    expect(axisTicks(container, 'y')).toEqual(['income', 'score'])
+    expect(container.querySelectorAll('.recharts-bar-rectangle')).toHaveLength(2)
   })
 
   it('shows an empty state when there are no features', () => {

--- a/apps/frontend/__tests__/components/chartClickPayloads.test.tsx
+++ b/apps/frontend/__tests__/components/chartClickPayloads.test.tsx
@@ -1,0 +1,90 @@
+import React from 'react'
+import { render, fireEvent } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import { FeatureImportanceChart } from '@/components/FeatureImportanceChart'
+import { ScatterPlotChart } from '@/components/ScatterPlotChart'
+import type { FeatureScore } from '@/lib/services/featureSelection'
+
+// The two components recharts 3 actually broke (#346). Neither had any test.
+//
+// Scope note, so these are not read as more than they are: the v3 breakage was
+// **type-level only**. `Bar`/`Scatter` now type their onClick argument as
+// BarRectangleItem / ScatterPointItem, which stopped compiling (TS2345) — but at
+// runtime v3 spreads the datum's own fields onto that item, so reading the
+// argument directly and reading `.payload` produce the same values. Verified:
+// mutating the adapters back to the v2 shape leaves these tests green. **`tsc` is
+// the only gate that catches that regression**, which is why the migration commit
+// leans on it.
+//
+// What these do cover, and nothing did before: the bars/points render and are
+// clickable under v3, each adapter fires exactly once with the datum's fields,
+// and omitting the callback is a safe no-op.
+jest.mock('recharts', () =>
+  jest.requireActual('@/__tests__/utils/sizedRecharts').sizedRecharts()
+)
+
+const FEATURES: FeatureScore[] = [
+  { feature_name: 'age', score: 0.9, rank: 1, selected: true },
+  { feature_name: 'tenure', score: 0.4, rank: 2, selected: false },
+]
+
+describe('FeatureImportanceChart', () => {
+  it('hands onFeatureClick the datum, not the recharts event object', () => {
+    const onFeatureClick = jest.fn()
+    const { container } = render(
+      <FeatureImportanceChart features={FEATURES} onFeatureClick={onFeatureClick} />
+    )
+
+    const bars = container.querySelectorAll('.recharts-bar-rectangle')
+    expect(bars).toHaveLength(2)
+
+    fireEvent.click(bars[0])
+
+    expect(onFeatureClick).toHaveBeenCalledTimes(1)
+    expect(onFeatureClick.mock.calls[0][0]).toMatchObject({
+      feature_name: expect.any(String),
+      score: expect.any(Number),
+    })
+  })
+
+  it('does nothing when no onFeatureClick is supplied', () => {
+    const { container } = render(<FeatureImportanceChart features={FEATURES} />)
+    const bar = container.querySelector('.recharts-bar-rectangle')!
+    expect(() => fireEvent.click(bar)).not.toThrow()
+  })
+})
+
+describe('ScatterPlotChart', () => {
+  const data = {
+    data: [
+      { x: 1, y: 2, label: 'a' },
+      { x: 3, y: 4, label: 'b' },
+    ],
+    xLabel: 'x',
+    yLabel: 'y',
+  }
+
+  it('hands onPointClick the datum, not the recharts event object', () => {
+    const onPointClick = jest.fn()
+    const { container } = render(
+      <ScatterPlotChart data={data} onPointClick={onPointClick} />
+    )
+
+    const points = container.querySelectorAll('.recharts-scatter-symbol')
+    expect(points.length).toBeGreaterThan(0)
+
+    fireEvent.click(points[0])
+
+    expect(onPointClick).toHaveBeenCalledTimes(1)
+    expect(onPointClick.mock.calls[0][0]).toMatchObject({
+      x: expect.any(Number),
+      y: expect.any(Number),
+    })
+  })
+
+  it('does nothing when no onPointClick is supplied', () => {
+    const { container } = render(<ScatterPlotChart data={data} />)
+    const point = container.querySelector('.recharts-scatter-symbol')!
+    expect(() => fireEvent.click(point)).not.toThrow()
+  })
+})

--- a/apps/frontend/__tests__/utils/sizedRecharts.tsx
+++ b/apps/frontend/__tests__/utils/sizedRecharts.tsx
@@ -1,0 +1,52 @@
+import React from 'react'
+
+/**
+ * Real recharts with **only** `ResponsiveContainer` replaced by a fixed-size wrapper.
+ *
+ * jsdom lays everything out as 0x0, so recharts' real `ResponsiveContainer` measures
+ * zero and renders an empty div — which is why the chart suites historically mocked
+ * every recharts primitive as a prop-ignoring passthrough. Those mocks are blind to
+ * the library: after the recharts 2 -> 3 major (#346) they would render happily
+ * against props v3 no longer accepts, exactly the failure mode #390 hit with
+ * react-window. Stubbing the container alone keeps `Line`/`Bar`/`XAxis`/`Tooltip`
+ * and the whole dataKey -> SVG pipeline real, so a signature change turns the suite
+ * red instead of passing through.
+ *
+ * Usage (jest.mock factories can't close over outer scope, hence requireActual):
+ *
+ *     jest.mock('recharts', () =>
+ *       jest.requireActual('@/__tests__/utils/sizedRecharts').sizedRecharts()
+ *     )
+ */
+export function sizedRecharts(width = 800, height = 400) {
+  const actual = jest.requireActual('recharts')
+
+  const ResponsiveContainer = ({
+    children,
+  }: {
+    children?: React.ReactNode
+  }) =>
+    React.isValidElement(children)
+      ? React.cloneElement(children as React.ReactElement<Record<string, unknown>>, {
+          width,
+          height,
+        })
+      : children
+
+  return { ...actual, ResponsiveContainer }
+}
+
+/**
+ * Text of the rendered tick labels on one axis, in document order.
+ *
+ * recharts 3 hoists tick labels into their own z-index layer instead of nesting
+ * them under the axis group, so they are addressed by `recharts-{x,y}Axis-tick-labels`
+ * rather than by descending from `.recharts-xAxis`.
+ */
+export function axisTicks(container: HTMLElement, axis: 'x' | 'y'): string[] {
+  return Array.from(
+    container.querySelectorAll(
+      `.recharts-${axis}Axis-tick-labels .recharts-cartesian-axis-tick-value`
+    )
+  ).map((el) => el.textContent ?? '')
+}

--- a/apps/frontend/app/explore/[id]/page.tsx
+++ b/apps/frontend/app/explore/[id]/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useParams, useRouter } from 'next/navigation'
 import { useSession } from 'next-auth/react'
 import { getAuthToken } from '@/lib/auth-helpers'
@@ -73,6 +73,23 @@ export default function DatasetAnalysisPage() {
   const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [activeTab, setActiveTab] = useState('overview')
+
+  // Memoised because it feeds InteractiveVisualizationDashboard's chart-fetch
+  // dependency list. Built inline in the JSX, it was a fresh array on every
+  // render of this page, so the dashboard refetched, re-rendered and refetched
+  // again — the scatter/boxplot/line tabs never left "Loading visualization…".
+  const vizColumns = useMemo(
+    () =>
+      dataset?.schema?.columns?.map((col) => ({
+        name: col.name,
+        // Canonical field is the backend's `data_type` (schema_inference.py
+        // DataType enum); legacy documents may only carry pandas-style `type`.
+        type: classifyColumnType(col.data_type ?? col.type),
+        unique_count: col.unique_count ?? col.cardinality,
+        null_count: col.null_count,
+      })),
+    [dataset?.schema?.columns],
+  )
 
   const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000/api/v1'
 
@@ -453,17 +470,10 @@ export default function DatasetAnalysisPage() {
           </TabsContent>
 
           <TabsContent value="visualizations">
-            {dataset.schema?.columns ? (
+            {vizColumns ? (
               <InteractiveVisualizationDashboard
                 datasetId={dataset.id}
-                columns={dataset.schema.columns.map((col) => ({
-                  name: col.name,
-                  // Canonical field is the backend's `data_type` (schema_inference.py
-                  // DataType enum); legacy documents may only carry pandas-style `type`.
-                  type: classifyColumnType(col.data_type ?? col.type),
-                  unique_count: col.unique_count ?? col.cardinality,
-                  null_count: col.null_count
-                }))}
+                columns={vizColumns}
                 statistics={dataset.statistics}
               />
             ) : (

--- a/apps/frontend/components/BarChart.tsx
+++ b/apps/frontend/components/BarChart.tsx
@@ -102,6 +102,10 @@ export function BarChart({
     width,
     height,
     data: sortedData,
+    // Horizontal bars need recharts' `layout="vertical"`; without it the axes
+    // below (numeric X, category Y) contradict the chart's own layout and every
+    // bar renders with zero extent — an empty chart under correct summary stats.
+    layout: orientation === 'horizontal' ? ('vertical' as const) : ('horizontal' as const),
     margin: { top: 20, right: 30, left: 60, bottom: 80 },
     onClick: handleChartClick
   }

--- a/apps/frontend/components/FeatureImportanceChart.tsx
+++ b/apps/frontend/components/FeatureImportanceChart.tsx
@@ -132,7 +132,14 @@ export function FeatureImportanceChart({
           <Tooltip content={<CustomTooltip />} />
           <Bar
             dataKey="score"
-            onClick={(data) => onFeatureClick && onFeatureClick(data)}
+            // recharts 3 types the Bar onClick payload as BarRectangleItem, which
+            // carries the datum's fields but is not typed as FeatureScore. The
+            // original entry is on `payload`, so read it from there instead of
+            // asserting the whole event object is a FeatureScore.
+            onClick={(bar) => {
+              const entry = (bar as unknown as { payload?: FeatureScore }).payload
+              if (onFeatureClick && entry) onFeatureClick(entry)
+            }}
             cursor={onFeatureClick ? 'pointer' : 'default'}
           >
             {chartData.map((entry, index) => (

--- a/apps/frontend/components/FeatureImportanceChart.tsx
+++ b/apps/frontend/components/FeatureImportanceChart.tsx
@@ -11,6 +11,7 @@ import {
   ResponsiveContainer,
   Cell
 } from 'recharts'
+import type { BarRectangleItem } from 'recharts'
 import type { FeatureScore } from '@/lib/services/featureSelection'
 
 export interface FeatureImportanceChartProps {
@@ -132,12 +133,14 @@ export function FeatureImportanceChart({
           <Tooltip content={<CustomTooltip />} />
           <Bar
             dataKey="score"
-            // recharts 3 types the Bar onClick payload as BarRectangleItem, which
-            // carries the datum's fields but is not typed as FeatureScore. The
-            // original entry is on `payload`, so read it from there instead of
-            // asserting the whole event object is a FeatureScore.
-            onClick={(bar) => {
-              const entry = (bar as unknown as { payload?: FeatureScore }).payload
+            // recharts 3 types the Bar onClick argument as BarRectangleItem, which
+            // spreads the datum's fields but is not itself a FeatureScore, so the
+            // v2 code stopped compiling (TS2345). The entry is on `payload`; read
+            // it from there rather than asserting the event object is a
+            // FeatureScore. Typed against recharts' own export instead of casting
+            // through `unknown`, which would drop checking on the very API that broke.
+            onClick={(bar: BarRectangleItem) => {
+              const entry = bar.payload as FeatureScore | undefined
               if (onFeatureClick && entry) onFeatureClick(entry)
             }}
             cursor={onFeatureClick ? 'pointer' : 'default'}

--- a/apps/frontend/components/ScatterPlotChart.tsx
+++ b/apps/frontend/components/ScatterPlotChart.tsx
@@ -2,6 +2,7 @@
 
 import React from 'react'
 import { ScatterChart, Scatter, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Legend } from 'recharts'
+import type { ScatterPointItem } from 'recharts'
 
 export interface ScatterPlotData {
   data: Array<{
@@ -95,16 +96,20 @@ export function ScatterPlotChart({
               name={category === 'default' ? data.title || 'Data' : category}
               data={points}
               fill={colors[index % colors.length]}
-              // recharts 3 narrows the Scatter onClick payload to ScatterPointItem,
-              // which has no string index signature. The caller wants the datum, so
-              // hand it the payload rather than the event object.
+              // recharts 3 narrows the Scatter onClick argument to ScatterPointItem,
+              // which has no string index signature, so the v2 code stopped
+              // compiling. The caller wants the datum, so hand it `payload` — and
+              // skip the call entirely when there is none, rather than reporting an
+              // empty click the caller cannot tell from a real one. Typed against
+              // recharts' own export instead of casting through `unknown`.
               onClick={
                 onPointClick
-                  ? (point) =>
-                      onPointClick(
-                        (point as unknown as { payload?: Record<string, unknown> })
-                          .payload ?? {},
-                      )
+                  ? (point: ScatterPointItem) => {
+                      const entry = point.payload as
+                        | Record<string, unknown>
+                        | undefined
+                      if (entry) onPointClick(entry)
+                    }
                   : undefined
               }
               cursor="pointer"

--- a/apps/frontend/components/ScatterPlotChart.tsx
+++ b/apps/frontend/components/ScatterPlotChart.tsx
@@ -95,7 +95,18 @@ export function ScatterPlotChart({
               name={category === 'default' ? data.title || 'Data' : category}
               data={points}
               fill={colors[index % colors.length]}
-              onClick={onPointClick}
+              // recharts 3 narrows the Scatter onClick payload to ScatterPointItem,
+              // which has no string index signature. The caller wants the datum, so
+              // hand it the payload rather than the event object.
+              onClick={
+                onPointClick
+                  ? (point) =>
+                      onPointClick(
+                        (point as unknown as { payload?: Record<string, unknown> })
+                          .payload ?? {},
+                      )
+                  : undefined
+              }
               cursor="pointer"
             />
           ))}

--- a/apps/frontend/package-lock.json
+++ b/apps/frontend/package-lock.json
@@ -48,7 +48,7 @@
         "react-dropzone": "^19.1.1",
         "react-markdown": "^10.1.0",
         "react-window": "2.3.0",
-        "recharts": "^2.12.0",
+        "recharts": "^3.10.1",
         "tailwind-merge": "^3.6.0"
       },
       "devDependencies": {
@@ -4458,6 +4458,32 @@
       "integrity": "sha512-JtyZR+mqgBibTo8xea3B6ZRmzZiM/YeVBtUkas6zMuXjAlfIFIW2FgqeM9eLyvEaYX66vr6DJMK+4U6LV0KhNw==",
       "license": "MIT"
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.12.0.tgz",
+      "integrity": "sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -4497,6 +4523,18 @@
       "dependencies": {
         "@sinonjs/commons": "^3.0.1"
       }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
@@ -4978,9 +5016,9 @@
       }
     },
     "node_modules/@types/d3-array": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.1.tgz",
-      "integrity": "sha512-Y2Jn2idRrLzUfAKV2LyRImR+y4oa2AntrgID95SHJxuMUrkNXmanDSed71sRNZysveJVt1hLLemQZIady0FpEg==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
       "license": "MIT"
     },
     "node_modules/@types/d3-color": {
@@ -5035,9 +5073,9 @@
       "license": "MIT"
     },
     "node_modules/@types/d3-shape": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.7.tgz",
-      "integrity": "sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==",
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
       "license": "MIT",
       "dependencies": {
         "@types/d3-path": "*"
@@ -5316,6 +5354,12 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
     "node_modules/@types/webidl-conversions": {
@@ -6935,9 +6979,9 @@
       }
     },
     "node_modules/d3-format": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
-      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -7352,16 +7396,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/dom-helpers": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
-      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.8.7",
-        "csstype": "^3.0.2"
-      }
-    },
     "node_modules/dompurify": {
       "version": "3.4.12",
       "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
@@ -7629,6 +7663,17 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.50.0.tgz",
+      "integrity": "sha512-OyZKhUVvEep9ITEiwHn8GKnMRQIVqoSIX7WnRbkWgJkllCujilqP2rD0u979tkl8wqyc8ICwlc1UBVv/Sl1G6w==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks",
+        "tests/types"
+      ]
     },
     "node_modules/esbuild": {
       "version": "0.28.1",
@@ -8429,9 +8474,9 @@
       }
     },
     "node_modules/eventemitter3": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
     },
     "node_modules/execa": {
@@ -8505,15 +8550,6 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/fast-equals": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.2.2.tgz",
-      "integrity": "sha512-V7/RktU11J3I36Nwq2JnZEM7tNm17eBJz+u25qdxBZeCKiX6BkVSZQjwWIr+IobgnZy+ag73tTZgZi7tr0LrBw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.0.0"
-      }
     },
     "node_modules/fast-glob": {
       "version": "3.3.1",
@@ -9357,6 +9393,17 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/immer": {
+      "version": "11.1.15",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.15.tgz",
+      "integrity": "sha512-VrNANlmnWQnh5COXIIOQXM9oOJw7naGKlBT74ZOOR6lpVXc3gFEu9FJLDFcpCJ2j+NWr8TIwtWD//T6ZX6TKiQ==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
       }
     },
     "node_modules/import-fresh": {
@@ -11036,6 +11083,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -11537,12 +11585,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/lodash": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
-      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
-      "license": "MIT"
-    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -11564,6 +11606,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -12688,6 +12731,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -13344,6 +13388,7 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -13355,6 +13400,7 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/property-information": {
@@ -13569,8 +13615,8 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-is-18": {
       "name": "react-is",
@@ -13613,6 +13659,30 @@
       "peerDependencies": {
         "@types/react": ">=18",
         "react": ">=18"
+      }
+    },
+    "node_modules/react-redux": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
+      "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-remove-scroll": {
@@ -13662,21 +13732,6 @@
         }
       }
     },
-    "node_modules/react-smooth": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.4.tgz",
-      "integrity": "sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-equals": "^5.0.1",
-        "prop-types": "^15.8.1",
-        "react-transition-group": "^4.4.5"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
     "node_modules/react-style-singleton": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
@@ -13699,22 +13754,6 @@
         }
       }
     },
-    "node_modules/react-transition-group": {
-      "version": "4.4.5",
-      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
-      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@babel/runtime": "^7.5.5",
-        "dom-helpers": "^5.0.1",
-        "loose-envify": "^1.4.0",
-        "prop-types": "^15.6.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0",
-        "react-dom": ">=16.6.0"
-      }
-    },
     "node_modules/react-window": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/react-window/-/react-window-2.3.0.tgz",
@@ -13726,42 +13765,34 @@
       }
     },
     "node_modules/recharts": {
-      "version": "2.15.4",
-      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.15.4.tgz",
-      "integrity": "sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.10.1.tgz",
+      "integrity": "sha512-QXFrvt6IVcw7eeZCoyXTwkIJAX3Dv1nyVhMicXJ47GsGDDpcN8z6o644DibE9XjpBTThtsomLKnTV6lc+cVFUA==",
       "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
       "dependencies": {
-        "clsx": "^2.0.0",
-        "eventemitter3": "^4.0.1",
-        "lodash": "^4.17.21",
-        "react-is": "^18.3.1",
-        "react-smooth": "^4.0.4",
-        "recharts-scale": "^0.4.4",
-        "tiny-invariant": "^1.3.1",
-        "victory-vendor": "^36.6.8"
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^11.1.8",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.2.0",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       },
       "peerDependencies": {
-        "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
-    },
-    "node_modules/recharts-scale": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/recharts-scale/-/recharts-scale-0.4.5.tgz",
-      "integrity": "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==",
-      "license": "MIT",
-      "dependencies": {
-        "decimal.js-light": "^2.4.1"
-      }
-    },
-    "node_modules/recharts/node_modules/react-is": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-      "license": "MIT"
     },
     "node_modules/redent": {
       "version": "3.0.0",
@@ -13775,6 +13806,22 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -13870,6 +13917,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.2.0.tgz",
+      "integrity": "sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.12",
@@ -15544,9 +15597,9 @@
       }
     },
     "node_modules/victory-vendor": {
-      "version": "36.9.2",
-      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.9.2.tgz",
-      "integrity": "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==",
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
       "license": "MIT AND ISC",
       "dependencies": {
         "@types/d3-array": "^3.0.3",

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -61,7 +61,7 @@
     "react-dropzone": "^19.1.1",
     "react-markdown": "^10.1.0",
     "react-window": "2.3.0",
-    "recharts": "^2.12.0",
+    "recharts": "^3.10.1",
     "tailwind-merge": "^3.6.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Closes #346.

## The migration

`recharts` 2.15.4 → 3.10.1. Two real API breakages, both caught by `tsc` and nothing else:

- **`FeatureImportanceChart`** — `Bar`'s `onClick` is typed `BarRectangleItem` in v3, not the datum. The entry lives on `.payload`, so read it from there rather than asserting the event object is a `FeatureScore`.
- **`ScatterPlotChart`** — `Scatter`'s `onClick` narrows to `ScatterPointItem`, which has no string index signature. Same fix: hand the caller the payload.

Nothing else in the repo was implicated, matching the failure surface recorded on the issue from Dependabot's #378.

## The tests were blind to all of it

All 7 chart-adjacent suites mocked `recharts` with prop-ignoring passthroughs. Mutation-checked before touching anything: pointing **every** `dataKey` in `ROCCurveChart` at a nonexistent field — a blank chart in production — still passed all 5 of its tests.

They now run the **real library**, with a single stub for `ResponsiveContainer` (`__tests__/utils/sizedRecharts.tsx`) because that is the one thing jsdom genuinely cannot do: it lays out 0×0, so recharts measures zero and renders nothing. Everything else — `Line`, `Bar`, `XAxis`, `ReferenceLine`, the whole `dataKey` → SVG pipeline — is real, so assertions read off actual drawn output: axis ticks for bin/category/feature ordering, path `d` for the curves, line geometry for the reference lines.

**Mutation-checked, all six red where they were green before:** ROC / PR / Histogram / SHAP / Bar / Line `dataKey` breaks. Reverting `FeatureImportanceChart` to its v2 handler shape still fails `tsc` (`TS2345`, `BarRectangleItem` vs `FeatureScore`).

Two carve-outs, both commented in place:
- `BarChart`/`LineChart` keep a `Tooltip` stub — recharts derives the active index from mouse geometry and jsdom reports none, so no real hover opens the tooltip. The stub reproduces v3's contract exactly (clone `content`, inject `active`/`payload`/`label`).
- Those suites' `onClick` tests fire real recharts' `onClick` and assert the adapter is invoked, but not the state's *contents* — same reason.

## Two bugs this surfaced

Neither is caused by the upgrade; the old mocks simply could not see either.

1. **`BarChart` with `orientation="horizontal"` drew nothing.** The branch puts the numeric axis on X and the category axis on Y, which recharts only honours with `layout="vertical"` on the chart itself. Without it every bar has zero extent — the monitor **Distribution** tab rendered an empty plot under a correct "Total 30 / Categories 1" summary.
2. **`explore/[id]` refetched forever.** The `columns` array handed to `InteractiveVisualizationDashboard` was built inline in the JSX, so it was a fresh array every render. It feeds that dashboard's `useAsyncData` dependency list, so the fetch effect re-ran → re-rendered → re-fetched: **>100 requests in 40s**, and the scatter / boxplot / line tabs never left "Loading visualization…". Memoised on `dataset.schema.columns`; identity, not deep equality, is what the hook keys on.

Both mutation-checked — reverting the `layout` prop, and rebuilding the columns array per render, each turn their test red.

## Visual verification

Run against the real stack (Mongo + FastAPI + Next), with a genuine pipeline: 1,000-row CSV uploaded → LightGBM trained → deployed → 30 predictions through the `X-API-Key` production surface.

| Component | Where | Evidence |
|---|---|---|
| `FeatureImportanceChart` | evaluate → Overview | 16 bars, colour-banded legend, feature names on the y-axis |
| `ShapSummaryChart` | evaluate → Overview | bars ordered by descending impact, plain-language summary |
| `ROCCurveChart` | evaluate → Curves | 2 classes, distinct colour + dash, AUC in the legend, diagonal reference line |
| `PRCurveChart` | evaluate → Curves | 2 classes, precision/recall axes |
| `LineChart` | monitor → Timeline | 3 series (latency / errors / requests), spike matches the 30 seeded predictions |
| `BarChart` | monitor → Distribution | bar reaches 30 on the Count axis — **after** the `layout` fix; empty before |
| `HistogramChart` | explore → Visualizations | 50 bins over `age` |
| `ScatterPlotChart` | explore → Visualizations | 1,000 points, `age` × `tenure`, **0 refetches** after the loop fix |

`ConfusionMatrixChart` is pure SVG, not recharts, so it is out of scope here.

## Gates

- `npx jest` — 106 suites, 1,342 passed, 3 skipped
- `tsc --noEmit` clean
- `eslint . --max-warnings 233` — 233 warnings, 0 errors, **no new warnings** (at the ceiling; nothing added)
- `next build` clean

## Known limitations

- **Third-party review:** `codex review --base main` returned no findings. `opencode` (GLM) timed out at 10 minutes on a diff this size and did not produce a review.
- **Monitor Timeline axis label collision.** On `monitor/[id]` → Timeline, the x-axis `label` ("Time") overlaps both the tick row and the legend. Cosmetic, and I could not cheaply attribute it to v3 vs. pre-existing offset tuning, so it is not touched here — filed as a follow-up rather than tuning magic numbers inside this PR.
- **Chart tests now assert on recharts-internal class names** (`.recharts-line-curve`, `.recharts-xAxis-tick-labels`, `.recharts-bar-rectangle`). That is deliberate — it is what makes them sensitive to the library — but it does couple them to recharts' DOM, so a future major will need the same treatment.
