### PR TITLE
fix(frontend): load @tailwindcss/typography so prose content is styled (#398)

### DIFF
--- a/apps/frontend/__tests__/styles/themeTokens.test.ts
+++ b/apps/frontend/__tests__/styles/themeTokens.test.ts
@@ -116,15 +116,20 @@ describe('globals.css compiles to a working theme', () => {
     expect(css).toMatch(rule)
   })
 
-  it('does not load the typography plugin yet', () => {
-    // Inverted on purpose. `prose` is used in OnboardingStep, AIInsightsPanel and
-    // app/onboarding, and @tailwindcss/typography is a devDependency — but v4 only
-    // applies a plugin via @plugin, so those blocks render unstyled. That is a
-    // pre-existing bug held back from this PR deliberately (tracked as #398): enabling it restyles
-    // real content, which is a visual change needing its own sign-off rather than
-    // riding along inside a version migration. This assertion pins the scope, so
-    // turning it on is a deliberate edit here and not an accident.
-    expect(css).not.toMatch(/\.prose\s*[,{]/)
+  it('loads the typography plugin (#398)', () => {
+    // `prose` is used in OnboardingStep, AIInsightsPanel and app/onboarding. v4
+    // only applies a plugin via `@plugin`, so listing @tailwindcss/typography in
+    // package.json left every one of those blocks unstyled. This assertion was
+    // deliberately inverted while #345 pinned its scope; #398 turned the plugin on,
+    // so it now guards the opposite direction — dropping the `@plugin` line breaks
+    // the same content again, silently, exactly as it did before.
+    expect(css).toMatch(/\.prose\s*[,{:]/)
+  })
+
+  it('emits the dark-mode prose-invert variant the app relies on', () => {
+    // AIInsightsPanel uses `dark:prose-invert`; without the plugin's invert
+    // modifier that class is inert and dark-mode prose keeps light-mode colours.
+    expect(css).toMatch(/--tw-prose-invert-body|\.prose-invert/)
   })
 
   it('applies the global border colour that @apply border-border provides', () => {

--- a/apps/frontend/app/globals.css
+++ b/apps/frontend/app/globals.css
@@ -8,6 +8,10 @@
 /* tailwindcss-animate supplies animate-in / fade-in / slide-in-from-* (used ~9x
    each across dialogs, sheets and toasts). v4 loads v3 plugins via @plugin. */
 @plugin "tailwindcss-animate";
+/* `prose` in OnboardingStep, AIInsightsPanel and app/onboarding rendered unstyled
+   until this line existed: v4 activates a plugin only via @plugin, never from
+   package.json alone (#398). Guarded in __tests__/styles/themeTokens.test.ts. */
+@plugin "@tailwindcss/typography";
 
 /* v4 removed `theme.container`; it is a utility now. Mirrors the old config:
    center: true, padding: "2rem", screens: { "2xl": "1400px" }. */


### PR DESCRIPTION
Closes #398.

One line in `app/globals.css`:

```css
@plugin "@tailwindcss/typography";
```

The plugin has been a `devDependency` all along, but Tailwind v4 activates a plugin **only** via `@plugin` — listing it in `package.json` does nothing. So every `prose` block rendered with browser defaults. Pre-existing; it predates the v4 migration and is equally broken on `main`.

## What was actually broken

Measured on `/onboarding` by building with and without the line, then reading computed styles off the rendered page:

| | before | after |
|---|---|---|
| `list-style-type` | **`none`** | `disc` |
| heading `font-weight` | **`400`** | `600` |
| `line-height` | `24px` | `28px` |
| `li` `margin-top` | `0px` | `8px` |

The bullets in "What you'll learn" were invisible and the headings were not bold. Affects `OnboardingStep` (×6), `app/onboarding`, and `AIInsightsPanel`.

## Cost

Built both ways and diffed the emitted CSS:

- **+21,394 bytes raw** (96,213 → 117,607) — matches the ~21KB the issue estimated
- **+2,444 bytes gzipped** (17,487 → 19,931), which is what actually ships

## Test

`__tests__/styles/themeTokens.test.ts` carried an assertion that the plugin was **not** loaded — inverted on purpose by #345 so that enabling it had to be a deliberate edit. Flipped to assert presence, so dropping the `@plugin` line silently breaks the same content again and now fails. Added a second assertion for the `prose-invert` variant. Verified RED before the fix, GREEN after.

## Verification

- ✅ **`/onboarding`, light** — headings bold, bullets visible, spacing correct (before/after screenshots captured against a real backend)
- ⚠️ **`AIInsightsPanel` — not verified.** The panel does not load at all: it renders `Error: Failed to generate AI summary` because `useDatasetChatContext` builds `…/api/v1/api/user_data/{id}/ai-summary` (doubled prefix) against a route that is `/api/v1/user_data/{id}/ai-summary`. Unrelated to this change and pre-existing — filed as **#406** with the full call-site table. That panel is 1 of the 8 `prose` sites; the other 7 are covered by the onboarding check.
- ⚠️ **Dark mode — not verifiable through the UI.** The AC asks for a dark check, but nothing in the app ever adds the `.dark` class: no `ThemeProvider`, no `next-themes`, no `setTheme`. All 27 `dark:` variants, including `AIInsightsPanel`'s `dark:prose-invert`, are currently dead code. Forcing `.dark` by hand shows `prose` blocks without `dark:prose-invert` render dark-on-dark — **but they did before this change too** (measured: `lab(8.1 …)` before vs `rgb(54,65,83)` after, both unreadable on a dark background), so it is not a regression. Filed as **#407**, which also lists the 7 sites needing `dark:prose-invert` whenever dark mode is actually wired. Deliberately not adding those classes here — they cannot be verified today, and the issue scoped this to one line.

## Gates

- `npx jest` — 107 suites, 1,347 passed, 3 skipped
- `tsc --noEmit` clean
- `eslint . --max-warnings 233` — 233 warnings, 0 errors, no new warnings
- `next build` clean

## Follow-ups filed

- **#406** [P1.16] `NEXT_PUBLIC_API_URL` double-prefixing 404s the AI Insights panel and chunked-upload resume
- **#407** [P2.30] dark mode has no activation path — all 27 `dark:` variants are dead code