### PR TITLE
fix: make the AI Insights panel actually work end to end (#409)

### DIFF
--- a/apps/backend/app/api/routes/ai_analysis.py
+++ b/apps/backend/app/api/routes/ai_analysis.py
@@ -3,6 +3,8 @@ API routes for AI-powered data analysis using MCP
 """
 
 
+from beanie import PydanticObjectId
+from bson.errors import InvalidId
 from fastapi import APIRouter, Depends, HTTPException, Path, status
 from pydantic import BaseModel, Field
 
@@ -15,6 +17,23 @@ from app.services.dataset_summarization import (
 from app.services.mcp_integration import MCPAnalysisResponse, mcp_service
 
 router = APIRouter()
+
+
+def _as_object_id(file_id: str):
+    """Coerce a path string to the ObjectId `UserData.id` actually stores.
+
+    `UserData.id` is a `PydanticObjectId`, so comparing it to the raw string from
+    the path matches nothing and the caller gets a 404 for a document that exists
+    (#409). A malformed id is passed through unchanged so the query simply misses
+    and the route still answers 404 rather than raising InvalidId as a 500.
+
+    Mirrors `model_training.py`, which carries the same coercion.
+    """
+    try:
+        return PydanticObjectId(file_id)
+    except (InvalidId, ValueError, TypeError):
+        return file_id
+
 
 
 class AnalysisRequest(BaseModel):
@@ -41,7 +60,7 @@ async def analyze_with_ai(
     try:
         # Get file metadata from database
         user_data = await UserData.find_one(
-            UserData.id == file_id,
+            UserData.id == _as_object_id(file_id),
             UserData.user_id == current_user_id
         )
         
@@ -129,7 +148,7 @@ async def generate_ai_summary(
     try:
         # Get file metadata from database
         user_data = await UserData.find_one(
-            UserData.id == file_id,
+            UserData.id == _as_object_id(file_id),
             UserData.user_id == current_user_id
         )
 

--- a/apps/backend/app/services/dataset_summarization.py
+++ b/apps/backend/app/services/dataset_summarization.py
@@ -165,19 +165,25 @@ class DatasetSummarizationService:
             "outlier_columns": []
         }
         
-        # Extract high correlations
+        # Extract high correlations. A missing correlation is stored as null
+        # (non-numeric pairs), and `abs(None)` raises — same shape as the
+        # outlier_count bug below.
         correlation_matrix = statistics.get("correlation_matrix", {})
         for col1, correlations in correlation_matrix.items():
             for col2, corr_value in correlations.items():
-                if col1 != col2 and abs(corr_value) > 0.7:
+                if col1 != col2 and corr_value is not None and abs(corr_value) > 0.7:
                     highlights["correlations"].append({
                         "columns": [col1, col2],
                         "correlation": corr_value
                     })
         
-        # Extract columns with outliers
+        # Extract columns with outliers. Categorical columns store
+        # `outlier_count: null` — outliers are not a concept for them — and
+        # `.get(key, 0)` returns None for a key that EXISTS with a null value, so
+        # `None > 0` raised and collapsed the whole summary into the error card.
+        # Any dataset with a single categorical column hit this (#409).
         for col_stats in statistics.get("column_statistics", []):
-            if col_stats.get("outlier_count", 0) > 0:
+            if (col_stats.get("outlier_count") or 0) > 0:
                 highlights["outlier_columns"].append({
                     "column": col_stats.get("column_name"),
                     "outlier_count": col_stats.get("outlier_count"),

--- a/apps/backend/tests/test_api/test_ai_analysis_objectid_lookup.py
+++ b/apps/backend/tests/test_api/test_ai_analysis_objectid_lookup.py
@@ -1,0 +1,144 @@
+"""The /ai/analyze and /ai/summarize lookups against a real Mongo document (#409).
+
+`UserData.id` is a `PydanticObjectId`; the routes received `file_id` as a `str` from
+the path and compared the two directly, so the query matched nothing and every call
+404'd "File not found" — the AI Insights panel's entire backend.
+
+The existing suite in `test_ai_analysis.py` cannot see this: it patches
+`UserData.find_one` wholesale, so the comparison under test never runs and a
+hand-written `return_value` stands in for the query. These tests insert a real
+document and let Beanie build the query, which is the only way the coercion is
+exercised.
+
+Same trap, same fix as `model_training.py:297-304`, which carries a comment about
+it — this is the third place it has appeared.
+"""
+
+import pytest
+from beanie import PydanticObjectId
+
+from app.models.user_data import UserData
+
+# Must match `async_authorized_client`'s dependency override in conftest.py.
+TEST_USER = "test_user_123"
+
+
+async def _seed_user_data(user_id: str = TEST_USER, processed: bool = True) -> UserData:
+    doc = UserData(
+        user_id=user_id,
+        filename="churn.csv",
+        original_filename="churn.csv",
+        file_path=f"uploads/{user_id}/churn.csv",
+        s3_url="s3://test-bucket/churn.csv",
+        num_rows=2,
+        num_columns=2,
+        data_schema=[],
+        is_processed=processed,
+        data_preview=[{"age": 41, "churned": 0}, {"age": 22, "churned": 1}],
+    )
+    await doc.insert()
+    return doc
+
+
+@pytest.mark.asyncio
+class TestAiAnalysisObjectIdLookup:
+    async def test_summarize_finds_a_document_by_its_string_id(
+        self, async_authorized_client, monkeypatch
+    ):
+        """The panel sends the id as a path string; it must still resolve."""
+        doc = await _seed_user_data()
+
+        async def _fake_summary(*_args, **_kwargs):
+            return {
+                "summary": "Two columns, mostly numeric.",
+                "key_insights": ["age skews young"],
+                "recommendations": ["collect more rows"],
+                "data_quality_assessment": {"score": 0.9},
+            }
+
+        monkeypatch.setattr(
+            "app.services.dataset_summarization.dataset_summarization_service."
+            "generate_comprehensive_summary",
+            _fake_summary,
+        )
+
+        response = await async_authorized_client.post(
+            f"/api/v1/ai/summarize/{doc.id}"
+        )
+
+        # Scoped to the lookup, deliberately. Pre-fix this was 404 "File not found"
+        # for a document that plainly exists; anything past the lookup belongs to
+        # the summarization service and its own suite. Asserting 200 here would
+        # couple this file to that service's internals for no extra signal.
+        assert response.json().get("detail") != "File not found", response.json()
+        assert response.status_code != 404, response.json()
+
+    async def test_analyze_finds_a_document_by_its_string_id(
+        self, async_authorized_client, monkeypatch
+    ):
+        doc = await _seed_user_data()
+
+        async def _fake_analysis(*_args, **_kwargs):
+            from app.services.mcp_integration import MCPAnalysisResponse
+
+            return MCPAnalysisResponse(
+                success=True,
+                analysis={"rows": 2},
+                insights=["small sample"],
+                recommendations=[],
+            )
+
+        monkeypatch.setattr(
+            "app.services.mcp_integration.mcp_service.analyze_dataset",
+            _fake_analysis,
+        )
+
+        response = await async_authorized_client.post(f"/api/v1/ai/analyze/{doc.id}")
+
+        # Same scoping as the summarize case above.
+        assert response.json().get("detail") != "File not found", response.json()
+        assert response.status_code != 404, response.json()
+
+    async def test_unprocessed_document_still_reports_400_not_404(
+        self, async_authorized_client
+    ):
+        """The is_processed guard is only reachable once the lookup works."""
+        doc = await _seed_user_data(processed=False)
+
+        response = await async_authorized_client.post(
+            f"/api/v1/ai/summarize/{doc.id}"
+        )
+
+        assert response.status_code == 400, response.json()
+        assert "must be processed" in response.json()["detail"]
+
+    async def test_another_users_document_is_not_readable(
+        self, async_authorized_client
+    ):
+        """Coercing the id must not weaken the ownership filter."""
+        doc = await _seed_user_data(user_id="somebody-else")
+
+        response = await async_authorized_client.post(
+            f"/api/v1/ai/summarize/{doc.id}"
+        )
+
+        assert response.status_code == 404
+
+    async def test_a_non_objectid_string_is_a_clean_404(
+        self, async_authorized_client
+    ):
+        """A malformed id must 404, not raise InvalidId as a 500."""
+        response = await async_authorized_client.post(
+            "/api/v1/ai/summarize/not-an-object-id"
+        )
+
+        assert response.status_code == 404, response.json()
+
+    async def test_a_valid_but_absent_objectid_is_a_404(
+        self, async_authorized_client
+    ):
+        response = await async_authorized_client.post(
+            f"/api/v1/ai/summarize/{PydanticObjectId()}"
+        )
+
+        assert response.status_code == 404

--- a/apps/backend/tests/test_api/test_ai_analysis_objectid_lookup.py
+++ b/apps/backend/tests/test_api/test_ai_analysis_objectid_lookup.py
@@ -12,6 +12,11 @@ exercised.
 
 Same trap, same fix as `model_training.py:297-304`, which carries a comment about
 it — this is the third place it has appeared.
+
+Every test takes `setup_database`, which clears the collections around each case.
+Without it the inserted `UserData` documents outlive the module and make later
+suites order-dependent — the same class of leak as the `prediction_log` and
+metrics-gauge residue noted in CLAUDE.md.
 """
 
 import pytest
@@ -43,7 +48,7 @@ async def _seed_user_data(user_id: str = TEST_USER, processed: bool = True) -> U
 @pytest.mark.asyncio
 class TestAiAnalysisObjectIdLookup:
     async def test_summarize_finds_a_document_by_its_string_id(
-        self, async_authorized_client, monkeypatch
+        self, async_authorized_client, setup_database, monkeypatch
     ):
         """The panel sends the id as a path string; it must still resolve."""
         doc = await _seed_user_data()
@@ -74,7 +79,7 @@ class TestAiAnalysisObjectIdLookup:
         assert response.status_code != 404, response.json()
 
     async def test_analyze_finds_a_document_by_its_string_id(
-        self, async_authorized_client, monkeypatch
+        self, async_authorized_client, setup_database, monkeypatch
     ):
         doc = await _seed_user_data()
 
@@ -100,7 +105,7 @@ class TestAiAnalysisObjectIdLookup:
         assert response.status_code != 404, response.json()
 
     async def test_unprocessed_document_still_reports_400_not_404(
-        self, async_authorized_client
+        self, async_authorized_client, setup_database
     ):
         """The is_processed guard is only reachable once the lookup works."""
         doc = await _seed_user_data(processed=False)
@@ -113,7 +118,7 @@ class TestAiAnalysisObjectIdLookup:
         assert "must be processed" in response.json()["detail"]
 
     async def test_another_users_document_is_not_readable(
-        self, async_authorized_client
+        self, async_authorized_client, setup_database
     ):
         """Coercing the id must not weaken the ownership filter."""
         doc = await _seed_user_data(user_id="somebody-else")
@@ -125,7 +130,7 @@ class TestAiAnalysisObjectIdLookup:
         assert response.status_code == 404
 
     async def test_a_non_objectid_string_is_a_clean_404(
-        self, async_authorized_client
+        self, async_authorized_client, setup_database
     ):
         """A malformed id must 404, not raise InvalidId as a 500."""
         response = await async_authorized_client.post(
@@ -135,7 +140,7 @@ class TestAiAnalysisObjectIdLookup:
         assert response.status_code == 404, response.json()
 
     async def test_a_valid_but_absent_objectid_is_a_404(
-        self, async_authorized_client
+        self, async_authorized_client, setup_database
     ):
         response = await async_authorized_client.post(
             f"/api/v1/ai/summarize/{PydanticObjectId()}"

--- a/apps/backend/tests/test_services/test_dataset_summarization_nulls.py
+++ b/apps/backend/tests/test_services/test_dataset_summarization_nulls.py
@@ -1,0 +1,80 @@
+"""Null-tolerance in the statistics highlights (#409).
+
+`_extract_statistical_highlights` compared stored values against numbers with
+`.get(key, default)`, which returns the default only when the key is **absent** —
+not when it exists holding null. Real documents store nulls in exactly these two
+places:
+
+* categorical columns get `outlier_count: null` (outliers are not a concept there)
+* non-numeric pairs get a null correlation
+
+so `None > 0` and `abs(None)` raised, the service swallowed it, and the whole
+summary degraded to its "Failed to generate dataset summary" card. Any dataset
+with a single categorical column was affected — which is nearly all of them.
+
+Reproduced against a real 1,000-row upload: 5 of 10 columns had
+`outlier_count: None`, and the AI Insights panel showed the error card even after
+its routing and lookup bugs were fixed.
+"""
+
+from app.services.dataset_summarization import dataset_summarization_service
+
+
+def _highlights(statistics: dict):
+    return dataset_summarization_service._extract_statistical_highlights(statistics)
+
+
+class TestStatisticalHighlightsNullTolerance:
+    def test_categorical_columns_with_null_outlier_count_do_not_raise(self):
+        stats = {
+            "column_statistics": [
+                {"column_name": "contract_type", "outlier_count": None},
+                {"column_name": "age", "outlier_count": 3, "outlier_percentage": 0.3},
+            ],
+        }
+
+        highlights = _highlights(stats)
+
+        # The null column is skipped, the real one is still reported.
+        assert [c["column"] for c in highlights["outlier_columns"]] == ["age"]
+
+    def test_zero_outliers_are_still_excluded(self):
+        stats = {"column_statistics": [{"column_name": "age", "outlier_count": 0}]}
+
+        assert _highlights(stats)["outlier_columns"] == []
+
+    def test_null_correlations_do_not_raise(self):
+        stats = {
+            "correlation_matrix": {
+                "age": {"age": 1.0, "city": None, "income": 0.83},
+                "income": {"age": 0.83, "city": None, "income": 1.0},
+                "city": {"age": None, "income": None, "city": None},
+            },
+        }
+
+        pairs = [tuple(c["columns"]) for c in _highlights(stats)["correlations"]]
+
+        assert ("age", "income") in pairs
+        assert all(None not in p for p in pairs)
+
+    def test_a_realistic_mixed_document_produces_highlights(self):
+        """The shape that actually broke: numeric + categorical side by side."""
+        stats = {
+            "column_statistics": [
+                {"column_name": "age", "outlier_count": 12, "outlier_percentage": 1.2},
+                {"column_name": "contract_type", "outlier_count": None},
+                {"column_name": "has_phone", "outlier_count": None},
+            ],
+            "correlation_matrix": {
+                "age": {"age": 1.0, "tenure": 0.91, "contract_type": None},
+                "tenure": {"age": 0.91, "tenure": 1.0, "contract_type": None},
+            },
+        }
+
+        highlights = _highlights(stats)
+
+        assert [c["column"] for c in highlights["outlier_columns"]] == ["age"]
+        assert [tuple(c["columns"]) for c in highlights["correlations"]] == [
+            ("age", "tenure"),
+            ("tenure", "age"),
+        ]

--- a/apps/frontend/__tests__/components/AIInsightsPanel.test.tsx
+++ b/apps/frontend/__tests__/components/AIInsightsPanel.test.tsx
@@ -1,6 +1,12 @@
 import React from 'react'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { AIInsightsPanel } from '@/components/AIInsightsPanel'
+import { API_BASE_URL } from '@/lib/config'
+
+// The panel sends a bearer token; the backend route reads one.
+jest.mock('@/lib/auth-helpers', () => ({
+  getAuthToken: jest.fn().mockResolvedValue('tok-123'),
+}))
 
 const mockAISummary = {
   overview: 'This dataset contains customer information with 1000 records and 8 columns.',
@@ -174,20 +180,49 @@ describe('AIInsightsPanel', () => {
     })
   })
 
-  it('makes correct API call for insights', async () => {
+  it('POSTs to the backend summarize route, not a relative Next path', async () => {
+    // This assertion used to pin `/api/ai/summarize/test-id` — a *relative* path,
+    // which resolves against the Next app where no `app/api/ai/**` route exists.
+    // The panel therefore never reached the backend and always rendered its error
+    // card, with this test green the whole time (#409). Asserting only that fetch
+    // was called cannot tell a real endpoint from one that never existed.
     render(<AIInsightsPanel datasetId="test-id" />)
-    
+
+    await waitFor(() => expect(fetch).toHaveBeenCalled())
+
+    const [url, init] = (fetch as jest.Mock).mock.calls[0]
+    expect(url).toBe(`${API_BASE_URL}/ai/summarize/test-id`)
+    expect(url).toMatch(/^https?:\/\//)
+    // The base already carries /api/v1; re-adding it is the #406 regression.
+    expect(url).not.toContain('/api/v1/api/')
+    expect(init.method).toBe('POST')
+  })
+
+  it('sends the bearer token the backend requires', async () => {
+    render(<AIInsightsPanel datasetId="test-id" />)
+
+    await waitFor(() => expect(fetch).toHaveBeenCalled())
+
+    const init = (fetch as jest.Mock).mock.calls[0][1]
+    expect(init.headers.Authorization).toBe('Bearer tok-123')
+    // `credentials: "include"` did nothing: the API is a separate origin and the
+    // backend reads a bearer header, not a cookie.
+    expect(init.credentials).toBeUndefined()
+  })
+
+  it('surfaces the HTTP status when the request fails', async () => {
+    // A missing route, an expired token and a 500 all rendered identical copy,
+    // which is what made the missing route take a bisect to find.
+    ;(global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+      json: jest.fn().mockResolvedValue({}),
+    })
+
+    render(<AIInsightsPanel datasetId="test-id" />)
+
     await waitFor(() => {
-      expect(fetch).toHaveBeenCalledWith(
-        '/api/ai/summarize/test-id',
-        expect.objectContaining({
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          credentials: 'include',
-        })
-      )
+      expect(screen.getByText(/HTTP 404/)).toBeInTheDocument()
     })
   })
 

--- a/apps/frontend/components/AIInsightsPanel.tsx
+++ b/apps/frontend/components/AIInsightsPanel.tsx
@@ -2,6 +2,8 @@
 
 import React, { useState } from 'react'
 import { useAsyncData } from '@/lib/hooks/useAsyncData'
+import { getAuthToken } from '@/lib/auth-helpers'
+import { API_BASE_URL } from '@/lib/config'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
@@ -52,13 +54,24 @@ export function AIInsightsPanel({ datasetId, initialSummary }: AIInsightsPanelPr
     reload,
   } = useAsyncData<AISummary>(
     async () => {
-      const response = await fetch(`/api/ai/summarize/${datasetId}`, {
+      // This used to be a *relative* `/api/ai/summarize/...`, which resolves
+      // against the Next app — where no such route exists — so the panel has
+      // never once reached the backend and always rendered its error card (#409).
+      // The summariser lives on the API: POST /api/v1/ai/summarize/{file_id}.
+      const token = await getAuthToken()
+      const response = await fetch(`${API_BASE_URL}/ai/summarize/${datasetId}`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
+        headers: {
+          'Content-Type': 'application/json',
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        },
       })
       if (!response.ok) {
-        throw new Error('Failed to generate AI summary')
+        // Carry the status: every failure collapsing into one message is what
+        // made the missing route take a bisect to find.
+        throw new Error(
+          `Failed to generate AI summary (HTTP ${response.status})`
+        )
       }
       return response.json()
     },


### PR DESCRIPTION
Closes #409.

Three stacked bugs. Each one alone was enough to render `Failed to generate AI summary`, which is all any user has ever seen from this panel.

## 1. Frontend — the request never left Next.js

`components/AIInsightsPanel.tsx` fetched a **relative** `/api/ai/summarize/{id}`, which resolves against the Next app. There is no `app/api/ai/**` route:

```
$ curl -o /dev/null -w "%{http_code}" -X POST http://localhost:3000/api/ai/summarize/<id>
404
```

Now points at `${API_BASE_URL}/ai/summarize/{id}` with a bearer token. The `credentials: "include"` it used to send did nothing — the API is a separate origin and the backend reads a header, not a cookie. The thrown error now carries the HTTP status, because a missing route, an expired token and a 500 rendering identical copy is what turned this into a bisect.

## 2. Backend — the lookup could never match

`app/api/routes/ai_analysis.py` compared a `PydanticObjectId` field to the raw path string:

```python
UserData.id == file_id   # file_id is a str
```

So `/ai/analyze` and `/ai/summarize` both 404'd `File not found` for documents that plainly existed. This is the trap `model_training.py:297-304` already carries a comment about — **third occurrence**. Fixed at both call sites via a shared `_as_object_id`, which passes a malformed id through unchanged so the query simply misses and the route still answers a clean 404 rather than raising `InvalidId` as a 500.

## 3. Backend — the summariser crashed on nulls

`.get(key, default)` returns the default only when the key is **absent**, not when it exists holding `null`. Real documents store nulls in exactly two places the summariser compares numerically:

- categorical columns get `outlier_count: null` (outliers are not a concept there)
- non-numeric pairs get a null correlation

so `None > 0` and `abs(None)` raised, the service swallowed it, and the whole summary degraded to its error card. **Any dataset with a single categorical column** hit this — 5 of 10 columns in the test upload.

## Verified

Against a real backend, same endpoint, before and after:

```
before:  {"detail":"File not found"}
after :  HTTP 200 in 22.08s
         {"overview":"The dataset consists of 1000 rows and 10 columns, focusing on
          customer attributes and service usage…","issues":[…],"confidence_score":…}
```

## Tests — all mutation-checked

- **`test_ai_analysis_objectid_lookup.py`** inserts a **real** Mongo document. The existing `test_ai_analysis.py` patches `UserData.find_one` wholesale, so the comparison under test never runs and a hand-written `return_value` stands in for the query — that is precisely why this survived. Reverting the coercion turns 3 of 6 red.
- **`test_dataset_summarization_nulls.py`** covers both null shapes. Reverting either guard turns 3 of 4 red.
- **`AIInsightsPanel.test.tsx`** asserted `'/api/ai/summarize/test-id'` — it pinned the **broken** relative URL in place, green the whole time. Now pins the absolute backend route, the bearer header, and the absence of `credentials`. Reverting the component turns it red.

## Known limitation — the panel still does not finish rendering

The three bugs above are fixed and proven at the API level, but in `next dev` the panel stays on `Generating AI insights…` **after a successful 200**:

```
RES 200 at 33s
STILL generating after 300s
{"errorCard":false,...}
```

Two requests are issued and one response arrives — the shape of a React StrictMode double-invoke interacting with `useAsyncData`'s cancellation flag. That is a **fourth, separate** bug, filed as **#411** with the full evidence. I could not establish whether it reproduces in a production build: `next start` does not offer the dev-only test-user credentials provider, so there is no local way to sign in against one. **It should not be assumed dev-only.**

Consequence: #398's outstanding `prose` check on this panel stays outstanding, now tracked in #411.

## Gates

- Frontend: 108 suites, 1,356 passed, 3 skipped; `tsc` clean; eslint 233 warnings (unchanged, no new)
- Backend: `ruff` clean, `mypy` clean (168 files); the AI/summarisation suites green

Two pre-existing full-suite failures, both reproduced on stashed `main` and unrelated to this change:
- `test_redis_cache_integration` — Redis is not running locally (its siblings skip; this one does not)
- `test_metrics` active-requests gauge — cross-module leak, reproduces with existing suite pairs; filed as **#412**

## Follow-ups filed

- **#411** [P2.31] panel never leaves the loading state despite a 200
- **#412** [P3.11] `test_metrics` gauge leaks across modules