### PR TITLE
fix(frontend): delete 13 theme tokens mapped to variables that never existed (#399)

### DIFF
--- a/apps/frontend/__tests__/styles/themeTokens.test.ts
+++ b/apps/frontend/__tests__/styles/themeTokens.test.ts
@@ -190,3 +190,44 @@ describe('ported v3 config survives', () => {
     expect(css).toMatch(/--radix-accordion-content-height/)
   })
 })
+
+describe('@theme inline maps nothing that is undefined (#399)', () => {
+  // Generalises the #345 lesson past the hand-maintained THEME_TOKENS list.
+  // `@theme inline { --color-x: var(--x) }` with `--x` never defined compiles
+  // fine and ships nothing: any utility built on it resolves to an undefined
+  // variable and the browser DROPS the declaration — silently, exactly like the
+  // hsl(oklch(...)) bug. The shadcn scaffold left 13 of these behind (chart-1..5
+  // and the sidebar family), removed in #399.
+  const source = readFileSync(CSS_PATH, 'utf8')
+
+  /** `--color-foo: var(--bar);` pairs inside the @theme inline block. */
+  const mappings = (() => {
+    const block = source.match(/@theme inline\s*\{([\s\S]*?)\n\}/)
+    if (!block) throw new Error('no @theme inline block found in globals.css')
+    return [...block[1].matchAll(/--([\w-]+)\s*:\s*var\(\s*--([\w-]+)\s*\)/g)].map(
+      (m) => ({ alias: m[1], token: m[2] })
+    )
+  })()
+
+  /** Custom properties defined anywhere outside the @theme inline block. */
+  const defined = (() => {
+    const withoutTheme = source.replace(/@theme inline\s*\{[\s\S]*?\n\}/, '')
+    return new Set(
+      [...withoutTheme.matchAll(/^\s*--([\w-]+)\s*:/gm)].map((m) => m[1])
+    )
+  })()
+
+  it('finds mappings to check', () => {
+    expect(mappings.length).toBeGreaterThan(10)
+  })
+
+  it('every mapped token is defined somewhere', () => {
+    // Font tokens come from next/font at runtime, not from a CSS declaration.
+    const runtimeProvided = new Set(['font-geist-sans', 'font-geist-mono'])
+    const dangling = mappings
+      .filter((m) => !defined.has(m.token) && !runtimeProvided.has(m.token))
+      .map((m) => `--${m.alias} -> var(--${m.token})`)
+
+    expect(dangling).toEqual([])
+  })
+})

--- a/apps/frontend/app/globals.css
+++ b/apps/frontend/app/globals.css
@@ -25,23 +25,17 @@
 }
 
 @theme inline {
+  /* The shadcn scaffold's chart-1..5 and sidebar-* aliases used to sit here,
+     mapped to variables that were never defined anywhere (#399). Removed rather
+     than defined: nothing used them, and the chart components carry their own
+     palettes. A mapping without a definition is not harmless — any utility built
+     on it resolves to an undefined variable and the browser drops the
+     declaration silently, which is the #345 failure mode. Guarded by
+     __tests__/styles/themeTokens.test.ts. */
   --color-background: var(--background);
   --color-foreground: var(--foreground);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
-  --color-sidebar-ring: var(--sidebar-ring);
-  --color-sidebar-border: var(--sidebar-border);
-  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
-  --color-sidebar-accent: var(--sidebar-accent);
-  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
-  --color-sidebar-primary: var(--sidebar-primary);
-  --color-sidebar-foreground: var(--sidebar-foreground);
-  --color-sidebar: var(--sidebar);
-  --color-chart-5: var(--chart-5);
-  --color-chart-4: var(--chart-4);
-  --color-chart-3: var(--chart-3);
-  --color-chart-2: var(--chart-2);
-  --color-chart-1: var(--chart-1);
   --color-ring: var(--ring);
   --color-input: var(--input);
   --color-border: var(--border);


### PR DESCRIPTION
Closes #399.

`@theme inline` aliased `chart-1..5` and the whole `sidebar-*` family to custom properties defined **nowhere** — shadcn scaffold leftovers.

Took option 1 from the issue (delete, not define): nothing referenced them, and #346 has since shipped without adopting `chart-*` — the chart components carry their own palettes.

```
$ grep -roE "\b(bg|text|border|fill|stroke|ring|from|to|via)-(chart-[1-5]|sidebar[a-z-]*)\b" app components lib | wc -l
0
```

## Inert today, latent tomorrow

Tailwind v4 only emits utilities that are actually used, so the compiled CSS is **byte-identical** before and after:

```
before: raw=117607  gzip=19931
after : raw=117607  gzip=19931
```

The hazard was the next person: writing `bg-chart-1` would produce `background-color: var(--chart-1)` with the variable undefined, and the browser **drops that declaration silently**. That is the #345 failure mode precisely — and these were sitting directly beside the tokens #345 had just repaired.

## The guard is the actual deliverable

`themeTokens.test.ts` asserted over a hand-maintained `THEME_TOKENS` list, so it could only ever catch tokens someone remembered to add — which is why it never saw these 13.

It now parses **every** `--color-x: var(--y)` out of the `@theme inline` block and fails if `--y` is not defined somewhere in the file. That generalises the #345 lesson past the list, which is the third acceptance criterion on the issue.

Verified RED before the deletion — it named all 13 dangling mappings by hand:

```
+   "--color-sidebar-ring -> var(--sidebar-ring)",
+   "--color-chart-1 -> var(--chart-1)",
    … 11 more
```

Mutation-checked: re-adding a single dangling mapping turns it red again.

Font tokens are exempted with a comment — `next/font` supplies `--font-geist-sans`/`--font-geist-mono` at runtime, not through a CSS declaration, so they are legitimately mapped-without-definition.

## Gates

- `npx jest` — 1,358 passed, 3 skipped (35 in the theme suite, up from 33)
- `tsc --noEmit` clean
- `eslint . --max-warnings 233` — 233 warnings, 0 errors, no new warnings
- `next build` clean, output byte-identical