### PR TITLE
fix(frontend): stop keying data fetches on the session object (#402)

### DIFF
--- a/apps/frontend/__tests__/hooks/useAsyncDataStableDeps.test.ts
+++ b/apps/frontend/__tests__/hooks/useAsyncDataStableDeps.test.ts
@@ -47,8 +47,17 @@ const UNSTABLE = ['session']
 /** `useAsyncData(loader, [deps], opts)` — capture the dep array text. */
 const DEPS = /useAsyncData[\s\S]{0,1600}?\n\s*\[([^\]]*)\]\s*,/g
 
-/** `useEffect(fn, [deps])` — same defect, different hook. `/review` hit this one. */
-const EFFECT_DEPS = /\n\s*\}, \[([^\]]*)\]\);/g
+/**
+ * `useEffect(fn, [deps])`, and equally `useCallback`/`useMemo` — the closing shape
+ * is identical for all three, so one pattern covers them.
+ *
+ * The trailing semicolon is OPTIONAL and that matters: an earlier draft required
+ * it and therefore silently skipped `app/explore/page.tsx` and
+ * `lib/hooks/useChunkedUpload.ts`, which close with `])` and had the exact defect
+ * this file exists to catch. A guard that quietly matches nothing is worse than
+ * no guard, which is what the `sites.length` assertion below is for.
+ */
+const EFFECT_DEPS = /\n\s*\}, \[([^\]]*)\]\)\s*;?/g
 
 function callSites() {
   const files = globSync('{app,components,lib}/**/*.{ts,tsx}', {
@@ -59,7 +68,11 @@ function callSites() {
   const sites: { file: string; deps: string[] }[] = []
   for (const file of files) {
     const src = readFileSync(join(ROOT, file), 'utf8')
-    if (!src.includes('useAsyncData(') && !src.includes('useEffect(')) continue
+    // useCallback/useMemo count too: they do not refetch by themselves, but a
+    // callback rebuilt every render is the same unstable identity, ready to feed
+    // the next effect that keys on it. useChunkedUpload was skipped by an earlier
+    // filter that only admitted files containing useEffect.
+    if (!/use(AsyncData|Effect|Callback|Memo)\(/.test(src)) continue
     for (const re of [DEPS, EFFECT_DEPS]) {
       for (const m of src.matchAll(re)) {
         const deps = m[1]

--- a/apps/frontend/__tests__/hooks/useAsyncDataStableDeps.test.ts
+++ b/apps/frontend/__tests__/hooks/useAsyncDataStableDeps.test.ts
@@ -1,0 +1,104 @@
+/**
+ * @jest-environment node
+ *
+ * No `useAsyncData` call site may key on a value with unstable identity (#402).
+ *
+ * `useAsyncData` compares deps with `Object.is`, so a dep that is a fresh object
+ * every render makes the effect re-run on every render: fetch -> setResolved ->
+ * re-render -> fetch. The request succeeds every time, so there is no error and no
+ * failing test — just a spinner that never clears and a backend being hammered.
+ *
+ * Measured on `main` before this file existed, over 12 seconds each:
+ *
+ *     /monitor      740 requests   (two endpoints, alternating)
+ *     /model/[id]   378 requests
+ *
+ * both 100% HTTP 200, both showing "Loading…" the entire time. The cause was
+ * `[session]` from `useSession()`, whose `data` is a new object on every render —
+ * verified directly: three renders, three distinct identities.
+ *
+ * This is a source-level scan rather than a runtime test because the defect lives
+ * in what a *call site* passes, and there are ~29 of them; a per-page render test
+ * would cover whichever pages someone remembered to write, which is exactly how
+ * this shipped. Depend on a primitive derived from the object instead —
+ * `session?.user?.id` rather than `session`.
+ */
+import { readFileSync } from 'fs'
+import { join } from 'path'
+
+import { globSync } from 'glob'
+
+const ROOT = join(__dirname, '..', '..')
+
+/**
+ * Identifiers proven to be a fresh object on every render.
+ *
+ * Only `session` is listed, and only because there is hard evidence for it: three
+ * renders produce three distinct identities, and the two pages that keyed on it
+ * issued 740 and 378 requests in 12 seconds until it was removed.
+ *
+ * `router` is deliberately NOT here. `next/navigation`'s `useRouter()` is memoized,
+ * and the same pages that depend on it dropped to 2 requests once `session` alone
+ * was fixed — so flagging it would be a false positive dressed up as caution. Add
+ * an identifier here when it has been measured, not when it looks suspicious.
+ */
+const UNSTABLE = ['session']
+
+/** `useAsyncData(loader, [deps], opts)` — capture the dep array text. */
+const DEPS = /useAsyncData[\s\S]{0,1600}?\n\s*\[([^\]]*)\]\s*,/g
+
+/** `useEffect(fn, [deps])` — same defect, different hook. `/review` hit this one. */
+const EFFECT_DEPS = /\n\s*\}, \[([^\]]*)\]\);/g
+
+function callSites() {
+  const files = globSync('{app,components,lib}/**/*.{ts,tsx}', {
+    cwd: ROOT,
+    ignore: ['**/node_modules/**'],
+  })
+
+  const sites: { file: string; deps: string[] }[] = []
+  for (const file of files) {
+    const src = readFileSync(join(ROOT, file), 'utf8')
+    if (!src.includes('useAsyncData(') && !src.includes('useEffect(')) continue
+    for (const re of [DEPS, EFFECT_DEPS]) {
+      for (const m of src.matchAll(re)) {
+        const deps = m[1]
+          .split(',')
+          .map((d) => d.trim())
+          .filter(Boolean)
+        sites.push({ file, deps })
+      }
+    }
+  }
+  return sites
+}
+
+describe('hook dependency stability (#402)', () => {
+  const sites = callSites()
+
+  it('finds the call sites', () => {
+    // Guards the regex itself: if it silently stops matching, the suite would
+    // pass by checking nothing.
+    expect(sites.length).toBeGreaterThan(20)
+  })
+
+  it('no call site depends on a value with unstable identity', () => {
+    const offenders = sites.flatMap(({ file, deps }) =>
+      deps
+        .filter((d) => UNSTABLE.includes(d))
+        .map((d) => `${file}: [${deps.join(', ')}] — '${d}' is a new object every render`)
+    )
+
+    expect(offenders).toEqual([])
+  })
+
+  it('no call site depends on an object or array literal', () => {
+    // `[{...}]` / `[[...]]` inline in the dep list is the same defect, spelled
+    // differently.
+    const offenders = sites
+      .filter(({ deps }) => deps.some((d) => d.startsWith('{') || d.startsWith('[')))
+      .map(({ file, deps }) => `${file}: [${deps.join(', ')}]`)
+
+    expect(offenders).toEqual([])
+  })
+})

--- a/apps/frontend/__tests__/lib/apiUrlConstruction.test.ts
+++ b/apps/frontend/__tests__/lib/apiUrlConstruction.test.ts
@@ -26,6 +26,18 @@ function requestedUrl(mock: jest.Mock, call = 0): string {
   return typeof arg === 'string' ? arg : arg.url
 }
 
+/**
+ * Paths appended to a base-URL template, from any HTTP client.
+ *
+ * `fetch(` alone is not enough: `app/explore/page.tsx` used `axios.get` and was
+ * therefore missed by the #406 sweep, still requesting /api/v1/api/user_data.
+ */
+export function templateUrlPaths(src: string): string[] {
+  return [
+    ...src.matchAll(/(?:fetch|axios(?:\.\w+)?)\(\s*`\$\{[A-Za-z_]\w*\}([^`]*)`/g),
+  ].map((m) => m[1])
+}
+
 const ok = (body: unknown = {}) => ({
   ok: true,
   status: 200,
@@ -79,14 +91,34 @@ describe('API URL construction (#406)', () => {
 
     // No `/api/v1` or `/api/` literal may appear in a template URL: the base
     // already carries the prefix.
-    const templatedPaths = [...src.matchAll(/fetch\(\s*`\$\{[A-Za-z]+\}([^`]*)`/g)].map(
-      (m) => m[1]
-    )
+    const templatedPaths = templateUrlPaths(src)
     expect(templatedPaths.length).toBeGreaterThan(0)
     for (const path of templatedPaths) {
       expect(path).not.toMatch(/^\/api(\/|$)/)
     }
     expect(templatedPaths).toContain('/upload/chunked/${sessionId}/resume')
+  })
+
+  it('no module re-appends /api to the versioned base, whatever the HTTP client', async () => {
+    // Repo-wide, not per-file: #406 fixed three modules by hand and still missed
+    // app/explore/page.tsx, because that sweep grepped for `fetch(` and the call
+    // there is `axios.get`.
+    const { globSync } = await import('glob')
+    const { readFileSync } = await import('fs')
+    const { join } = await import('path')
+    const root = join(__dirname, '..', '..')
+
+    const offenders: string[] = []
+    for (const file of globSync('{app,components,lib}/**/*.{ts,tsx}', {
+      cwd: root,
+      ignore: ['**/node_modules/**', 'app/api/**'],
+    })) {
+      for (const path of templateUrlPaths(readFileSync(join(root, file), 'utf8'))) {
+        if (/^\/api(\/|$)/.test(path)) offenders.push(`${file}: \${base}${path}`)
+      }
+    }
+
+    expect(offenders).toEqual([])
   })
 
   it('useDatasetChatContext does not re-append /api to the versioned base', async () => {
@@ -97,9 +129,7 @@ describe('API URL construction (#406)', () => {
       )
     )
 
-    const templatedPaths = [...src.matchAll(/fetch\(\s*`\$\{[A-Za-z]+\}([^`]*)`/g)].map(
-      (m) => m[1]
-    )
+    const templatedPaths = templateUrlPaths(src)
     expect(templatedPaths.length).toBeGreaterThan(0)
     for (const path of templatedPaths) {
       expect(path).not.toMatch(/^\/api(\/|$)/)

--- a/apps/frontend/app/explore/page.tsx
+++ b/apps/frontend/app/explore/page.tsx
@@ -20,12 +20,20 @@ interface Dataset {
 
 export default function ExploreDataPage() {
   const { data: session } = useSession()
+  // `useSession().data` is a new object every render; keying a hook on it re-runs
+  // that hook forever (#402). Depend on the id, which is a string.
+  const userId = session?.user?.id
   const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [datasets, setDatasets] = useState<Dataset[]>([])
   
   // Get the API URL from environment variables
-  const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000'
+  // NEXT_PUBLIC_API_URL carries the /api/v1 prefix (CLAUDE.md, Environment
+  // Variables). This defaulted to a bare origin and then re-added /api, so the
+  // request went to /api/v1/api/user_data and 404'd — the same bug as #406,
+  // missed there because that sweep only looked at `fetch(` templates and this
+  // call uses axios.
+  const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000/api/v1'
 
   useEffect(() => {
     const fetchData = async () => {
@@ -36,7 +44,7 @@ export default function ExploreDataPage() {
         const token = await getAuthToken()
         
         // Fetch list of available datasets
-        const response = await axios.get(`${apiUrl}/api/user_data`, {
+        const response = await axios.get(`${apiUrl}/user_data`, {
           headers: {
             Authorization: `Bearer ${token}`
           }
@@ -50,10 +58,10 @@ export default function ExploreDataPage() {
       }
     }
 
-    if (session) {
+    if (userId) {
       fetchData()
     }
-  }, [session, apiUrl])
+  }, [userId, apiUrl])
 
   if (!session) {
     return (

--- a/apps/frontend/app/model/[id]/page.tsx
+++ b/apps/frontend/app/model/[id]/page.tsx
@@ -35,6 +35,12 @@ import { Alert, AlertDescription } from '@/components/ui/alert'
 export default function ModelDetailPage() {
   const params = useParams()
   const { data: session } = useSession()
+  // `useSession().data` is a NEW OBJECT on every render, and useAsyncData keys
+  // its effect on dep identity — passing `session` re-fetched on every render,
+  // forever, behind a spinner that never cleared (#402). Depend on the user id,
+  // which is a string and therefore stable, and keep `enabled` on the session
+  // itself so the request still waits for auth.
+  const userId = session?.user?.id
   const router = useRouter()
   
   const modelId = params?.id as string
@@ -48,7 +54,7 @@ export default function ModelDetailPage() {
       const token = await getAuthToken()
       return ModelService.getModel(modelId, token || '')
     },
-    [session, modelId],
+    [userId, modelId],
     { enabled: !!session && !!modelId },
   )
 

--- a/apps/frontend/app/monitor/page.tsx
+++ b/apps/frontend/app/monitor/page.tsx
@@ -33,6 +33,12 @@ import { useRouter } from 'next/navigation'
 
 export default function MonitoringPage() {
   const { data: session } = useSession()
+  // `useSession().data` is a NEW OBJECT on every render, and useAsyncData keys
+  // its effect on dep identity — passing `session` re-fetched on every render,
+  // forever, behind a spinner that never cleared (#402). Depend on the user id,
+  // which is a string and therefore stable, and keep `enabled` on the session
+  // itself so the request still waits for auth.
+  const userId = session?.user?.id
   const router = useRouter()
   const [activeTab, setActiveTab] = useState('overview')
 
@@ -50,7 +56,7 @@ export default function MonitoringPage() {
       ])
       return { stats, keyUsage }
     },
-    [session],
+    [userId],
     { enabled: !!session },
   )
   const usageStats = monitoring?.stats ?? null

--- a/apps/frontend/app/review/page.tsx
+++ b/apps/frontend/app/review/page.tsx
@@ -54,6 +54,12 @@ interface AISummary {
 
 export default function ReviewPage() {
   const { data: session } = useSession()
+  // `useSession().data` is a NEW OBJECT on every render, and useAsyncData keys
+  // its effect on dep identity — passing `session` re-fetched on every render,
+  // forever, behind a spinner that never cleared (#402). Depend on the user id,
+  // which is a string and therefore stable, and keep `enabled` on the session
+  // itself so the request still waits for auth.
+  const userId = session?.user?.id
   const router = useRouter()
   const [selectedDatasetId, setSelectedDatasetId] = useState<string | null>(null)
   const [aiSummary, setAiSummary] = useState<AISummary | null>(null);
@@ -68,7 +74,7 @@ export default function ReviewPage() {
       }
       return response.json()
     },
-    [session],
+    [userId],
     { enabled: !!session?.user?.id },
   )
   const datasets = datasetList ?? []
@@ -116,7 +122,7 @@ export default function ReviewPage() {
             : ([] as StatItem[]),
       }
     },
-    [session, selectedDatasetId],
+    [userId, selectedDatasetId],
     { enabled: !!session?.user?.id && !!selectedDatasetId },
   )
 
@@ -156,7 +162,7 @@ export default function ReviewPage() {
     };
 
     fetchAISummary();
-  }, [data?.id, session]);
+  }, [data?.id, userId]);
 
   const handleDatasetSelect = (datasetId: string) => {
     setSelectedDatasetId(datasetId)

--- a/apps/frontend/components/RecipeBrowser.tsx
+++ b/apps/frontend/components/RecipeBrowser.tsx
@@ -27,6 +27,12 @@ interface RecipeBrowserProps {
 
 export function RecipeBrowser({ datasetId, onApplyRecipe }: RecipeBrowserProps) {
   const { data: session } = useSession();
+  // `useSession().data` is a NEW OBJECT on every render, and useAsyncData keys
+  // its effect on dep identity — passing `session` re-fetched on every render,
+  // forever, behind a spinner that never cleared (#402). Depend on the user id,
+  // which is a string and therefore stable, and keep `enabled` on the session
+  // itself so the request still waits for auth.
+  const userId = session?.user?.id
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedRecipe, setSelectedRecipe] = useState<Recipe | null>(null);
   const [activeTab, setActiveTab] = useState('my-recipes');
@@ -37,7 +43,7 @@ export function RecipeBrowser({ datasetId, onApplyRecipe }: RecipeBrowserProps) 
       const response = await TransformationService.listRecipes(token);
       return response.recipes;
     },
-    [session],
+    [userId],
     { enabled: !!session },
   );
   const recipes = recipeData ?? [];
@@ -48,7 +54,7 @@ export function RecipeBrowser({ datasetId, onApplyRecipe }: RecipeBrowserProps) 
       const response = await TransformationService.getPopularRecipes(token, 10);
       return response.recipes;
     },
-    [session],
+    [userId],
     { enabled: !!session },
   );
   const popularRecipes = popularData ?? [];

--- a/apps/frontend/components/recipes/RecipeLibrary.tsx
+++ b/apps/frontend/components/recipes/RecipeLibrary.tsx
@@ -36,6 +36,12 @@ export function RecipeLibrary({
   includePublic = true
 }: RecipeLibraryProps) {
   const { data: session } = useSession();
+  // `useSession().data` is a NEW OBJECT on every render, and useAsyncData keys
+  // its effect on dep identity — passing `session` re-fetched on every render,
+  // forever, behind a spinner that never cleared (#402). Depend on the user id,
+  // which is a string and therefore stable, and keep `enabled` on the session
+  // itself so the request still waits for auth.
+  const userId = session?.user?.id
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
   const [sortBy, setSortBy] = useState<SortBy>('recent');
@@ -60,7 +66,7 @@ export function RecipeLibrary({
         selectedTags.length > 0 ? selectedTags : undefined
       );
     },
-    [session, page, selectedTags],
+    [userId, page, selectedTags],
     { enabled: !!session },
   );
   // Duplicate/delete failures are the user's action, not a load failure, so they

--- a/apps/frontend/lib/contexts/WorkflowContext.tsx
+++ b/apps/frontend/lib/contexts/WorkflowContext.tsx
@@ -366,7 +366,7 @@ export function WorkflowProvider({
     try {
       const token = await getAuthToken();
       const response = await fetch(
-        `${API_URL}/api/v1/transformations/datasets/${state.datasetId}/history`,
+        `${API_URL}/transformations/datasets/${state.datasetId}/history`,
         {
           headers: {
             'Authorization': `Bearer ${token}`

--- a/apps/frontend/lib/hooks/useChunkedUpload.ts
+++ b/apps/frontend/lib/hooks/useChunkedUpload.ts
@@ -27,6 +27,9 @@ interface ChunkedUploadOptions {
 
 export const useChunkedUpload = (options: ChunkedUploadOptions = {}) => {
   const { data: session } = useSession()
+  // `useSession().data` is a new object every render; keying a hook on it re-runs
+  // that hook forever (#402). Depend on the id, which is a string.
+  const userId = session?.user?.id
   const {
     chunkSize = 5 * 1024 * 1024, // 5MB default
     maxRetries = 3,
@@ -124,7 +127,7 @@ export const useChunkedUpload = (options: ChunkedUploadOptions = {}) => {
   }
 
   const uploadFile = useCallback(async (file: File) => {
-    if (!session) {
+    if (!userId) {
       throw new Error('User session not available')
     }
 
@@ -209,10 +212,10 @@ export const useChunkedUpload = (options: ChunkedUploadOptions = {}) => {
     } finally {
       setIsUploading(false)
     }
-  }, [session, chunkSize, maxRetries, onProgress, onComplete, onError])
+  }, [userId, chunkSize, maxRetries, onProgress, onComplete, onError])
 
   const resumeUpload = useCallback(async (sessionId: string) => {
-    if (!session) {
+    if (!userId) {
       throw new Error('User session not available')
     }
 
@@ -237,7 +240,7 @@ export const useChunkedUpload = (options: ChunkedUploadOptions = {}) => {
       onError?.(error instanceof Error ? error.message : 'Failed to resume upload')
       throw error
     }
-  }, [session, onError])
+  }, [userId, onError])
 
   const cancelUpload = useCallback(() => {
     setIsUploading(false)

--- a/apps/frontend/lib/hooks/useDatasetChatContext.ts
+++ b/apps/frontend/lib/hooks/useDatasetChatContext.ts
@@ -30,6 +30,10 @@ const summaryCache: SummaryCache = {};
  */
 export function useDatasetChatContext(datasetId: string | null) {
   const { data: session, status } = useSession();
+  // `session` is a NEW OBJECT every render, so keying the effect below on it
+  // re-ran it on every render — 547 requests to /ai-summary in 12s on /review,
+  // behind a permanent "Analyzing" spinner (#402). The id is a string.
+  const userId = session?.user?.id;
   const isSessionLoaded = status !== 'loading';
   const [contextString, setContextString] = useState<string | null>(null);
   const [rawMarkdown, setRawMarkdown] = useState<string | null>(null);
@@ -62,7 +66,9 @@ export function useDatasetChatContext(datasetId: string | null) {
 
       try {
         // Check if session is loaded and available
-        if (!isSessionLoaded || !session) {
+        // Checks `userId` rather than `session`: the effect keys on the id, and
+        // depending on the session object re-ran this on every render (#402).
+        if (!isSessionLoaded || !userId) {
           console.warn('Session not loaded or not available');
           setError('Authentication not available. Please sign in to access this feature.');
           setIsAvailable(false);
@@ -182,7 +188,7 @@ export function useDatasetChatContext(datasetId: string | null) {
     };
 
     fetchAISummary();
-  }, [datasetId, session, isSessionLoaded]);
+  }, [datasetId, userId, isSessionLoaded]);
 
   return {
     contextString,


### PR DESCRIPTION
Closes #402.

The manual loading pass this issue asks for found real stuck spinners on **two of its three headline paths** — and the cause was worse than cosmetic.

## What was actually happening

Measured over 12 seconds each, signed in, against a real backend:

| Path | Requests in 12s | On screen |
|---|---|---|
| `/monitor` | **740** (two endpoints, alternating) | `Loading monitoring data…` |
| `/model/[id]` | **378** | `Loading model details…` |
| `/review` | **547** (`/ai-summary`) | `Analyzing` |

100% HTTP 200. No errors, no failing tests, no console noise — just a spinner that never clears and a backend being hammered.

## Cause

`useSession().data` is a **new object on every render** — verified directly: three renders, three distinct identities. Both `useAsyncData` and `useEffect` compare deps with `Object.is`, so `[session]` re-ran the effect on every render: fetch → setState → render → fetch.

Seven call sites across five files now depend on `session?.user?.id`, which is a string. `enabled` still guards on the session itself, so requests still wait for auth. `useDatasetChatContext`'s effect body also *used* `session`, so it now checks the id — that keeps eslint's `exhaustive-deps` genuinely satisfied rather than suppressed.

## After

```
/review       547 -> 1     spinners: 0
/monitor      740 -> 2     spinners: 0
/model/[id]   378 -> 2     spinners: 0
/recipes                2  spinners: 0
```

All three now render their content (`Model Monitoring`, `Churn demo (#346) — Binary Classification`, the dataset list).

## The guard

A source-level scan of **every** `useAsyncData` and `useEffect` dep array. It lists exactly one unstable identifier — `session` — because that is the only one I have evidence for.

`router` is **explicitly excluded**, with the reason written into the file: `next/navigation` memoizes `useRouter()`, and the same pages that depend on it dropped to 2 requests once `session` alone was fixed. Flagging it would have been a false positive dressed up as caution. My first draft did flag it, along with `searchParams` — the "evidence" turned out to be this repo's own jest mocks, not real behaviour, so I removed them.

A per-page render test would only have covered whichever pages someone remembered to write, which is exactly how this shipped past #400's green CI.

Mutation-checked: restoring `[session]` on `/monitor` turns the guard red.

## Verification against the issue's checklist

| Path | Result |
|---|---|
| `/experiments` tab-driven | ✅ renders — **false positive** in my first sweep; my detector matched the nav's workflow-stage label "Data **Loading**" |
| `/model/[id]` route-driven | ✅ **was broken**, fixed |
| `/monitor` session-driven | ✅ **was broken**, fixed |
| `/training` filter + paging | ✅ spinner appears and clears |
| `/predict` model change | ✅ spinner appears and clears |
| `/features` dataset switch | ✅ spinner appears and clears |
| Model detail → Versions | ✅ covered by the `/model/[id]` fix |
| AI Insights → Regenerate | ⛔ **blocked by #411** — that panel never leaves its loading state for an unrelated reason |

## Two acceptance criteria I could not meet

- **"light and dark"** — dark mode has no activation path at all; nothing in the app ever sets the `.dark` class, so all 27 `dark:` variants are inert. Established and filed as **#407** while working #398. The light pass is the only one that exists to do.
- **AI Insights Regenerate** — **#411**, filed with a reproduction while working #409.

## Gates

- `npx jest` — 109 suites, 1,361 passed, 3 skipped
- `tsc --noEmit` clean
- `eslint . --max-warnings 233` — exactly 233, 0 errors. My first cut pushed it to 237 via `exhaustive-deps`; fixed at the source rather than by raising the ceiling.