### PR TITLE
fix(frontend): stop the x-axis title colliding with the legend and tick row (#404)

### DIFF
--- a/apps/frontend/__tests__/components/LineChart.test.tsx
+++ b/apps/frontend/__tests__/components/LineChart.test.tsx
@@ -81,3 +81,72 @@ describe('LineChart', () => {
     expect(screen.getByText('Sales: 150.00')).toBeInTheDocument()
   })
 })
+
+describe('axis title and legend do not collide (#404)', () => {
+  // On /monitor the x-axis title ("Time") was drawn straight through the legend
+  // row and the tick labels — all three landed in the same ~30px band. recharts
+  // defaults the legend to `height: auto` at `bottom: <margin.bottom>`, i.e. right
+  // where the axis title sits. LineChart now reserves an explicit legend band at
+  // `bottom: 0`, which both separates them and makes the extents computable —
+  // with `height: auto` there is nothing to assert against.
+  const multi = {
+    data: [
+      { x: '11:50 PM', latency: 12, requests: 3 },
+      { x: '02:50 AM', latency: 30, requests: 9 },
+    ],
+    lines: [
+      { dataKey: 'latency', label: 'Avg Latency (ms)' },
+      { dataKey: 'requests', label: 'Requests' },
+    ],
+    xLabel: 'Time',
+    yLabel: 'Count / ms',
+  }
+
+  /** Approximate vertical extent of an SVG <text>, from its baseline. */
+  const textBand = (el: Element) => {
+    const y = Number(el.getAttribute('y'))
+    return { top: y - 12, bottom: y + 4 }
+  }
+
+  it('the legend sits below the axis title, which sits below the ticks', () => {
+    const { container } = render(<LineChart data={multi} />)
+
+    const title = Array.from(container.querySelectorAll('text')).find(
+      (t) => t.textContent === 'Time'
+    )
+    const tick = container.querySelector(
+      '.recharts-xAxis-tick-labels .recharts-cartesian-axis-tick-value'
+    )
+    const legend = container.querySelector(
+      '.recharts-legend-wrapper'
+    ) as HTMLElement | null
+
+    expect(title).toBeDefined()
+    expect(tick).not.toBeNull()
+    expect(legend).not.toBeNull()
+
+    const chartHeight = 400 // the height sizedRecharts gives ResponsiveContainer
+    const style = legend!.getAttribute('style') ?? ''
+    const legendHeight = Number(/height:\s*(\d+)px/.exec(style)?.[1])
+    const legendBottomOffset = Number(/bottom:\s*(\d+)px/.exec(style)?.[1])
+
+    // `height: auto` would make this NaN — which is the state that made the
+    // collision unassertable in the first place.
+    expect(Number.isFinite(legendHeight)).toBe(true)
+    expect(Number.isFinite(legendBottomOffset)).toBe(true)
+
+    const legendTop = chartHeight - legendBottomOffset - legendHeight
+    const titleBand = textBand(title!)
+    const tickBand = textBand(tick!)
+
+    expect(tickBand.bottom).toBeLessThan(titleBand.top)
+    expect(titleBand.bottom).toBeLessThan(legendTop)
+  })
+
+  it('a single-series chart renders no legend to collide with', () => {
+    const { container } = render(
+      <LineChart data={{ ...multi, lines: [multi.lines[0]] }} />
+    )
+    expect(container.querySelector('.recharts-legend-wrapper')).toBeNull()
+  })
+})

--- a/apps/frontend/components/LineChart.tsx
+++ b/apps/frontend/components/LineChart.tsx
@@ -31,6 +31,11 @@ interface LineChartProps {
 // (react-hooks/static-components). recharts clones the `content` element and
 // injects active/payload/label, so `xLabel` is passed in explicitly instead of
 // being closed over.
+/** Reserved for the legend row, so the x-axis title can sit clear above it (#404). */
+const LEGEND_HEIGHT = 32
+/** Drops the x-axis title below the tick row but above the reserved legend band. */
+const X_LABEL_OFFSET = -10
+
 function CustomTooltip({
   active,
   payload,
@@ -87,13 +92,21 @@ export function LineChart({
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis 
             dataKey="x"
-            label={{ value: data.xLabel, position: 'insideBottom', offset: -10 }}
+            label={{ value: data.xLabel, position: 'insideBottom', offset: X_LABEL_OFFSET }}
           />
           <YAxis 
             label={{ value: data.yLabel, angle: -90, position: 'insideLeft' }}
           />
           <Tooltip content={<CustomTooltip xLabel={data.xLabel} />} />
-          {data.lines.length > 1 && <Legend />}
+          {/* Explicit height and bottom:0 pin the legend to the very bottom of the
+              margin. With recharts' defaults it rendered at `bottom: 60px` — inside
+              the band the x-axis title occupies — so "Time" was drawn straight
+              through the legend row on /monitor (#404). `height: auto` also made the
+              collision impossible to assert, since nothing could compute the
+              legend's extent; fixing the height is what lets the test below check it. */}
+          {data.lines.length > 1 && (
+            <Legend verticalAlign="bottom" height={LEGEND_HEIGHT} wrapperStyle={{ bottom: 0 }} />
+          )}
           
           {data.lines.map((line, index) => (
             <Line


### PR DESCRIPTION
Closes #404.

On `/monitor` → **Timeline** the axis title ("Time"), the tick labels and the legend all landed in the same ~30px band, so "Time" was drawn straight through "Errors".

## Cause

recharts defaults `<Legend />` to `height: auto` positioned at `bottom: <margin.bottom>` — which is exactly where an `insideBottom` axis title sits. `LineChart` now reserves an explicit 32px legend band pinned to `bottom: 0`.

## Why this had no test before

The `height: auto` default is not just the cause, it is why the collision was **unassertable**: nothing could compute the legend's extent, so there was nothing to compare the title against. Fixing the height is what makes a guard possible at all.

The guard asserts the **ordering** — ticks above title, title above legend — rather than pinning magic pixel values, so it survives font and spacing changes but still fails on a real collision. It also asserts the legend's height parses as a number, since `auto` (i.e. `NaN`) is precisely the state that made this invisible.

## Verified in a real browser

`getBoundingClientRect` on the live page, where layout is real rather than jsdom's zeros:

```
ticks    905 - 922
title    926 - 943
legend   990 - 1022
```

Three disjoint bands; all three pairwise overlap checks `false`. Before the fix they intersected — the earlier screenshot on #346 shows "Time" struck through the legend row.

Mutation-checked: restoring the bare `<Legend />` turns the guard red.

## One question from the issue I could not settle

> Determine whether the collision predates recharts 3

**Undetermined.** The legend default that causes it is not v3-specific, so it very likely predates the migration — but I could not cheaply bisect against v2 to say so with confidence, and the fix is identical either way. Flagging rather than asserting.

## Scope note

The fix is in the shared `components/LineChart`, so it covers `components/quality/QualityDashboard.tsx` too — the other consumer the issue asked to check. The collision only ever appeared with **more than one** line, since that is the condition that renders a `Legend` at all; a single-series chart has no legend to collide with, which the second test pins.

## Gates

- `npx jest` — 1,364 passed, 3 skipped
- `tsc --noEmit` clean
- `eslint . --max-warnings 233` — 233, 0 errors, no new warnings