### PR TITLE
fix(frontend): stop useAsyncData throwing away a result its own cleanup cancelled (#411)

### DIFF
--- a/apps/frontend/__tests__/hooks/useAsyncData.test.tsx
+++ b/apps/frontend/__tests__/hooks/useAsyncData.test.tsx
@@ -267,3 +267,81 @@ describe('useAsyncData keepPreviousData', () => {
     expect(result.current.data).toBe('b-data')
   })
 })
+
+describe('a result that lands after an effect cleanup (#411)', () => {
+  // React StrictMode double-invokes effects in dev: mount -> effect A -> cleanup A
+  // -> effect B. The old code used a closure `cancelled` flag, so A's result was
+  // thrown away even though its deps were still current. When the request is slow
+  // enough that only one of the two ever comes back, `loading` stays true forever.
+  //
+  // Observed on the AI Insights panel against a real backend: two requests, one
+  // HTTP 200 at 35s, and "Generating AI insights…" still on screen at 240s.
+  //
+  // Discarding by closure flag is also redundant — `settled` already ignores any
+  // result whose deps or reload token no longer match. What it cannot do is
+  // recover a result the effect threw away.
+
+  it('accepts an in-flight result whose deps are current again', async () => {
+    // Same shape as the StrictMode double-invoke, reachable without it: the effect
+    // for 'a' is cleaned up when deps move to 'b', then deps come back to 'a' (tab
+    // away and back) while that first request is still in flight. Its result is
+    // valid for the current deps, but the closure flag threw it away — so nothing
+    // ever settled and the spinner stayed up.
+    const releases: ((v: string) => void)[] = []
+    const loader = jest.fn(
+      () => new Promise<string>((res) => { releases.push(res) })
+    )
+
+    const { result, rerender } = renderHook(
+      ({ id }) => useAsyncData(loader, [id]),
+      { initialProps: { id: 'a' } }
+    )
+
+    rerender({ id: 'b' })
+    rerender({ id: 'a' })
+
+    expect(result.current.loading).toBe(true)
+
+    await act(async () => {
+      releases[0]('answer for a')   // the request the cleanup discarded
+      await Promise.resolve()
+    })
+
+    expect(result.current.data).toBe('answer for a')
+    expect(result.current.loading).toBe(false)
+  })
+
+  it('still ignores a result whose deps have moved on', async () => {
+    // The protection the closure flag was there for must survive: a slow request
+    // for 'a' must not populate the hook after the caller has switched to 'b'.
+    const pending: Record<string, (v: string) => void> = {}
+    const loader = jest.fn(function (this: void) {
+      return new Promise<string>((res) => {
+        pending[Object.keys(pending).length === 0 ? 'first' : 'second'] = res
+      })
+    })
+
+    const { result, rerender } = renderHook(
+      ({ id }) => useAsyncData(loader, [id]),
+      { initialProps: { id: 'a' } }
+    )
+
+    rerender({ id: 'b' })
+
+    await act(async () => {
+      pending.first('stale answer for a')
+      await Promise.resolve()
+    })
+
+    expect(result.current.data).toBeUndefined()
+    expect(result.current.loading).toBe(true)
+
+    await act(async () => {
+      pending.second('fresh answer for b')
+      await Promise.resolve()
+    })
+
+    expect(result.current.data).toBe('fresh answer for b')
+    expect(result.current.loading).toBe(false)
+  })
+})

--- a/apps/frontend/lib/hooks/useAsyncData.ts
+++ b/apps/frontend/lib/hooks/useAsyncData.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState, type DependencyList } from 'react'
+import { useCallback, useEffect, useRef, useState, type DependencyList } from 'react'
 
 /**
  * Keyed async loading with a derived `loading` flag (#393).
@@ -89,6 +89,41 @@ export function useAsyncData<T>(
   const [reloadToken, setReloadToken] = useState(0)
   const [resolved, setResolved] = useState<Resolved<T> | null>(null)
 
+  // Only an UNMOUNT stops a result being recorded — not an effect cleanup.
+  //
+  // The effect cleanup used to set a closure `cancelled` flag, which threw away a
+  // result even when its deps were still current. That is what React StrictMode's
+  // mount -> cleanup -> mount does on every dev mount, and what a dep round-trip
+  // (a -> b -> a, e.g. tab away and back) does in production. If the surviving
+  // request was slow, NOTHING ever settled: measured at 240s+ of "Generating AI
+  // insights…" against a real backend that had already answered (#411).
+  //
+  // Discarding was never needed for correctness. Staleness is handled at read
+  // time: `settled` below ignores any result whose deps or reload token no longer
+  // match, so a late answer for the wrong key cannot surface. Recording it is
+  // harmless; throwing it away is not recoverable.
+  const mounted = useRef(true)
+  useEffect(() => {
+    mounted.current = true
+    return () => {
+      mounted.current = false
+    }
+  }, [])
+
+  // What the caller is asking for RIGHT NOW, readable from inside a promise
+  // continuation. A result is recorded only if it still answers that question —
+  // which keeps a slow response for 'a' from overwriting a fresh one for 'b',
+  // the protection the closure flag did provide, while no longer throwing away a
+  // result whose key is still current.
+  // Synced in an effect, not during render: `react-hooks/refs` (enforced as an
+  // error here) forbids touching a ref while rendering. An effect with no dep
+  // array runs after every render, which is early enough — promise continuations
+  // are always later still.
+  const current = useRef({ deps, reloadToken })
+  useEffect(() => {
+    current.current = { deps, reloadToken }
+  })
+
   // `loader` is deliberately NOT a dependency. Call sites pass an inline arrow, so
   // it has a new identity every render and keying on it would refetch forever.
   // Omitting it is safe rather than stale: the effect is recreated whenever
@@ -98,24 +133,23 @@ export function useAsyncData<T>(
   useEffect(() => {
     if (!enabled) return
 
-    let cancelled = false
+    const stillWanted = () =>
+      mounted.current &&
+      current.current.reloadToken === reloadToken &&
+      sameDeps(current.current.deps, deps)
+
     loader()
       .then((data) => {
-        if (!cancelled) setResolved({ deps, token: reloadToken, data })
+        if (stillWanted()) setResolved({ deps, token: reloadToken, data })
       })
       .catch((err: unknown) => {
-        if (cancelled) return
+        if (!stillWanted()) return
         setResolved({
           deps,
           token: reloadToken,
           error: errorMessage ?? (err instanceof Error ? err.message : String(err)),
         })
       })
-
-    // Guards against a superseded request landing after a newer one.
-    return () => {
-      cancelled = true
-    }
   // eslint-disable-next-line react-hooks/exhaustive-deps -- caller's deps, spread by contract; loader intentionally excluded
   }, [...deps, reloadToken, enabled, errorMessage])
 


### PR DESCRIPTION
Closes #411. Also closes the last open box on #398.

`useAsyncData`'s effect used a closure `cancelled` flag set by its cleanup, so a result was discarded **even when its deps were still current**.

React StrictMode performs exactly that sequence on every dev mount (mount → cleanup → mount), and a dep round-trip — `a → b → a`, i.e. tab away and back — does it in production. When the surviving request was slow, nothing ever settled:

```
RES 200 at 33s          ← the answer arrived, and was thrown away
STILL generating after 240s
```

against a backend that answers the same call in 24s by `curl`.

## Why the flag was wrong, not just unlucky

Discarding was never needed for correctness. Staleness is already handled at **read** time — `settled` ignores any result whose deps or reload token no longer match. What read-time filtering *cannot* do is recover a result the effect already threw away.

So the effect now records a result if it still answers the **current** question: mounted, same reload token, same deps — read through a ref rather than a stale closure.

That preserves the one thing the flag genuinely provided: a slow response for `a` must not overwrite a fresh one for `b`. The pre-existing test `ignores a stale response that resolves after a newer request` pins that, and it **broke immediately** when I first tried simply deleting the flag — which is what sent me to the current-deps comparison rather than a request-sequence counter (my second attempt, which still discarded the round-trip case).

The ref is synced in an effect rather than during render: `react-hooks/refs` is enforced as an **error** in this repo, and an effect with no dep array runs long before any promise continuation.

## Mutation-checked in both directions

```
restore the closure discard        -> the new test goes red
drop the staleness check entirely  -> the pre-existing stale-response test goes red
```

Both matter: the first proves the fix does something, the second proves it did not trade one bug for another.

## Verified end to end

AI Insights panel, real backend, real OpenAI call:

```
SETTLED at 31s
"The dataset contains 1,000 rows and 10 columns, representing customer data…"
Confidence: 100%   gpt-4-turbo
```

## This also closes #398's last box

#398 could not visually confirm the `prose` styling on `AIInsightsPanel`, because the panel never rendered. It does now:

```
prose: { found: true, headingWeight: "800", listStyle: "decimal" }
```

so `@tailwindcss/typography` is confirmed live on that surface too.

## Scope note

This is a shared hook with ~29 call sites, so the change is deliberately conservative — same public contract, same `settled` semantics, one fewer way to lose a result. The existing 11 contract tests in `useAsyncData.test.tsx` all still pass unchanged.

## Gates

- `npx jest` — 1,366 passed, 3 skipped
- `tsc --noEmit` clean
- `eslint . --max-warnings 233` — 233, 0 errors. My first cut introduced a **`react-hooks/refs` error** (ref written during render); fixed at the source rather than suppressed.