### PR TITLE
fix(frontend): re-guard useAsyncData on `enabled` when a result lands (#411 review)

### DIFF
--- a/apps/frontend/__tests__/hooks/useAsyncData.test.tsx
+++ b/apps/frontend/__tests__/hooks/useAsyncData.test.tsx
@@ -345,3 +345,47 @@ describe('a result that lands after an effect cleanup (#411)', () => {
     expect(result.current.loading).toBe(false)
   })
 })
+
+describe('disabling mid-flight (#417 review)', () => {
+  // Before #411 this was covered by accident: `enabled` was in the fetch effect's
+  // dependency array, so flipping it re-ran the effect and the OLD instance's
+  // cleanup set `cancelled = true`. Removing that cleanup removed the protection
+  // with it — `stillWanted()` checked mounted/token/deps but not `enabled`, and
+  // `settled` does not check it either, so a request begun while enabled would
+  // still populate `data` after the caller had gated the fetch off.
+  it('does not record a result that resolves after enabled goes false', async () => {
+    let release: (v: string) => void = () => {}
+    const loader = jest.fn(() => new Promise<string>((res) => { release = res }))
+
+    const { result, rerender } = renderHook(
+      ({ enabled }) => useAsyncData(loader, ['a'], { enabled }),
+      { initialProps: { enabled: true } }
+    )
+
+    expect(loader).toHaveBeenCalledTimes(1)
+
+    rerender({ enabled: false })
+
+    await act(async () => {
+      release('answer nobody asked for any more')
+      await Promise.resolve()
+    })
+
+    expect(result.current.data).toBeUndefined()
+    expect(result.current.loading).toBe(false)
+  })
+
+  it('still resolves normally when enabled stays true', async () => {
+    let release: (v: string) => void = () => {}
+    const loader = jest.fn(() => new Promise<string>((res) => { release = res }))
+
+    const { result } = renderHook(() => useAsyncData(loader, ['a'], { enabled: true }))
+
+    await act(async () => {
+      release('wanted')
+      await Promise.resolve()
+    })
+
+    expect(result.current.data).toBe('wanted')
+  })
+})

--- a/apps/frontend/__tests__/hooks/useAsyncData.test.tsx
+++ b/apps/frontend/__tests__/hooks/useAsyncData.test.tsx
@@ -491,3 +491,38 @@ describe('ordering must be per-key, not global (#418 review round 2)', () => {
     expect(result.current.loading).toBe(false)
   })
 })
+
+describe('an older answer shown while a newer one is still pending (#418 review round 3)', () => {
+  // This is INTENDED, not a leak, and it is the whole point of #411: given a valid
+  // answer for the key the caller is currently asking about, show it rather than
+  // spin. The newer answer replaces it when it arrives. Asserted here so the
+  // behaviour is a decision on the record rather than a side effect of the
+  // ordering rule — the reviewer on #418 rightly noted nothing pinned it.
+  it('renders the older result, then replaces it when the newer one lands', async () => {
+    const releases: ((v: string) => void)[] = []
+    const loader = jest.fn(() => new Promise<string>((res) => { releases.push(res) }))
+
+    const { result, rerender } = renderHook(
+      ({ enabled }) => useAsyncData(loader, ['a'], { enabled }),
+      { initialProps: { enabled: true } }
+    )
+    rerender({ enabled: false })
+    rerender({ enabled: true })
+    expect(loader).toHaveBeenCalledTimes(2)
+
+    // Older answers first, while the newer is still in flight.
+    await act(async () => {
+      releases[0]('older but valid')
+      await Promise.resolve()
+    })
+    expect(result.current.data).toBe('older but valid')
+    expect(result.current.loading).toBe(false)
+
+    // Newer lands and supersedes it.
+    await act(async () => {
+      releases[1]('newer')
+      await Promise.resolve()
+    })
+    expect(result.current.data).toBe('newer')
+  })
+})

--- a/apps/frontend/__tests__/hooks/useAsyncData.test.tsx
+++ b/apps/frontend/__tests__/hooks/useAsyncData.test.tsx
@@ -389,3 +389,61 @@ describe('disabling mid-flight (#417 review)', () => {
     expect(result.current.data).toBe('wanted')
   })
 })
+
+describe('two in-flight requests for the same key (#418 review)', () => {
+  // Toggling `enabled` off and on with unchanged deps starts a SECOND request
+  // without invalidating the first: the effect re-runs (enabled is in its dep
+  // array) but there is no cleanup, so both are live. Both satisfy
+  // mounted/enabled/token/deps at resolution, so whichever lands LAST wins — and
+  // if that is the older request, it overwrites fresher data with staler data.
+  it('an older in-flight result does not overwrite a newer one that already landed', async () => {
+    const releases: ((v: string) => void)[] = []
+    const loader = jest.fn(() => new Promise<string>((res) => { releases.push(res) }))
+
+    const { result, rerender } = renderHook(
+      ({ enabled }) => useAsyncData(loader, ['a'], { enabled }),
+      { initialProps: { enabled: true } }
+    )
+
+    rerender({ enabled: false })
+    rerender({ enabled: true })
+
+    expect(loader).toHaveBeenCalledTimes(2)
+
+    // The newer request answers first…
+    await act(async () => {
+      releases[1]('fresh')
+      await Promise.resolve()
+    })
+    expect(result.current.data).toBe('fresh')
+
+    // …and the older one, landing later, must not clobber it.
+    await act(async () => {
+      releases[0]('stale')
+      await Promise.resolve()
+    })
+    expect(result.current.data).toBe('fresh')
+  })
+
+  it('an older result still settles when nothing newer has landed', async () => {
+    // The #411 guarantee must survive: if the newest request never comes back,
+    // an older one whose key is still current is better than spinning forever.
+    const releases: ((v: string) => void)[] = []
+    const loader = jest.fn(() => new Promise<string>((res) => { releases.push(res) }))
+
+    const { result, rerender } = renderHook(
+      ({ enabled }) => useAsyncData(loader, ['a'], { enabled }),
+      { initialProps: { enabled: true } }
+    )
+    rerender({ enabled: false })
+    rerender({ enabled: true })
+
+    await act(async () => {
+      releases[0]('the only answer that came back')
+      await Promise.resolve()
+    })
+
+    expect(result.current.data).toBe('the only answer that came back')
+    expect(result.current.loading).toBe(false)
+  })
+})

--- a/apps/frontend/__tests__/hooks/useAsyncData.test.tsx
+++ b/apps/frontend/__tests__/hooks/useAsyncData.test.tsx
@@ -447,3 +447,47 @@ describe('two in-flight requests for the same key (#418 review)', () => {
     expect(result.current.loading).toBe(false)
   })
 })
+
+describe('ordering must be per-key, not global (#418 review round 2)', () => {
+  // A single global counter reintroduces #411 via an unrelated key: a fast request
+  // for B bumps the counter past a slow, still-valid request for A, so when A
+  // finally answers it is discarded even though nothing newer FOR A has landed.
+  it('a slow result is still accepted after a different key resolved ahead of it', async () => {
+    const byKey: Record<string, ((v: string) => void)[]> = { A: [], B: [] }
+    const loader = jest.fn(function (this: void) {
+      return new Promise<string>((res) => {
+        // Route by whichever key the current render asked for.
+        byKey[currentKey].push(res)
+      })
+    })
+    let currentKey: 'A' | 'B' = 'A'
+
+    const { result, rerender } = renderHook(({ k }) => useAsyncData(loader, [k]), {
+      initialProps: { k: 'A' as 'A' | 'B' },
+    })
+
+    currentKey = 'B'
+    rerender({ k: 'B' })
+
+    // B answers quickly and records.
+    await act(async () => {
+      byKey.B[0]('B answer')
+      await Promise.resolve()
+    })
+    expect(result.current.data).toBe('B answer')
+
+    // Back to A ("tab away and back"). A third request starts and never answers.
+    currentKey = 'A'
+    rerender({ k: 'A' })
+
+    // The ORIGINAL slow A request finally lands. Nothing newer for A has landed,
+    // so it must settle rather than leave the panel spinning.
+    await act(async () => {
+      byKey.A[0]('A answer, late but still correct')
+      await Promise.resolve()
+    })
+
+    expect(result.current.data).toBe('A answer, late but still correct')
+    expect(result.current.loading).toBe(false)
+  })
+})

--- a/apps/frontend/lib/hooks/useAsyncData.ts
+++ b/apps/frontend/lib/hooks/useAsyncData.ts
@@ -119,9 +119,9 @@ export function useAsyncData<T>(
   // error here) forbids touching a ref while rendering. An effect with no dep
   // array runs after every render, which is early enough — promise continuations
   // are always later still.
-  const current = useRef({ deps, reloadToken })
+  const current = useRef({ deps, reloadToken, enabled })
   useEffect(() => {
-    current.current = { deps, reloadToken }
+    current.current = { deps, reloadToken, enabled }
   })
 
   // `loader` is deliberately NOT a dependency. Call sites pass an inline arrow, so
@@ -133,8 +133,15 @@ export function useAsyncData<T>(
   useEffect(() => {
     if (!enabled) return
 
+    // `enabled` belongs here too. It used to be covered by accident: it was in the
+    // effect's dependency array, so flipping it re-ran the effect and the old
+    // instance's cleanup discarded the in-flight request. Removing that cleanup
+    // (#411) removed the protection with it, and `settled` does not check
+    // `enabled` either — so a request begun while enabled would still populate
+    // `data` after the caller had gated the fetch off.
     const stillWanted = () =>
       mounted.current &&
+      current.current.enabled &&
       current.current.reloadToken === reloadToken &&
       sameDeps(current.current.deps, deps)
 

--- a/apps/frontend/lib/hooks/useAsyncData.ts
+++ b/apps/frontend/lib/hooks/useAsyncData.ts
@@ -119,19 +119,28 @@ export function useAsyncData<T>(
   // error here) forbids touching a ref while rendering. An effect with no dep
   // array runs after every render, which is early enough — promise continuations
   // are always later still.
-  // Monotonic id per issued request, plus the id of the newest one that has
-  // already been recorded. Toggling `enabled` off and on with unchanged deps
-  // starts a SECOND request without invalidating the first — the effect re-runs
-  // but has no cleanup — so both are live and both satisfy every other condition.
-  // Without this, whichever landed last won, and if that was the older request it
-  // overwrote fresh data with stale.
+  // Monotonic id per issued request, plus the newest result already recorded AND
+  // the key it was for.
+  //
+  // Why any ordering at all: toggling `enabled` off and on with unchanged deps
+  // starts a SECOND request without invalidating the first — the effect re-runs but
+  // has no cleanup — so both are live and both satisfy every other condition.
+  // Whichever landed last won, and when that was the older request it overwrote
+  // fresh data with stale.
+  //
+  // Why the key is part of it: a global counter is wrong. A fast request for B
+  // would bump the counter past a slow, still-valid request for A, so A's answer is
+  // discarded when it finally arrives even though nothing newer FOR A has landed —
+  // reintroducing #411 through an unrelated key, in exactly the tab-away-and-back
+  // case this hook's history is about. Ordering therefore constrains a request only
+  // against others for the SAME key.
   //
   // Deliberately NOT "only the newest request may record": that is the rule that
-  // reintroduces #411, where the newest request is the one that never comes back
-  // and an older, still-valid answer is thrown away. An older result is welcome
-  // while nothing newer has landed; it is only barred from overwriting.
+  // reintroduces #411 head-on, since the newest request is the one that never comes
+  // back. An older result is welcome while nothing newer for its key has landed; it
+  // is only barred from overwriting.
   const requestSeq = useRef(0)
-  const lastRecorded = useRef(0)
+  const lastRecorded = useRef<{ id: number; deps: DependencyList } | null>(null)
 
   const current = useRef({ deps, reloadToken, enabled })
   useEffect(() => {
@@ -155,6 +164,12 @@ export function useAsyncData<T>(
     // `data` after the caller had gated the fetch off.
     const requestId = ++requestSeq.current
 
+    /** Newest already-recorded id for this key; 0 when the last one was another key. */
+    const recordedIdForThisKey = () => {
+      const last = lastRecorded.current
+      return last && sameDeps(last.deps, deps) ? last.id : 0
+    }
+
     // Note on coverage: `mounted`, `enabled` and the ordering guard each have a
     // test that fails when removed. The `sameDeps` check does NOT — the ordering
     // guard subsumes it in every case reachable today, and `settled` filters by
@@ -166,11 +181,11 @@ export function useAsyncData<T>(
       current.current.enabled &&
       current.current.reloadToken === reloadToken &&
       sameDeps(current.current.deps, deps) &&
-      requestId >= lastRecorded.current
+      requestId >= recordedIdForThisKey()
 
     const record = (next: Resolved<T>) => {
       if (!stillWanted()) return
-      lastRecorded.current = requestId
+      lastRecorded.current = { id: requestId, deps }
       setResolved(next)
     }
 

--- a/apps/frontend/lib/hooks/useAsyncData.ts
+++ b/apps/frontend/lib/hooks/useAsyncData.ts
@@ -119,6 +119,20 @@ export function useAsyncData<T>(
   // error here) forbids touching a ref while rendering. An effect with no dep
   // array runs after every render, which is early enough — promise continuations
   // are always later still.
+  // Monotonic id per issued request, plus the id of the newest one that has
+  // already been recorded. Toggling `enabled` off and on with unchanged deps
+  // starts a SECOND request without invalidating the first — the effect re-runs
+  // but has no cleanup — so both are live and both satisfy every other condition.
+  // Without this, whichever landed last won, and if that was the older request it
+  // overwrote fresh data with stale.
+  //
+  // Deliberately NOT "only the newest request may record": that is the rule that
+  // reintroduces #411, where the newest request is the one that never comes back
+  // and an older, still-valid answer is thrown away. An older result is welcome
+  // while nothing newer has landed; it is only barred from overwriting.
+  const requestSeq = useRef(0)
+  const lastRecorded = useRef(0)
+
   const current = useRef({ deps, reloadToken, enabled })
   useEffect(() => {
     current.current = { deps, reloadToken, enabled }
@@ -139,19 +153,33 @@ export function useAsyncData<T>(
     // (#411) removed the protection with it, and `settled` does not check
     // `enabled` either — so a request begun while enabled would still populate
     // `data` after the caller had gated the fetch off.
+    const requestId = ++requestSeq.current
+
+    // Note on coverage: `mounted`, `enabled` and the ordering guard each have a
+    // test that fails when removed. The `sameDeps` check does NOT — the ordering
+    // guard subsumes it in every case reachable today, and `settled` filters by
+    // deps again at read time. It is kept as the cheapest way to avoid recording a
+    // result the reader would discard anyway, not because a test proves it load-
+    // bearing. Said plainly so nobody reads the mutation check as covering it.
     const stillWanted = () =>
       mounted.current &&
       current.current.enabled &&
       current.current.reloadToken === reloadToken &&
-      sameDeps(current.current.deps, deps)
+      sameDeps(current.current.deps, deps) &&
+      requestId >= lastRecorded.current
+
+    const record = (next: Resolved<T>) => {
+      if (!stillWanted()) return
+      lastRecorded.current = requestId
+      setResolved(next)
+    }
 
     loader()
       .then((data) => {
-        if (stillWanted()) setResolved({ deps, token: reloadToken, data })
+        record({ deps, token: reloadToken, data })
       })
       .catch((err: unknown) => {
-        if (!stillWanted()) return
-        setResolved({
+        record({
           deps,
           token: reloadToken,
           error: errorMessage ?? (err instanceof Error ? err.message : String(err)),


### PR DESCRIPTION
Follow-up to #417, which merged before I had read its review through. The review was right, and this corrects it.

## The regression

`enabled` used to be protected **by accident**: it sat in the fetch effect's dependency array, so flipping it re-ran the effect, and the old instance's cleanup set `cancelled = true`, discarding the in-flight request.

#417 removed that cleanup deliberately — it was also discarding results that were still wanted, which is what left the AI Insights panel spinning forever — but the `enabled` protection went with it. `stillWanted()` checked mounted / token / deps, and `settled` does not check `enabled` either.

So: a request begun while enabled would still populate `data` after the caller had gated the fetch off, with `loading` reported as `false`. As the reviewer noted, several call sites gate `enabled` on exactly the kind of state that can flip mid-request.

## Reproduced before fixing

```
enable → start request → flip enabled to false → resolve
expected: data === undefined
received: "answer nobody asked for any more"
```

## Fix

`enabled` now travels in the same ref as `deps` and `reloadToken`, and is checked at resolution time alongside them — the same shape as the other three conditions rather than a special case.

Mutation-checked: dropping the `enabled` check turns the new test red.

A second test asserts the ordinary enabled-throughout path still resolves, so the guard cannot be trivially "satisfied" by never recording anything — which is the failure mode a one-sided test would have missed.

## Gates

- `npx jest` — 1,368 passed, 3 skipped (15 in the `useAsyncData` contract suite, up from 13)
- `tsc --noEmit` clean
- `eslint . --max-warnings 233` — 233, 0 errors

## Note

Worth recording that the two `useAsyncData` guarantees pull against each other: discard too eagerly and slow results are lost forever (#411); discard too little and stale or gated-off results surface (this). Every condition now lives in one place — `stillWanted()` — with the reason for each written next to it, rather than being distributed between an effect dependency array and a closure flag where the interaction was invisible.