### PR TITLE
fix(frontend): keep a per-key watermark so an intervening key can't erase it (#418 review)

### DIFF
--- a/apps/frontend/__tests__/hooks/useAsyncData.test.tsx
+++ b/apps/frontend/__tests__/hooks/useAsyncData.test.tsx
@@ -526,3 +526,55 @@ describe('an older answer shown while a newer one is still pending (#418 review 
     expect(result.current.data).toBe('newer')
   })
 })
+
+describe('an intervening key must not erase a watermark (#418 review round 4)', () => {
+  // A single-slot watermark forgets what it already knew about key A as soon as a
+  // result for key B is recorded. A stale A request that outlived both can then
+  // walk straight back in, clobbering fresher A data — the exact bug the ordering
+  // guard exists to prevent, re-opened through a different key.
+  it('a stale same-key result cannot return after another key recorded in between', async () => {
+    const byKey: Record<string, ((v: string) => void)[]> = { a: [], b: [] }
+    let key: 'a' | 'b' = 'a'
+    const loader = jest.fn(
+      () => new Promise<string>((res) => { byKey[key].push(res) })
+    )
+
+    const { result, rerender } = renderHook(
+      ({ k, enabled }) => useAsyncData(loader, [k], { enabled }),
+      { initialProps: { k: 'a' as 'a' | 'b', enabled: true } }
+    )
+
+    // r1 and r2, both for key 'a'; r1 is left pending on purpose.
+    rerender({ k: 'a', enabled: false })
+    rerender({ k: 'a', enabled: true })
+    expect(byKey.a).toHaveLength(2)
+
+    await act(async () => {
+      byKey.a[1]('a: fresher')
+      await Promise.resolve()
+    })
+    expect(result.current.data).toBe('a: fresher')
+
+    // Navigate to 'b' and let it record — this is what used to erase the mark.
+    key = 'b'
+    rerender({ k: 'b', enabled: true })
+    await act(async () => {
+      byKey.b[0]('b: data')
+      await Promise.resolve()
+    })
+    expect(result.current.data).toBe('b: data')
+
+    // Back to 'a'; a fourth request starts and stays pending.
+    key = 'a'
+    rerender({ k: 'a', enabled: true })
+
+    // The original r1 finally answers. It is older than the r2 that already won,
+    // so it must NOT be shown.
+    await act(async () => {
+      byKey.a[0]('a: stale')
+      await Promise.resolve()
+    })
+
+    expect(result.current.data).not.toBe('a: stale')
+  })
+})

--- a/apps/frontend/lib/hooks/useAsyncData.ts
+++ b/apps/frontend/lib/hooks/useAsyncData.ts
@@ -73,6 +73,9 @@ interface Resolved<T> {
   error?: string
 }
 
+/** How many distinct keys' watermarks to remember. Bounds the history above. */
+const RECORDED_HISTORY = 8
+
 /** Shallow Object.is comparison, the same identity rule React uses for hook deps. */
 function sameDeps(a: DependencyList, b: DependencyList): boolean {
   if (a.length !== b.length) return false
@@ -135,12 +138,18 @@ export function useAsyncData<T>(
   // case this hook's history is about. Ordering therefore constrains a request only
   // against others for the SAME key.
   //
+  // Why a LIST and not one slot: a single slot remembers only the most recent
+  // record, so recording for B forgets what was already known about A, and a stale
+  // A request that outlived both walks straight back in. Keeping a short history
+  // preserves each key's watermark across an intervening key. Bounded because this
+  // only needs to outlive requests that are still in flight, not the session.
+  //
   // Deliberately NOT "only the newest request may record": that is the rule that
   // reintroduces #411 head-on, since the newest request is the one that never comes
   // back. An older result is welcome while nothing newer for its key has landed; it
   // is only barred from overwriting.
   const requestSeq = useRef(0)
-  const lastRecorded = useRef<{ id: number; deps: DependencyList } | null>(null)
+  const recorded = useRef<{ id: number; deps: DependencyList }[]>([])
 
   const current = useRef({ deps, reloadToken, enabled })
   useEffect(() => {
@@ -164,11 +173,12 @@ export function useAsyncData<T>(
     // `data` after the caller had gated the fetch off.
     const requestId = ++requestSeq.current
 
-    /** Newest already-recorded id for this key; 0 when the last one was another key. */
-    const recordedIdForThisKey = () => {
-      const last = lastRecorded.current
-      return last && sameDeps(last.deps, deps) ? last.id : 0
-    }
+    /** Highest id already recorded for THIS key; 0 if this key has never recorded. */
+    const recordedIdForThisKey = () =>
+      recorded.current.reduce(
+        (max, entry) => (sameDeps(entry.deps, deps) ? Math.max(max, entry.id) : max),
+        0
+      )
 
     // Note on coverage: `mounted`, `enabled` and the ordering guard each have a
     // test that fails when removed. The `sameDeps` check does NOT — the ordering
@@ -185,7 +195,12 @@ export function useAsyncData<T>(
 
     const record = (next: Resolved<T>) => {
       if (!stillWanted()) return
-      lastRecorded.current = { id: requestId, deps }
+      // Keep the newest entry per key, capped — only in-flight requests can still
+      // consult this, and there are never many.
+      recorded.current = [
+        ...recorded.current.filter((e) => !sameDeps(e.deps, deps)).slice(-RECORDED_HISTORY),
+        { id: requestId, deps },
+      ]
       setResolved(next)
     }
 

--- a/apps/frontend/lib/hooks/useAsyncData.ts
+++ b/apps/frontend/lib/hooks/useAsyncData.ts
@@ -195,12 +195,19 @@ export function useAsyncData<T>(
 
     const record = (next: Resolved<T>) => {
       if (!stillWanted()) return
-      // Keep the newest entry per key, capped — only in-flight requests can still
-      // consult this, and there are never many.
+      // Newest entry per key, then trim — slicing AFTER the append is what makes
+      // RECORDED_HISTORY the true cap; trimming first left room for one more.
+      //
+      // Eviction tradeoff, stated here and not only at the top of the file: if more
+      // than RECORDED_HISTORY distinct keys have requests in flight at once, the
+      // oldest watermark is dropped and that key reverts to the round-4 behaviour —
+      // a stale answer for it could be recorded again. Accepted because a single
+      // hook instance having 9+ keys simultaneously outstanding is not a shape any
+      // current call site can produce. If one ever does, this is the line to change.
       recorded.current = [
-        ...recorded.current.filter((e) => !sameDeps(e.deps, deps)).slice(-RECORDED_HISTORY),
+        ...recorded.current.filter((e) => !sameDeps(e.deps, deps)),
         { id: requestId, deps },
-      ]
+      ].slice(-RECORDED_HISTORY)
       setResolved(next)
     }
 

--- a/apps/frontend/lib/hooks/useAsyncData.ts
+++ b/apps/frontend/lib/hooks/useAsyncData.ts
@@ -173,12 +173,13 @@ export function useAsyncData<T>(
     // `data` after the caller had gated the fetch off.
     const requestId = ++requestSeq.current
 
-    /** Highest id already recorded for THIS key; 0 if this key has never recorded. */
+    /**
+     * Id already recorded for THIS key; 0 if this key has never recorded.
+     * `record()` de-dupes by key before appending, so there is at most one entry to
+     * find — a reduce/Math.max here would imply several candidates that cannot exist.
+     */
     const recordedIdForThisKey = () =>
-      recorded.current.reduce(
-        (max, entry) => (sameDeps(entry.deps, deps) ? Math.max(max, entry.id) : max),
-        0
-      )
+      recorded.current.find((entry) => sameDeps(entry.deps, deps))?.id ?? 0
 
     // Note on coverage: `mounted`, `enabled` and the ordering guard each have a
     // test that fails when removed. The `sameDeps` check does NOT — the ordering


### PR DESCRIPTION
Follow-up to #418. The reviewer traced a fourth hole by hand — without running it — and the trace was exact. It reached `main` because I merged #418 before reading its review through, the same mistake I made on #417.

## The hole

`lastRecorded` was a **single slot**, so recording a result for key `b` forgot what was already known about key `a`:

```
deps=[a]         r1 starts, slow
enabled off/on   r2 starts (same key), answers, records   -> mark {2, a}
deps=[b]         r3 starts, answers, records              -> mark {3, b}   ← a's mark lost
deps=[a]         r4 starts, still pending
r1 finally answers -> watermark for 'a' reads 0 -> recorded
```

`r1` is **older than the `r2` that already won**, so it clobbers fresher data with stale — exactly the class the ordering guard exists to prevent, re-opened through a different key.

Reproduced before fixing: the new test asserted `data` is not `"a: stale"`, and it was.

## Fix

A short, bounded history keyed by deps instead of one slot, so each key keeps its own watermark across an intervening key. Capped at 8 entries — only requests still in flight can consult it, and there are never many.

## Mutation-checked, one row per guard

```
single-slot watermark  -> round 4 test red
no ordering guard      -> rounds 1 and 2 tests red
no enabled guard       -> round 1 test red
no mounted guard       -> everything still passes
```

That last row is reported rather than buried: **`mounted` has no test of its own.** It prevents a post-unmount `setState`, which React 18 no longer warns about, so there is nothing observable to assert. It stays as cheap hygiene, not because anything proves it load-bearing.

## Where this hook now stands

Four rounds of correction, all in the same predicate, all about which results to accept. The constraints genuinely pull against each other:

| Discard too eagerly | slow answers lost forever | #411 |
| Discard too little | gated-off answers surface | #417 review |
| Scope ordering globally | an unrelated key discards a valid answer | #418 review r2 |
| Remember only the last record | an intervening key lets a stale answer back in | this |

All four now live in one predicate with the reason for each written beside it, and every one except `mounted` has a test that fails without it.

## Gates

- `npx jest` — 1,372 passed, 3 skipped (20 in the `useAsyncData` contract suite)
- `tsc --noEmit` clean
- `eslint . --max-warnings 233` — 233, 0 errors