### PR TITLE
test(backend): stop test_metrics asserting over other modules' gauge samples (#412)

### DIFF
--- a/apps/backend/tests/test_middleware/test_metrics.py
+++ b/apps/backend/tests/test_middleware/test_metrics.py
@@ -310,7 +310,17 @@ class TestMetricsLabels:
     def test_active_requests_labeled_by_method_only(self, client):
         """active_requests is labeled by method only (issue #273): the route
         template isn't known at request start, so labeling by endpoint would
-        reintroduce the raw-path cardinality bomb."""
+        reintroduce the raw-path cardinality bomb.
+
+        The registry is process-global and nothing resets it between modules, so
+        this must NOT require every sample to be GET — any earlier suite that made
+        a POST leaves a `method="POST"` sample behind and the assertion fails for
+        reasons that have nothing to do with this module. That is exactly what
+        happened: green alone, red in a full-suite run (#412).
+
+        The real invariant is label *shape*, which is method-agnostic: no
+        `endpoint`, no `status_code`, on any sample.
+        """
         client.get("/test")
         metrics = get_metrics().decode("utf-8")
 
@@ -320,8 +330,14 @@ class TestMetricsLabels:
             if line.startswith("http_requests_active{")
         ]
         assert active_lines, "expected an http_requests_active sample"
+
+        # Our own request must be represented...
+        assert any(
+            'method="GET"' in line for line in active_lines
+        ), f"no method=GET sample among: {active_lines}"
+
+        # ...and no sample, whoever produced it, may carry the high-cardinality
+        # labels this gauge deliberately dropped.
         for line in active_lines:
-            assert 'method="GET"' in line
-            # endpoint/status_code must NOT be labels on the gauge anymore
             assert "endpoint=" not in line
             assert "status_code=" not in line


### PR DESCRIPTION
Closes #412.

`test_active_requests_labeled_by_method_only` required **every** `http_requests_active` sample to be `method="GET"`. The Prometheus registry is process-global and nothing resets it between modules, so any earlier suite that made a POST left a `method="POST"` sample behind, and this failed for reasons unrelated to the module under test.

Reproduced with an **existing** pair, so it was never introduced by recent work:

```
$ pytest tests/test_api/test_ai_orchestration.py tests/test_middleware/test_metrics.py
FAILED tests/test_middleware/test_metrics.py::TestMetricsLabels::test_active_requests_labeled_by_method_only

$ pytest tests/test_middleware/test_metrics.py
19 passed
```

## Fix

The invariant this test exists for is label **shape**, and that is method-agnostic: no `endpoint`, no `status_code` on the gauge — the cardinality bomb #273 removed.

So it now asserts a `method="GET"` sample is **present** (proving its own request was tracked) and checks the forbidden labels across **every** sample, whoever produced it. Order-independent, and without resetting global state that other suites may be mid-assertion on — which was the issue's other suggested fix and the riskier one.

## Why it mattered

CI never saw this: `test_middleware/` is not in the service-free unit selection, and the integration job's ordering does not trigger it. It only bit a local full-suite run — exactly when someone is trying to confirm they broke nothing, which trains people to ignore a red result.

## Result

Full backend suite now passes locally:

```
2209 passed, 40 skipped in 350.98s
```

`test_redis_cache_integration` is deselected from that run — it needs Redis on :6380, which is not running here, and unlike its siblings it does not skip cleanly. That is a separate problem and it fails on `main` too; not touched here.