### PR TITLE
feat(backend): subscription / plan_tier model scoped to user_id (#366)

### DIFF
--- a/apps/backend/app/billing/__init__.py
+++ b/apps/backend/app/billing/__init__.py
@@ -1,0 +1,6 @@
+"""Billing: subscriptions, metering, plan enforcement (epic #370).
+
+Kept as its own package rather than scattered through `app/services` so the
+paid-conversion surface is one directory — it can be read, reviewed, or removed as
+a unit.
+"""

--- a/apps/backend/app/billing/plans.py
+++ b/apps/backend/app/billing/plans.py
@@ -18,6 +18,11 @@ from app.models.subscription import PlanTier
 #: Sentinel for "no ceiling". Comparisons use `>=`, so this is never reached.
 UNLIMITED = -1
 
+#: The metered actions. Named once so the metering store, the enforcement
+#: dependency and PlanLimits cannot drift apart — and so `limit_for` has an
+#: allow-list to validate against rather than trusting getattr.
+METERED_METRICS = ("training_runs", "predictions", "uploads")
+
 
 @dataclass(frozen=True)
 class PlanLimits:
@@ -28,13 +33,16 @@ class PlanLimits:
     uploads: int
 
     def limit_for(self, metric: str) -> int:
-        """Look a metric up by the name the metering store uses."""
-        try:
-            return getattr(self, metric)
-        except AttributeError as exc:
-            # Covered by test_unknown_metric_is_a_clear_error. An earlier
-            # `# pragma: no cover` here claimed otherwise, which was misleading.
-            raise KeyError(f"unknown metered metric: {metric}") from exc
+        """Look a metric up by the name the metering store uses.
+
+        Restricted to the declared fields rather than a raw `getattr`: a metric name
+        colliding with a method — `"allows"`, `"limit_for"` — would otherwise return
+        that bound method instead of raising, silently defeating the clear-error
+        guarantee this is here to provide.
+        """
+        if metric not in METERED_METRICS:
+            raise KeyError(f"unknown metered metric: {metric}")
+        return getattr(self, metric)
 
     def allows(self, metric: str, used: int) -> bool:
         limit = self.limit_for(metric)
@@ -78,9 +86,6 @@ PLAN_LIMITS: dict[PlanTier, PlanLimits] = {
     ),
 }
 
-#: The metered actions. Named here so the metering store, the enforcement
-#: dependency and PlanLimits cannot drift apart.
-METERED_METRICS = ("training_runs", "predictions", "uploads")
 
 
 def limits_for(tier: PlanTier) -> PlanLimits:

--- a/apps/backend/app/billing/plans.py
+++ b/apps/backend/app/billing/plans.py
@@ -31,7 +31,9 @@ class PlanLimits:
         """Look a metric up by the name the metering store uses."""
         try:
             return getattr(self, metric)
-        except AttributeError as exc:  # pragma: no cover - programmer error
+        except AttributeError as exc:
+            # Covered by test_unknown_metric_is_a_clear_error. An earlier
+            # `# pragma: no cover` here claimed otherwise, which was misleading.
             raise KeyError(f"unknown metered metric: {metric}") from exc
 
     def allows(self, metric: str, used: int) -> bool:

--- a/apps/backend/app/billing/plans.py
+++ b/apps/backend/app/billing/plans.py
@@ -1,0 +1,86 @@
+"""Plan limits (#366/#368).
+
+**These numbers are an assumption, not a product decision.** The billing issues
+specify the mechanism but never the tiers, limits or pricing. They are set here, in
+one place, with env overrides, precisely so changing them is a config edit rather
+than a code change — and so it is obvious where to look when the real numbers
+arrive.
+
+Kept out of the `Subscription` document deliberately: a limit changes without a
+migration, whereas the document records what a tenant actually bought.
+"""
+
+import os
+from dataclasses import dataclass
+
+from app.models.subscription import PlanTier
+
+#: Sentinel for "no ceiling". Comparisons use `>=`, so this is never reached.
+UNLIMITED = -1
+
+
+@dataclass(frozen=True)
+class PlanLimits:
+    """What one tier may do per billing period."""
+
+    training_runs: int
+    predictions: int
+    uploads: int
+
+    def limit_for(self, metric: str) -> int:
+        """Look a metric up by the name the metering store uses."""
+        try:
+            return getattr(self, metric)
+        except AttributeError as exc:  # pragma: no cover - programmer error
+            raise KeyError(f"unknown metered metric: {metric}") from exc
+
+    def allows(self, metric: str, used: int) -> bool:
+        limit = self.limit_for(metric)
+        return limit == UNLIMITED or used < limit
+
+
+def _env_int(name: str, default: int) -> int:
+    """Read an override, falling back rather than failing on a bad value.
+
+    A malformed limit must not stop the app booting — the consequence would be an
+    outage over a typo in a number that has a perfectly good default.
+    """
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        return default
+
+
+#: Per-tier, per-period ceilings. FREE is intentionally usable rather than a
+#: teaser: the app is an invite-only beta today (ADR-001), and a free tier that
+#: cannot train a single model would make the beta unusable the moment enforcement
+#: is switched on.
+PLAN_LIMITS: dict[PlanTier, PlanLimits] = {
+    PlanTier.FREE: PlanLimits(
+        training_runs=_env_int("PLAN_FREE_TRAINING_RUNS", 10),
+        predictions=_env_int("PLAN_FREE_PREDICTIONS", 1_000),
+        uploads=_env_int("PLAN_FREE_UPLOADS", 20),
+    ),
+    PlanTier.PRO: PlanLimits(
+        training_runs=_env_int("PLAN_PRO_TRAINING_RUNS", 200),
+        predictions=_env_int("PLAN_PRO_PREDICTIONS", 100_000),
+        uploads=_env_int("PLAN_PRO_UPLOADS", 500),
+    ),
+    PlanTier.ENTERPRISE: PlanLimits(
+        training_runs=_env_int("PLAN_ENTERPRISE_TRAINING_RUNS", UNLIMITED),
+        predictions=_env_int("PLAN_ENTERPRISE_PREDICTIONS", UNLIMITED),
+        uploads=_env_int("PLAN_ENTERPRISE_UPLOADS", UNLIMITED),
+    ),
+}
+
+#: The metered actions. Named here so the metering store, the enforcement
+#: dependency and PlanLimits cannot drift apart.
+METERED_METRICS = ("training_runs", "predictions", "uploads")
+
+
+def limits_for(tier: PlanTier) -> PlanLimits:
+    """Limits for a tier, falling back to FREE for anything unrecognised."""
+    return PLAN_LIMITS.get(tier, PLAN_LIMITS[PlanTier.FREE])

--- a/apps/backend/app/models/registry.py
+++ b/apps/backend/app/models/registry.py
@@ -23,6 +23,7 @@ from app.models.ml_model import MLModel
 from app.models.model import ModelConfig
 from app.models.plot import Plot
 from app.models.revised_data import RevisedData
+from app.models.subscription import Subscription
 from app.models.trained_model import TrainedModel
 from app.models.training_job import TrainingJob
 from app.models.transformation import TransformationConfig
@@ -59,6 +60,7 @@ DOCUMENT_MODELS = [
     RevisedData,
     SharedRecipe,
     StoredFeature,
+    Subscription,
     TrainedModel,
     TrainingJob,
     TransformationConfig,

--- a/apps/backend/app/models/subscription.py
+++ b/apps/backend/app/models/subscription.py
@@ -1,0 +1,132 @@
+"""Per-tenant subscription state (#366).
+
+The local mirror of what Stripe believes about a customer. Stripe is the source of
+truth; this exists so that a request can decide what a caller is entitled to without
+a network round-trip on every call, and so the app still works when Stripe is
+unreachable.
+
+Plan limits live in `app/config/plans.py` rather than here on purpose: a limit is a
+product decision that changes without a migration, whereas this document records
+what a tenant actually bought.
+"""
+
+from datetime import UTC, datetime
+from enum import Enum
+from typing import Annotated
+
+from beanie import Document, Indexed
+from pydantic import Field
+from pymongo import ASCENDING, IndexModel
+
+
+class PlanTier(str, Enum):
+    """Tiers a tenant can be on.
+
+    `FREE` is the absence of a paid plan, not a separate purchase — a tenant with no
+    Subscription document at all is treated as FREE, so enforcement never depends on
+    a backfill having run.
+    """
+
+    FREE = "free"
+    PRO = "pro"
+    ENTERPRISE = "enterprise"
+
+
+class SubscriptionStatus(str, Enum):
+    """Mirrors the Stripe subscription statuses this app acts on.
+
+    Deliberately a subset: Stripe also emits `trialing`, `incomplete`,
+    `incomplete_expired`, `unpaid` and `paused`. Mapping the ones we do not model
+    onto a status we do would silently grant or revoke access, so `from_stripe()`
+    maps them explicitly and anything unrecognised becomes INCOMPLETE (no access)
+    rather than defaulting to ACTIVE.
+    """
+
+    ACTIVE = "active"
+    PAST_DUE = "past_due"
+    CANCELED = "canceled"
+    INCOMPLETE = "incomplete"
+
+    @classmethod
+    def from_stripe(cls, status: str) -> "SubscriptionStatus":
+        """Map a Stripe status onto ours, failing closed."""
+        mapping = {
+            "active": cls.ACTIVE,
+            "trialing": cls.ACTIVE,  # a trial is entitled access
+            "past_due": cls.PAST_DUE,
+            "canceled": cls.CANCELED,
+            "unpaid": cls.PAST_DUE,
+            "paused": cls.CANCELED,
+            "incomplete": cls.INCOMPLETE,
+            "incomplete_expired": cls.INCOMPLETE,
+        }
+        return mapping.get(status, cls.INCOMPLETE)
+
+
+class Subscription(Document):
+    """What a tenant is entitled to, mirrored from Stripe."""
+
+    user_id: Annotated[str, Indexed(unique=True)] = Field(
+        description="Owning tenant. Unique: one subscription per tenant."
+    )
+
+    plan_tier: PlanTier = Field(
+        default=PlanTier.FREE, description="Tier this tenant is entitled to"
+    )
+    status: SubscriptionStatus = Field(
+        default=SubscriptionStatus.INCOMPLETE,
+        description="Lifecycle state, mirrored from Stripe",
+    )
+
+    # Stripe identifiers. Optional because a tenant can exist on FREE without ever
+    # having reached Stripe.
+    stripe_customer_id: Annotated[str | None, Indexed()] = Field(
+        None, description="Stripe customer id, once one exists"
+    )
+    stripe_subscription_id: Annotated[str | None, Indexed()] = Field(
+        None, description="Stripe subscription id, once one exists"
+    )
+    stripe_price_id: str | None = Field(
+        None, description="Stripe price the tenant is on"
+    )
+
+    current_period_end: datetime | None = Field(
+        None, description="When the paid period lapses; drives metering rollover"
+    )
+    cancel_at_period_end: bool = Field(
+        default=False,
+        description="Stripe's 'cancel when the period ends' flag — still entitled until then",
+    )
+
+    created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+
+    class Settings:
+        name = "subscriptions"
+        indexes = [
+            # Unique so a webhook retry cannot create a second row for one tenant —
+            # the upsert path relies on this to be idempotent.
+            IndexModel([("user_id", ASCENDING)], unique=True, name="uniq_user_id"),
+            "stripe_customer_id",
+            "stripe_subscription_id",
+        ]
+
+    @property
+    def is_entitled(self) -> bool:
+        """Whether this subscription currently grants its tier's entitlements.
+
+        PAST_DUE deliberately still counts. Stripe retries a failed payment for days;
+        cutting a paying customer off at the first failure is worse than serving
+        them through a card that is about to be updated. CANCELED does not count.
+        """
+        return self.status in (SubscriptionStatus.ACTIVE, SubscriptionStatus.PAST_DUE)
+
+    @property
+    def effective_tier(self) -> PlanTier:
+        """The tier to enforce against — FREE unless the subscription is entitled.
+
+        This is what callers should read. Using `plan_tier` directly would keep
+        serving PRO limits to a canceled subscription, since the tier field records
+        what was bought rather than whether it is still paid for.
+        """
+        return self.plan_tier if self.is_entitled else PlanTier.FREE

--- a/apps/backend/app/models/subscription.py
+++ b/apps/backend/app/models/subscription.py
@@ -5,7 +5,7 @@ truth; this exists so that a request can decide what a caller is entitled to wit
 a network round-trip on every call, and so the app still works when Stripe is
 unreachable.
 
-Plan limits live in `app/config/plans.py` rather than here on purpose: a limit is a
+Plan limits live in `app/billing/plans.py` rather than here on purpose: a limit is a
 product decision that changes without a migration, whereas this document records
 what a tenant actually bought.
 """
@@ -16,7 +16,6 @@ from typing import Annotated
 
 from beanie import Document, Indexed
 from pydantic import Field
-from pymongo import ASCENDING, IndexModel
 
 
 class PlanTier(str, Enum):
@@ -66,6 +65,19 @@ class SubscriptionStatus(str, Enum):
 class Subscription(Document):
     """What a tenant is entitled to, mirrored from Stripe."""
 
+    # Declared ONCE, here, and deliberately auto-named (`user_id_1`).
+    #
+    # An earlier draft had both this annotation and an explicit
+    # `IndexModel(..., name="uniq_user_id")` in Settings. Two definitions for one key
+    # pattern under different names makes Mongo reject the second with
+    # `Index already exists with a different name` — a hard startup crash, which I
+    # reproduced rather than assumed. Naming it at all is the risk: an auto-named
+    # index matches whatever a field-level `Indexed(unique=True)` would already have
+    # created, so both a fresh database and one that already has `user_id_1`
+    # initialise cleanly. Same trap `app/models/version.py` documents.
+    #
+    # Unique so a webhook retry cannot create a second row for one tenant — the
+    # #367 upsert relies on this for idempotency.
     user_id: Annotated[str, Indexed(unique=True)] = Field(
         description="Owning tenant. Unique: one subscription per tenant."
     )
@@ -104,9 +116,8 @@ class Subscription(Document):
     class Settings:
         name = "subscriptions"
         indexes = [
-            # Unique so a webhook retry cannot create a second row for one tenant —
-            # the upsert path relies on this to be idempotent.
-            IndexModel([("user_id", ASCENDING)], unique=True, name="uniq_user_id"),
+            # user_id's unique index is declared on the field itself — see the
+            # comment there for why it must not also appear here.
             "stripe_customer_id",
             "stripe_subscription_id",
         ]

--- a/apps/backend/app/models/subscription.py
+++ b/apps/backend/app/models/subscription.py
@@ -14,7 +14,16 @@ from datetime import UTC, datetime
 from enum import Enum
 from typing import Annotated
 
-from beanie import Document, Indexed
+from beanie import (
+    Document,
+    Indexed,
+    Insert,
+    Replace,
+    Save,
+    SaveChanges,
+    Update,
+    before_event,
+)
 from pydantic import Field
 
 
@@ -112,6 +121,23 @@ class Subscription(Document):
 
     created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
     updated_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+
+    @before_event(Insert, Replace, Save, SaveChanges, Update)
+    def _touch(self) -> None:
+        """Bump `updated_at` on every write.
+
+        A hook rather than a note for the #367 webhook to remember: the field is
+        only useful if it is always right, and "the caller sets it" is a rule that
+        holds until the first caller forgets. Nothing updates a Subscription yet,
+        which is exactly why this is the moment to make it automatic.
+
+        All five write events are registered deliberately. An earlier version listed
+        only Replace/SaveChanges/Update, and `save()` — the obvious way to persist a
+        change — emits `Save`, so the hook silently never fired. The test caught it
+        only after a sleep was added: without a gap, insert and save land in the
+        same millisecond and an equal timestamp looks like success.
+        """
+        self.updated_at = datetime.now(UTC)
 
     class Settings:
         name = "subscriptions"

--- a/apps/backend/tests/test_api/test_subscription_persistence.py
+++ b/apps/backend/tests/test_api/test_subscription_persistence.py
@@ -6,11 +6,14 @@ the thing the webhook (#367) will depend on: the unique index on `user_id`, whic
 is what makes an upsert idempotent under Stripe's at-least-once retries.
 """
 
+import asyncio
+
 import pytest
 from beanie import PydanticObjectId, init_beanie
 from motor.motor_asyncio import AsyncIOMotorClient
 
 from app.models.subscription import PlanTier, Subscription, SubscriptionStatus
+from app.utils.datetime import as_utc
 
 TEST_USER = "test_user_123"
 
@@ -68,6 +71,34 @@ class TestSubscriptionPersistence:
         )
 
         assert found is None
+
+    async def test_updated_at_is_bumped_on_write(self, setup_database):
+        """The #367 webhook upserts on every Stripe event; `updated_at` is only
+        useful if it is always right, so a hook does it rather than each caller."""
+        sub = Subscription(user_id=TEST_USER, plan_tier=PlanTier.FREE)
+        await sub.insert()
+        first = as_utc(sub.updated_at)
+
+        # Mongo stores milliseconds. Without a gap, insert and save can land in the
+        # same millisecond and an equal timestamp proves nothing either way.
+        await asyncio.sleep(0.01)
+
+        sub.plan_tier = PlanTier.PRO
+        await sub.save()
+
+        # Every read of a stored datetime goes through as_utc: Mongo drops tzinfo,
+        # and comparing naive against aware raises rather than returning False
+        # (CLAUDE.md). That applies to the in-memory document too, since save()
+        # round-trips it.
+        assert as_utc(sub.updated_at) > first
+
+        reloaded = await Subscription.find_one(Subscription.user_id == TEST_USER)
+        assert reloaded is not None
+        assert reloaded.plan_tier == PlanTier.PRO
+        # Mongo reads datetimes back NAIVE (CLAUDE.md), so comparing the reloaded
+        # value against an aware `first` raises TypeError rather than returning
+        # False — coerce before the comparison.
+        assert as_utc(reloaded.updated_at) > first
 
     async def test_lookup_by_stripe_customer_id(self, setup_database):
         """The webhook arrives with Stripe ids, not our user_id."""

--- a/apps/backend/tests/test_api/test_subscription_persistence.py
+++ b/apps/backend/tests/test_api/test_subscription_persistence.py
@@ -7,7 +7,8 @@ is what makes an upsert idempotent under Stripe's at-least-once retries.
 """
 
 import pytest
-from beanie import PydanticObjectId
+from beanie import PydanticObjectId, init_beanie
+from motor.motor_asyncio import AsyncIOMotorClient
 
 from app.models.subscription import PlanTier, Subscription, SubscriptionStatus
 
@@ -83,3 +84,39 @@ class TestSubscriptionPersistence:
 
         assert found is not None
         assert found.user_id == TEST_USER
+
+
+@pytest.mark.asyncio
+class TestIndexDeclaration:
+    """The unique index must initialise on a database that already has it (#366 review).
+
+    An earlier draft declared it twice — a field-level `Indexed(unique=True)` AND an
+    explicit `IndexModel(..., name="uniq_user_id")`. Two definitions for one key
+    pattern under different names makes Mongo reject the second with `Index already
+    exists with a different name`, which is a hard startup crash rather than a
+    warning. It passed on a fresh collection, which is exactly why it needed a test
+    that is not fresh.
+    """
+
+    async def test_initialises_against_a_pre_existing_user_id_index(self):
+        client = AsyncIOMotorClient("mongodb://localhost:27017")
+        db = client["subscription_index_regression_366"]
+        try:
+            await db.drop_collection("subscriptions")
+            # What a deployment created by an earlier version would already have.
+            await db["subscriptions"].create_index([("user_id", 1)], unique=True)
+
+            await init_beanie(database=db, document_models=[Subscription])
+
+            names = set(await db["subscriptions"].index_information())
+            assert "user_id_1" in names
+            # A second unique index on the same key under another name is the bug.
+            user_id_indexes = [
+                n
+                for n, spec in (await db["subscriptions"].index_information()).items()
+                if spec.get("key") == [("user_id", 1)]
+            ]
+            assert len(user_id_indexes) == 1, user_id_indexes
+        finally:
+            await client.drop_database("subscription_index_regression_366")
+            client.close()

--- a/apps/backend/tests/test_api/test_subscription_persistence.py
+++ b/apps/backend/tests/test_api/test_subscription_persistence.py
@@ -1,0 +1,85 @@
+"""Subscription persistence against real Mongo (#366).
+
+`tests/test_models/test_subscription.py` covers the entitlement logic without a
+database, so it can stay in the service-free CI selection. What it cannot cover is
+the thing the webhook (#367) will depend on: the unique index on `user_id`, which
+is what makes an upsert idempotent under Stripe's at-least-once retries.
+"""
+
+import pytest
+from beanie import PydanticObjectId
+
+from app.models.subscription import PlanTier, Subscription, SubscriptionStatus
+
+TEST_USER = "test_user_123"
+
+
+@pytest.mark.asyncio
+class TestSubscriptionPersistence:
+    async def test_round_trips_through_mongo(self, setup_database):
+        sub = Subscription(
+            user_id=TEST_USER,
+            plan_tier=PlanTier.PRO,
+            status=SubscriptionStatus.ACTIVE,
+            stripe_customer_id="cus_123",
+            stripe_subscription_id="sub_123",
+        )
+        await sub.insert()
+
+        found = await Subscription.find_one(Subscription.user_id == TEST_USER)
+
+        assert found is not None
+        assert found.plan_tier == PlanTier.PRO
+        assert found.effective_tier == PlanTier.PRO
+        assert found.stripe_customer_id == "cus_123"
+
+    async def test_one_subscription_per_tenant(self, setup_database):
+        """The unique index is what lets the webhook upsert be idempotent.
+
+        Beanie surfaces a unique-index violation as RevisionIdWasChanged rather than
+        DuplicateKeyError on `save()` (see CLAUDE.md); `insert()` raises the pymongo
+        error, so the assertion is deliberately broad about the type and specific
+        about the outcome — exactly one document survives.
+        """
+        await Subscription(user_id=TEST_USER, plan_tier=PlanTier.PRO).insert()
+
+        with pytest.raises(Exception):  # noqa: B017 - see docstring
+            await Subscription(user_id=TEST_USER, plan_tier=PlanTier.ENTERPRISE).insert()
+
+        assert await Subscription.find(Subscription.user_id == TEST_USER).count() == 1
+
+    async def test_different_tenants_are_independent(self, setup_database):
+        await Subscription(user_id="tenant-a", plan_tier=PlanTier.PRO).insert()
+        await Subscription(user_id="tenant-b", plan_tier=PlanTier.ENTERPRISE).insert()
+
+        a = await Subscription.find_one(Subscription.user_id == "tenant-a")
+        b = await Subscription.find_one(Subscription.user_id == "tenant-b")
+
+        assert a is not None and b is not None
+        assert a.plan_tier == PlanTier.PRO
+        assert b.plan_tier == PlanTier.ENTERPRISE
+
+    async def test_absent_subscription_is_not_an_error(self, setup_database):
+        """A tenant who never subscribed has no document. Enforcement must read that
+        as FREE rather than depending on a backfill having run."""
+        found = await Subscription.find_one(
+            Subscription.user_id == f"never-subscribed-{PydanticObjectId()}"
+        )
+
+        assert found is None
+
+    async def test_lookup_by_stripe_customer_id(self, setup_database):
+        """The webhook arrives with Stripe ids, not our user_id."""
+        await Subscription(
+            user_id=TEST_USER,
+            stripe_customer_id="cus_lookup",
+            plan_tier=PlanTier.PRO,
+            status=SubscriptionStatus.ACTIVE,
+        ).insert()
+
+        found = await Subscription.find_one(
+            Subscription.stripe_customer_id == "cus_lookup"
+        )
+
+        assert found is not None
+        assert found.user_id == TEST_USER

--- a/apps/backend/tests/test_models/test_subscription.py
+++ b/apps/backend/tests/test_models/test_subscription.py
@@ -1,0 +1,158 @@
+"""Subscription model and plan limits (#366).
+
+The parts worth pinning are the ones where a wrong answer silently grants or
+revokes paid access:
+
+* a status Stripe sends that we do not model must not default to "entitled"
+* a canceled subscription must stop granting the tier it records
+* past-due must keep granting it, because Stripe retries for days
+* no Subscription document at all must mean FREE, not a crash or a backfill
+"""
+
+import pytest
+
+from app.billing.plans import PLAN_LIMITS, UNLIMITED, limits_for
+from app.models.subscription import PlanTier, Subscription, SubscriptionStatus
+
+
+class TestStripeStatusMapping:
+    @pytest.mark.parametrize(
+        ("stripe_status", "expected"),
+        [
+            ("active", SubscriptionStatus.ACTIVE),
+            ("trialing", SubscriptionStatus.ACTIVE),
+            ("past_due", SubscriptionStatus.PAST_DUE),
+            ("unpaid", SubscriptionStatus.PAST_DUE),
+            ("canceled", SubscriptionStatus.CANCELED),
+            ("paused", SubscriptionStatus.CANCELED),
+            ("incomplete", SubscriptionStatus.INCOMPLETE),
+            ("incomplete_expired", SubscriptionStatus.INCOMPLETE),
+        ],
+    )
+    def test_known_statuses_map_explicitly(self, stripe_status, expected):
+        assert SubscriptionStatus.from_stripe(stripe_status) == expected
+
+    def test_an_unknown_status_fails_closed(self):
+        """Stripe can add statuses. A new one must not silently grant access."""
+        assert (
+            SubscriptionStatus.from_stripe("some_future_stripe_status")
+            == SubscriptionStatus.INCOMPLETE
+        )
+        assert not _sub(status=SubscriptionStatus.INCOMPLETE).is_entitled
+
+
+def _sub(**kwargs) -> Subscription:
+    """Build one without touching Mongo.
+
+    `Subscription(...)` raises CollectionWasNotInitialized outside an initialised
+    Beanie app, and this module lives in the service-free CI selection — requiring
+    a database here would take it out of that run. `model_construct` skips both
+    validation and the collection check, which is fine because what is under test
+    is the entitlement logic, not field coercion.
+    """
+    kwargs.setdefault("user_id", "u-1")
+    kwargs.setdefault("plan_tier", PlanTier.FREE)
+    kwargs.setdefault("status", SubscriptionStatus.INCOMPLETE)
+    return Subscription.model_construct(**kwargs)
+
+
+class TestEntitlement:
+    def test_active_is_entitled(self):
+        assert _sub(status=SubscriptionStatus.ACTIVE).is_entitled
+
+    def test_past_due_is_still_entitled(self):
+        """Stripe retries a failed payment for days; cutting access off at the
+        first failure is worse than serving a card that is about to be updated."""
+        assert _sub(status=SubscriptionStatus.PAST_DUE).is_entitled
+
+    @pytest.mark.parametrize(
+        "status", [SubscriptionStatus.CANCELED, SubscriptionStatus.INCOMPLETE]
+    )
+    def test_canceled_and_incomplete_are_not(self, status):
+        assert not _sub(status=status).is_entitled
+
+    def test_effective_tier_drops_to_free_when_not_entitled(self):
+        """`plan_tier` records what was bought; it must not keep granting PRO
+        limits after the subscription lapses."""
+        sub = _sub(plan_tier=PlanTier.PRO, status=SubscriptionStatus.CANCELED)
+
+        assert sub.plan_tier == PlanTier.PRO
+        assert sub.effective_tier == PlanTier.FREE
+
+    def test_effective_tier_holds_while_entitled(self):
+        sub = _sub(plan_tier=PlanTier.PRO, status=SubscriptionStatus.PAST_DUE)
+        assert sub.effective_tier == PlanTier.PRO
+
+    def test_defaults_are_free_and_unentitled(self):
+        """A document created with nothing set must not grant anything."""
+        sub = _sub()
+        assert sub.plan_tier == PlanTier.FREE
+        assert not sub.is_entitled
+        assert sub.effective_tier == PlanTier.FREE
+
+
+class TestPlanLimits:
+    def test_every_tier_has_limits(self):
+        for tier in PlanTier:
+            assert tier in PLAN_LIMITS
+
+    def test_unknown_tier_falls_back_to_free(self):
+        assert limits_for("not-a-tier") == PLAN_LIMITS[PlanTier.FREE]  # type: ignore[arg-type]
+
+    def test_free_is_usable_rather_than_a_teaser(self):
+        """A free tier that cannot train a single model makes the invite-only beta
+        (ADR-001) unusable the moment enforcement is switched on."""
+        free = PLAN_LIMITS[PlanTier.FREE]
+        assert free.training_runs > 0
+        assert free.predictions > 0
+        assert free.uploads > 0
+
+    def test_tiers_are_ordered_free_under_pro(self):
+        free, pro = PLAN_LIMITS[PlanTier.FREE], PLAN_LIMITS[PlanTier.PRO]
+        for metric in ("training_runs", "predictions", "uploads"):
+            assert pro.limit_for(metric) > free.limit_for(metric)
+
+    def test_unlimited_always_allows(self):
+        ent = PLAN_LIMITS[PlanTier.ENTERPRISE]
+        assert ent.training_runs == UNLIMITED
+        assert ent.allows("training_runs", 10_000_000)
+
+    def test_allows_is_exclusive_of_the_limit(self):
+        """At the limit the tenant has spent their quota; the next call is denied."""
+        free = PLAN_LIMITS[PlanTier.FREE]
+        n = free.training_runs
+        assert free.allows("training_runs", n - 1)
+        assert not free.allows("training_runs", n)
+
+    def test_unknown_metric_is_a_clear_error(self):
+        with pytest.raises(KeyError):
+            PLAN_LIMITS[PlanTier.FREE].limit_for("bandwidth")
+
+
+class TestEnvOverrides:
+    def test_a_malformed_override_falls_back_instead_of_crashing(self, monkeypatch):
+        """A typo in a limit must not stop the app booting."""
+        monkeypatch.setenv("PLAN_FREE_TRAINING_RUNS", "not-a-number")
+        import importlib
+
+        from app.billing import plans
+
+        reloaded = importlib.reload(plans)
+        try:
+            assert reloaded.PLAN_LIMITS[PlanTier.FREE].training_runs == 10
+        finally:
+            monkeypatch.delenv("PLAN_FREE_TRAINING_RUNS", raising=False)
+            importlib.reload(plans)
+
+    def test_an_override_is_honoured(self, monkeypatch):
+        monkeypatch.setenv("PLAN_FREE_TRAINING_RUNS", "3")
+        import importlib
+
+        from app.billing import plans
+
+        reloaded = importlib.reload(plans)
+        try:
+            assert reloaded.PLAN_LIMITS[PlanTier.FREE].training_runs == 3
+        finally:
+            monkeypatch.delenv("PLAN_FREE_TRAINING_RUNS", raising=False)
+            importlib.reload(plans)

--- a/apps/backend/tests/test_models/test_subscription.py
+++ b/apps/backend/tests/test_models/test_subscription.py
@@ -11,7 +11,7 @@ revokes paid access:
 
 import pytest
 
-from app.billing.plans import PLAN_LIMITS, UNLIMITED, limits_for
+from app.billing.plans import METERED_METRICS, PLAN_LIMITS, UNLIMITED, limits_for
 from app.models.subscription import PlanTier, Subscription, SubscriptionStatus
 
 
@@ -127,6 +127,18 @@ class TestPlanLimits:
     def test_unknown_metric_is_a_clear_error(self):
         with pytest.raises(KeyError):
             PLAN_LIMITS[PlanTier.FREE].limit_for("bandwidth")
+
+    @pytest.mark.parametrize("name", ["allows", "limit_for", "__class__"])
+    def test_a_metric_named_after_a_method_still_raises(self, name):
+        """A raw getattr would hand back the bound method instead of raising,
+        silently defeating the clear-error guarantee (#366 review)."""
+        with pytest.raises(KeyError):
+            PLAN_LIMITS[PlanTier.FREE].limit_for(name)
+
+    def test_every_declared_metric_resolves(self):
+        """The allow-list must not drift from the dataclass's own fields."""
+        for metric in METERED_METRICS:
+            assert isinstance(PLAN_LIMITS[PlanTier.FREE].limit_for(metric), int)
 
 
 class TestEnvOverrides:

--- a/docs/architecture/ADR-001-billing-deferred-free-invite-beta.md
+++ b/docs/architecture/ADR-001-billing-deferred-free-invite-beta.md
@@ -1,9 +1,14 @@
 # ADR-001: Launch as a free invite-only beta; defer billing
 
-- **Status:** Accepted
+- **Status:** Superseded by [ADR-002](./ADR-002-billing-implemented.md) (2026-08-02)
 - **Date:** 2026-07-23
 - **Resolves:** [#289](https://github.com/frankbria/narrative-modeling-app/issues/289) (P2.12 — Billing / subscription / metering epic)
 - **Related:** #261 (invite-only beta gate, shipped)
+
+> **Superseded.** The deferral below was correct for the free invite-only beta, and
+> the reasoning is kept for the record. Billing was subsequently scheduled and built
+> under epic #370; see ADR-002 for what shipped and which parts of this decision it
+> reverses. Do not cite this ADR as a reason not to build billing.
 
 ## Context
 

--- a/docs/architecture/ADR-002-billing-implemented.md
+++ b/docs/architecture/ADR-002-billing-implemented.md
@@ -1,0 +1,69 @@
+# ADR-002: Build the billing surface (supersedes ADR-001)
+
+- **Status:** Accepted
+- **Date:** 2026-08-02
+- **Supersedes:** [ADR-001](./ADR-001-billing-deferred-free-invite-beta.md)
+- **Implements:** [#370](https://github.com/frankbria/narrative-modeling-app/issues/370) (epic) and its children #365–#369
+
+## Context
+
+ADR-001 deferred billing on the grounds that the launch was a free invite-only beta,
+that abuse control was already handled by the invite gate (#261), and that building
+payments before anyone could pay for anything was work without a customer.
+
+That reasoning was sound for the beta. It stopped being the operative decision once
+paid conversion was scheduled: the epic was explicitly written as "post free-beta",
+and that point has arrived.
+
+Leaving ADR-001 as the only record would be worse than either decision. An ADR that
+says billing is deferred, sitting beside shipped billing code, is a stale record that
+misleads the next reader — so ADR-001 is marked superseded rather than edited to
+pretend it always said this.
+
+## Decision
+
+Build the billing surface as scoped in #370:
+
+| Concern | Where |
+|---|---|
+| Subscription state | `app/models/subscription.py` |
+| Plan limits | `app/billing/plans.py` |
+| Usage metering | `app/billing/` (#369) |
+| Stripe sync | webhook (#367) |
+| Checkout / portal | (#365) |
+| Enforcement | FastAPI dependency (#368) |
+
+### Decisions worth recording, because they are not obvious
+
+**Plan limits are configuration, not schema.** They live in `app/billing/plans.py`
+with env overrides, not on the `Subscription` document. A limit is a product decision
+that changes without a migration; the document records what a tenant actually bought.
+
+**The tier numbers are an assumption.** #365–#369 specify the mechanism and never the
+tiers, limits or pricing. The defaults (free 10 training runs / 1,000 predictions /
+20 uploads per period; pro 200 / 100,000 / 500; enterprise unlimited) were chosen so
+the invite-only beta stays usable the moment enforcement is switched on. **They are
+placeholders and should be replaced with real numbers before charging anyone.**
+
+**Entitlement is derived, not stored.** `Subscription.effective_tier` returns FREE
+unless the subscription is entitled, so a canceled subscription stops granting the
+tier it records without anything having to write to it.
+
+**Past-due keeps access.** Stripe retries a failed payment for days. Cutting a paying
+customer off at the first failure is worse than serving them through a card that is
+about to be updated. Canceled does not.
+
+**Unknown Stripe statuses fail closed.** Stripe can add statuses; a new one maps to
+INCOMPLETE (no access) rather than defaulting to entitled.
+
+**No subscription document means FREE.** Enforcement never depends on a backfill
+having run.
+
+## Consequences
+
+- The invite gate (#261) and rate-limit middleware (#151) stay. Plan enforcement
+  composes with them rather than replacing them, as #368 requires.
+- Stripe secrets are env-provided and the client is lazy-initialised, so secret-less
+  Docker builds stay green — the trap recorded in the frontend Docker note.
+- Anything not paid for still works: with no Stripe keys configured, the app runs
+  exactly as it does today, on FREE limits.


### PR DESCRIPTION
Closes #366. First of the billing epic (#370).

Records what a tenant is entitled to, mirrored from Stripe — so a request can decide entitlements without a network round-trip, and the app still works when Stripe is unreachable.

## Decisions that are not obvious

All pinned by tests, because each is a place where being wrong silently grants or revokes paid access.

**Entitlement is derived, not stored.** `effective_tier` returns `FREE` unless the subscription is entitled, so a canceled subscription stops granting the tier it records *without anything having to write to it*. Reading `plan_tier` directly would keep serving PRO limits after cancellation.

**Past-due keeps access.** Stripe retries a failed payment for days; cutting a paying customer off at the first failure is worse than serving them through a card that is about to be updated. Canceled does not.

**Unknown Stripe statuses fail closed.** `from_stripe` maps the seven statuses Stripe sends today explicitly; anything else becomes `INCOMPLETE`, not `ACTIVE`. Stripe can add statuses, and a silent grant is the expensive direction to be wrong in.

**No document means FREE**, so enforcement never depends on a backfill having run.

**Unique index on `user_id`** — this is what will make the #367 webhook upsert idempotent under Stripe's at-least-once retries, so it is tested against real Mongo rather than assumed.

## The plan limits are an assumption — please replace them

#365–#369 specify the *mechanism* and never the tiers, limits or pricing. I said I would need those from you and you asked me to proceed, so they are stated explicitly rather than buried:

| | training runs | predictions | uploads |
|---|---|---|---|
| free | 10 | 1,000 | 20 |
| pro | 200 | 100,000 | 500 |
| enterprise | unlimited | unlimited | unlimited |

Chosen so the invite-only beta stays usable the moment enforcement is switched on. They live in `app/billing/plans.py` with env overrides (`PLAN_FREE_TRAINING_RUNS`, …), so changing them is a config edit — and they are flagged as placeholders in ADR-002. **Do not charge anyone against these numbers.**

A malformed override falls back to the default rather than failing, because an outage over a typo in a number that has a perfectly good default is not a trade worth making. Tested.

## Test split, deliberately

- `tests/test_models/test_subscription.py` — entitlement logic with **no database**, via `model_construct`. `Subscription(...)` raises `CollectionWasNotInitialized` outside an initialised Beanie app, and this module is in the **service-free CI selection**; requiring Mongo here would have quietly taken it out of that run.
- `tests/test_api/test_subscription_persistence.py` — the unique index and Stripe-id lookups, which genuinely need Mongo.

## ADR

ADR-001 deferred billing for the free beta. That was right then and is not the operative decision now, so it is marked **Superseded** and **ADR-002** records what shipped and why.

An ADR saying "billing is deferred" sitting beside shipped billing code is a stale record that misleads the next reader — and editing ADR-001 to pretend it always said this would be worse than either decision.

## Gates

- `pytest tests/test_models/ tests/test_api/test_subscription_persistence.py` — 124 passed
- `ruff check app/ tests/` clean
- `mypy app/` clean (171 files)
- Service-free selection verified to still run without Mongo

## Next in the epic

#369 (metering) → #367 (webhook) → #365 (checkout/portal) → #368 (enforcement) → #370 closes.