### PR TITLE
style(backend): collapse a 3-blank-line run in plans.py (#423 review)

### DIFF
--- a/apps/backend/app/billing/plans.py
+++ b/apps/backend/app/billing/plans.py
@@ -87,7 +87,6 @@ PLAN_LIMITS: dict[PlanTier, PlanLimits] = {
 }
 
 
-
 def limits_for(tier: PlanTier) -> PlanLimits:
     """Limits for a tier, falling back to FREE for anything unrecognised."""
     return PLAN_LIMITS.get(tier, PLAN_LIMITS[PlanTier.FREE])


### PR DESCRIPTION
Cosmetic follow-up to the last review note on #423.

The reviewer expected `ruff` `E303` to reject the 3-blank-line run between `PLAN_LIMITS` and `limits_for`. Worth checking rather than assuming: `ruff check` reports **clean**, so `E303` is not enabled in this configuration. The gap was real; the predicted failure was not.

Tidied regardless, since it was unintentional.

No behaviour change. `ruff` clean, subscription tests pass.