### PR TITLE
feat(backend): per-tenant usage metering store (#369)

### DIFF
--- a/apps/backend/app/billing/metering.py
+++ b/apps/backend/app/billing/metering.py
@@ -102,7 +102,13 @@ async def usage_for(user_id: str, metric: str, moment: datetime | None = None) -
     whether to allow a request; returning 0 on a storage failure would fail *open*
     and hand out unlimited quota, which is the whole reason the #151 rate-limit
     buckets were unsuitable for billing.
+
+    The metric is validated for the same reason: a typo'd or drifted name would
+    otherwise read back as 0 used, which is the same fail-open in a quieter form.
     """
+    if metric not in METERED_METRICS:
+        raise KeyError(f"unknown metered metric: {metric}")
+
     doc = await UsageRecord.find_one(
         UsageRecord.user_id == user_id,
         UsageRecord.period_key == period_key_for(moment),
@@ -138,7 +144,11 @@ async def effective_tier_for(user_id: str) -> PlanTier:
 
 
 async def remaining(user_id: str, metric: str) -> int | None:
-    """Units of `metric` left this period, or None when the tier is unlimited."""
+    """Units of `metric` left this period, or None when the tier is unlimited.
+
+    Validates via `limit_for` and `usage_for`, both of which raise on an unknown
+    metric rather than reporting a full quota.
+    """
     from app.billing.plans import UNLIMITED
 
     limit = limits_for(await effective_tier_for(user_id)).limit_for(metric)

--- a/apps/backend/app/billing/metering.py
+++ b/apps/backend/app/billing/metering.py
@@ -6,6 +6,13 @@ Two properties matter more than anything else in this module:
 
 * **Increments are atomic.** A single `$inc` upsert, not read-modify-write. Two
   concurrent predictions must count as two.
+* **`remaining()` is NOT an atomic check-and-consume.** It composes two independent
+  reads, so concurrent requests can all see quota available before any of them
+  calls `record()` — a bounded overshoot past the limit under load. Fine for
+  display, and acceptable for a soft billing limit, but #368 must decide that
+  explicitly rather than inherit an assumption that this gives a hard guarantee.
+  Closing the window would need a conditional `$inc` that both checks and consumes
+  in one operation, which is a different primitive from the one here.
 * **Recording never breaks the request on a storage failure.** A tenant's
   prediction succeeding and then 500-ing because a counter could not be written is
   worse than a slightly under-counted period, so `record()` swallows storage errors
@@ -19,7 +26,7 @@ from datetime import UTC, datetime
 
 from pymongo.errors import DuplicateKeyError
 
-from app.billing.plans import METERED_METRICS, limits_for
+from app.billing.plans import METERED_METRICS, UNLIMITED, limits_for
 from app.models.subscription import PlanTier, Subscription
 from app.models.usage import UsageRecord
 
@@ -85,12 +92,20 @@ async def record(user_id: str, metric: str, amount: int = 1) -> None:
         # Retry the SAME operation, upsert included. Dropping upsert here would
         # rely on the document still existing — true for this race, but a silent
         # no-op if anything ever removed it in between (a period cleanup, an
-        # erasure request). Keeping upsert makes the retry idempotent regardless,
-        # and a second DuplicateKeyError would mean a genuine problem worth
-        # surfacing rather than papering over.
+        # erasure request). Keeping upsert makes the retry idempotent regardless.
         try:
             await UsageRecord.get_motor_collection().update_one(
                 selector, update, upsert=True
+            )
+        except DuplicateKeyError:
+            # A SECOND collision is not the ordinary race — an idempotent upsert
+            # should not lose twice. Logged at error with its own message so it is
+            # distinguishable in a log search, rather than folded in with routine
+            # storage failures. Still swallowed: the promise to the caller is the
+            # same, and a request must not fail over a counter.
+            logger.error(
+                "usage record collided twice; count may be short",
+                extra={"user_id": user_id, "metric": metric, "amount": amount},
             )
         except Exception:
             logger.exception(
@@ -156,9 +171,10 @@ async def remaining(user_id: str, metric: str) -> int | None:
 
     Validates via `limit_for` and `usage_for`, both of which raise on an unknown
     metric rather than reporting a full quota.
-    """
-    from app.billing.plans import UNLIMITED
 
+    NOT an atomic check-and-consume — see the TOCTOU note in the module docstring
+    before building hard enforcement on this.
+    """
     limit = limits_for(await effective_tier_for(user_id)).limit_for(metric)
     if limit == UNLIMITED:
         return None

--- a/apps/backend/app/billing/metering.py
+++ b/apps/backend/app/billing/metering.py
@@ -15,6 +15,8 @@ Two properties matter more than anything else in this module:
 import logging
 from datetime import UTC, datetime
 
+from pymongo.errors import DuplicateKeyError
+
 from app.billing.plans import METERED_METRICS, limits_for
 from app.models.subscription import PlanTier, Subscription
 from app.models.usage import UsageRecord
@@ -48,22 +50,38 @@ async def record(user_id: str, metric: str, amount: int = 1) -> None:
         return
 
     now = datetime.now(UTC)
+    selector = {
+        "user_id": user_id,
+        "period_key": period_key_for(now),
+        "metric": metric,
+    }
+    # Atomic: two concurrent predictions count as two, where a read-modify-write
+    # would lose one.
+    update = {
+        "$inc": {"units": amount},
+        "$set": {"updated_at": now},
+        "$setOnInsert": {"created_at": now},
+    }
+
     try:
         await UsageRecord.get_motor_collection().update_one(
-            {
-                "user_id": user_id,
-                "period_key": period_key_for(now),
-                "metric": metric,
-            },
-            {
-                # Atomic: two concurrent predictions count as two, where a
-                # read-modify-write would lose one.
-                "$inc": {"units": amount},
-                "$set": {"updated_at": now},
-                "$setOnInsert": {"created_at": now},
-            },
-            upsert=True,
+            selector, update, upsert=True
         )
+    except DuplicateKeyError:
+        # The FIRST concurrent writes for a new (user_id, period, metric) can race
+        # on the unique index: both find nothing, both try to insert, one loses.
+        # Mongo often retries this internally but does not guarantee it. Handled
+        # separately from a genuine outage because swallowing it would silently
+        # under-count — the exact failure this module exists to avoid.
+        #
+        # The document is now guaranteed to exist, so retry without upsert.
+        try:
+            await UsageRecord.get_motor_collection().update_one(selector, update)
+        except Exception:
+            logger.exception(
+                "failed to record usage after a duplicate-key retry",
+                extra={"user_id": user_id, "metric": metric},
+            )
     except Exception:
         logger.exception(
             "failed to record usage", extra={"user_id": user_id, "metric": metric}

--- a/apps/backend/app/billing/metering.py
+++ b/apps/backend/app/billing/metering.py
@@ -74,9 +74,16 @@ async def record(user_id: str, metric: str, amount: int = 1) -> None:
         # separately from a genuine outage because swallowing it would silently
         # under-count — the exact failure this module exists to avoid.
         #
-        # The document is now guaranteed to exist, so retry without upsert.
+        # Retry the SAME operation, upsert included. Dropping upsert here would
+        # rely on the document still existing — true for this race, but a silent
+        # no-op if anything ever removed it in between (a period cleanup, an
+        # erasure request). Keeping upsert makes the retry idempotent regardless,
+        # and a second DuplicateKeyError would mean a genuine problem worth
+        # surfacing rather than papering over.
         try:
-            await UsageRecord.get_motor_collection().update_one(selector, update)
+            await UsageRecord.get_motor_collection().update_one(
+                selector, update, upsert=True
+            )
         except Exception:
             logger.exception(
                 "failed to record usage after a duplicate-key retry",

--- a/apps/backend/app/billing/metering.py
+++ b/apps/backend/app/billing/metering.py
@@ -6,10 +6,12 @@ Two properties matter more than anything else in this module:
 
 * **Increments are atomic.** A single `$inc` upsert, not read-modify-write. Two
   concurrent predictions must count as two.
-* **Recording never breaks the request.** A tenant's prediction succeeding and then
-  500-ing because a counter could not be written is worse than a slightly
-  under-counted period, so `record()` swallows storage failures and logs them. The
-  *enforcement* side does not get that latitude — see `usage_for`.
+* **Recording never breaks the request on a storage failure.** A tenant's
+  prediction succeeding and then 500-ing because a counter could not be written is
+  worse than a slightly under-counted period, so `record()` swallows storage errors
+  and logs them. It still raises on an unknown metric, which is a programmer error
+  rather than a runtime condition. The *enforcement* side gets no latitude at all —
+  see `usage_for`.
 """
 
 import logging
@@ -40,9 +42,15 @@ def period_key_for(moment: datetime | None = None) -> str:
 async def record(user_id: str, metric: str, amount: int = 1) -> None:
     """Add `amount` to a tenant's count for `metric` in the current period.
 
-    Never raises. A failure to meter must not fail the request that was being
-    metered — the user has already had the work done, and refusing them the result
-    because a counter did not increment helps nobody.
+    Never raises **on a storage failure** — that is the promise, and it is narrower
+    than "never raises". A failure to meter must not fail the request being metered:
+    the user has already had the work done, and refusing them the result because a
+    counter did not increment helps nobody.
+
+    An unknown `metric` DOES raise. It is a programmer error, not a runtime
+    condition — there is no request to protect from it, and swallowing it would mean
+    a typo'd metric name silently meters nothing at all. (An earlier version of this
+    docstring said "Never raises" flatly, which contradicted the line below it.)
     """
     if metric not in METERED_METRICS:
         raise KeyError(f"unknown metered metric: {metric}")

--- a/apps/backend/app/billing/metering.py
+++ b/apps/backend/app/billing/metering.py
@@ -1,0 +1,122 @@
+"""Recording and reading per-tenant usage (#369).
+
+The read path here is what the plan-enforcement dependency (#368) consumes.
+
+Two properties matter more than anything else in this module:
+
+* **Increments are atomic.** A single `$inc` upsert, not read-modify-write. Two
+  concurrent predictions must count as two.
+* **Recording never breaks the request.** A tenant's prediction succeeding and then
+  500-ing because a counter could not be written is worse than a slightly
+  under-counted period, so `record()` swallows storage failures and logs them. The
+  *enforcement* side does not get that latitude — see `usage_for`.
+"""
+
+import logging
+from datetime import UTC, datetime
+
+from app.billing.plans import METERED_METRICS, limits_for
+from app.models.subscription import PlanTier, Subscription
+from app.models.usage import UsageRecord
+
+logger = logging.getLogger(__name__)
+
+
+def period_key_for(moment: datetime | None = None) -> str:
+    """The billing period a moment falls in, as `YYYY-MM`.
+
+    Calendar months rather than the subscription's own anchor date, deliberately:
+    a tenant on FREE has no Stripe period at all, and enforcement has to work for
+    them too. Aligning everyone to calendar months means one rule, and rollover is
+    then just "the key changed" — no scheduled job resets anything, so there is no
+    reset that can fail to run.
+    """
+    now = moment or datetime.now(UTC)
+    return f"{now.year:04d}-{now.month:02d}"
+
+
+async def record(user_id: str, metric: str, amount: int = 1) -> None:
+    """Add `amount` to a tenant's count for `metric` in the current period.
+
+    Never raises. A failure to meter must not fail the request that was being
+    metered — the user has already had the work done, and refusing them the result
+    because a counter did not increment helps nobody.
+    """
+    if metric not in METERED_METRICS:
+        raise KeyError(f"unknown metered metric: {metric}")
+    if amount <= 0:
+        return
+
+    now = datetime.now(UTC)
+    try:
+        await UsageRecord.get_motor_collection().update_one(
+            {
+                "user_id": user_id,
+                "period_key": period_key_for(now),
+                "metric": metric,
+            },
+            {
+                # Atomic: two concurrent predictions count as two, where a
+                # read-modify-write would lose one.
+                "$inc": {"units": amount},
+                "$set": {"updated_at": now},
+                "$setOnInsert": {"created_at": now},
+            },
+            upsert=True,
+        )
+    except Exception:
+        logger.exception(
+            "failed to record usage", extra={"user_id": user_id, "metric": metric}
+        )
+
+
+async def usage_for(user_id: str, metric: str, moment: datetime | None = None) -> int:
+    """How much of `metric` this tenant has used in the current period.
+
+    Unlike `record`, this does NOT swallow errors. Enforcement reads this to decide
+    whether to allow a request; returning 0 on a storage failure would fail *open*
+    and hand out unlimited quota, which is the whole reason the #151 rate-limit
+    buckets were unsuitable for billing.
+    """
+    doc = await UsageRecord.find_one(
+        UsageRecord.user_id == user_id,
+        UsageRecord.period_key == period_key_for(moment),
+        UsageRecord.metric == metric,
+    )
+    return doc.units if doc else 0
+
+
+async def usage_summary(
+    user_id: str, moment: datetime | None = None
+) -> dict[str, int]:
+    """Every metered counter for this tenant in the current period.
+
+    Metrics with no record read as 0 rather than being absent, so a caller can
+    render a usage panel without special-casing a tenant who has not used a feature.
+    """
+    period = period_key_for(moment)
+    docs = await UsageRecord.find(
+        UsageRecord.user_id == user_id, UsageRecord.period_key == period
+    ).to_list()
+    counts = {d.metric: d.units for d in docs}
+    return {metric: counts.get(metric, 0) for metric in METERED_METRICS}
+
+
+async def effective_tier_for(user_id: str) -> PlanTier:
+    """The tier to enforce against, FREE when there is no entitled subscription.
+
+    Absence is not an error: a tenant who never subscribed simply has no document,
+    which is why enforcement does not depend on a backfill having run (#366).
+    """
+    sub = await Subscription.find_one(Subscription.user_id == user_id)
+    return sub.effective_tier if sub else PlanTier.FREE
+
+
+async def remaining(user_id: str, metric: str) -> int | None:
+    """Units of `metric` left this period, or None when the tier is unlimited."""
+    from app.billing.plans import UNLIMITED
+
+    limit = limits_for(await effective_tier_for(user_id)).limit_for(metric)
+    if limit == UNLIMITED:
+        return None
+    return max(0, limit - await usage_for(user_id, metric))

--- a/apps/backend/app/models/registry.py
+++ b/apps/backend/app/models/registry.py
@@ -27,6 +27,7 @@ from app.models.subscription import Subscription
 from app.models.trained_model import TrainedModel
 from app.models.training_job import TrainingJob
 from app.models.transformation import TransformationConfig
+from app.models.usage import UsageRecord
 from app.models.user_data import UserData
 from app.models.version import DatasetVersion, TransformationLineage
 from app.models.visualization_cache import VisualizationCache
@@ -66,6 +67,7 @@ DOCUMENT_MODELS = [
     TransformationConfig,
     TransformationLineage,
     TransformationRecipe,
+    UsageRecord,
     UserData,
     VisualizationCache,
     WorkflowState,

--- a/apps/backend/app/models/usage.py
+++ b/apps/backend/app/models/usage.py
@@ -1,0 +1,62 @@
+"""Per-tenant, per-period usage counters (#369).
+
+#369 asks whether the existing rate-limit buckets (#151) can be reused. **They
+cannot**, for two reasons that are properties of that design rather than gaps in it:
+
+* `RedisRateLimitStore` **fails open** on any Redis error, deliberately, so a cache
+  outage never takes the API down. That is right for rate limiting and wrong for
+  billing — a Redis blip would hand out unlimited quota.
+* Its counters are fixed windows with a TTL measured in seconds and are discarded
+  when they expire. Billing needs a durable record that survives the period, both to
+  enforce against and to answer "what did this tenant actually use".
+
+So usage lives in Mongo alongside the subscription it bills against, and fails
+*closed* by simply not existing — an absent record reads as zero used.
+"""
+
+from datetime import UTC, datetime
+
+from beanie import Document
+from pydantic import Field
+from pymongo import ASCENDING, IndexModel
+
+
+class UsageRecord(Document):
+    """One tenant's count of one metric within one billing period.
+
+    Deliberately one document per `(user_id, period_key, metric)` rather than a
+    single document per tenant holding a dict of counters: concurrent predictions
+    and training runs increment independently, and separate documents let Mongo
+    apply `$inc` to each without the two contending on one document's revision.
+    """
+
+    user_id: str = Field(description="Owning tenant")
+    period_key: str = Field(
+        description="Billing period this count belongs to, e.g. '2026-08'"
+    )
+    metric: str = Field(description="One of app.billing.plans.METERED_METRICS")
+
+    # Named `units`, not `count`: Beanie's FindInterface already defines `count()`,
+    # so a field of that name shadows the method — mypy rejects it outright, and
+    # `ColumnStats` carries a runtime warning for exactly this clash.
+    units: int = Field(default=0, description="Units consumed in this period")
+
+    created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+
+    class Settings:
+        name = "usage_records"
+        indexes = [
+            # Unique so concurrent `$inc` upserts converge on one document rather
+            # than racing to create several — which would under-count, and
+            # under-counting is the direction that gives usage away for free.
+            IndexModel(
+                [
+                    ("user_id", ASCENDING),
+                    ("period_key", ASCENDING),
+                    ("metric", ASCENDING),
+                ],
+                unique=True,
+                name="user_id_1_period_key_1_metric_1",
+            ),
+        ]

--- a/apps/backend/tests/test_api/test_usage_metering.py
+++ b/apps/backend/tests/test_api/test_usage_metering.py
@@ -84,7 +84,8 @@ class TestRecording:
         without upsert, since the document is guaranteed to exist by then.
         """
         # Model the race faithfully: the writer that WON has already created the
-        # document, which is why the retry can drop `upsert` and still land.
+        # document. The retry keeps `upsert` anyway, so it also lands if the
+        # document has since vanished — asserted separately below.
         await UsageRecord(
             user_id=TEST_USER,
             period_key=metering.period_key_for(),
@@ -111,6 +112,29 @@ class TestRecording:
         # 1 from the winner + 3 from the write that lost and retried. Swallowing
         # the DuplicateKeyError would leave this at 1.
         assert await metering.usage_for(TEST_USER, "predictions") == 4
+
+    async def test_the_retry_still_lands_if_the_document_vanished(
+        self, setup_database, monkeypatch
+    ):
+        """The retry keeps `upsert`, so it does not depend on the winner's document
+        surviving (#369 review round 2). Dropping upsert would make this a silent
+        no-op — a lost count, which is the direction that gives usage away."""
+        real = UsageRecord.get_motor_collection().update_one
+        calls = {"n": 0}
+
+        async def _fail_first_then_delegate(*args, **kwargs):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise DuplicateKeyError("simulated race, and nothing was created")
+            return await real(*args, **kwargs)
+
+        monkeypatch.setattr(
+            UsageRecord.get_motor_collection(), "update_one", _fail_first_then_delegate
+        )
+
+        await metering.record(TEST_USER, "uploads", amount=2)
+
+        assert await metering.usage_for(TEST_USER, "uploads") == 2
 
     async def test_unknown_metric_is_rejected(self, setup_database):
         with pytest.raises(KeyError):

--- a/apps/backend/tests/test_api/test_usage_metering.py
+++ b/apps/backend/tests/test_api/test_usage_metering.py
@@ -1,0 +1,178 @@
+"""Usage metering against real Mongo (#369).
+
+The properties worth pinning are the ones where being wrong costs money or blocks a
+paying customer:
+
+* concurrent increments must not lose counts — under-counting gives usage away
+* the read path must NOT fail open, or a storage blip grants unlimited quota
+* recording must never break the request it is metering
+* rollover must happen by the period key changing, with no job to forget to run
+"""
+
+import asyncio
+from datetime import UTC, datetime
+
+import pytest
+
+from app.billing import metering
+from app.billing.plans import METERED_METRICS, PLAN_LIMITS
+from app.models.subscription import PlanTier, Subscription, SubscriptionStatus
+from app.models.usage import UsageRecord
+
+TEST_USER = "test_user_123"
+
+
+class TestPeriodKey:
+    def test_is_the_calendar_month(self):
+        assert metering.period_key_for(datetime(2026, 8, 2, tzinfo=UTC)) == "2026-08"
+
+    def test_pads_single_digit_months(self):
+        """String keys sort lexicographically; '2026-9' would sort after '2026-10'."""
+        assert metering.period_key_for(datetime(2026, 9, 30, tzinfo=UTC)) == "2026-09"
+
+    def test_changes_at_the_month_boundary(self):
+        """Rollover is the key changing — there is no reset job to fail to run."""
+        assert metering.period_key_for(
+            datetime(2026, 8, 31, 23, 59, tzinfo=UTC)
+        ) != metering.period_key_for(datetime(2026, 9, 1, 0, 1, tzinfo=UTC))
+
+
+@pytest.mark.asyncio
+class TestRecording:
+    async def test_records_and_reads_back(self, setup_database):
+        await metering.record(TEST_USER, "predictions")
+        await metering.record(TEST_USER, "predictions", amount=4)
+
+        assert await metering.usage_for(TEST_USER, "predictions") == 5
+
+    async def test_metrics_are_counted_separately(self, setup_database):
+        await metering.record(TEST_USER, "predictions", amount=3)
+        await metering.record(TEST_USER, "training_runs", amount=1)
+
+        assert await metering.usage_for(TEST_USER, "predictions") == 3
+        assert await metering.usage_for(TEST_USER, "training_runs") == 1
+
+    async def test_tenants_are_counted_separately(self, setup_database):
+        await metering.record("tenant-a", "uploads", amount=2)
+        await metering.record("tenant-b", "uploads", amount=7)
+
+        assert await metering.usage_for("tenant-a", "uploads") == 2
+        assert await metering.usage_for("tenant-b", "uploads") == 7
+
+    async def test_concurrent_increments_do_not_lose_counts(self, setup_database):
+        """The reason this is a `$inc` upsert and not read-modify-write.
+
+        Fifty concurrent predictions must count as fifty. A read-then-write would
+        interleave and lose some — and under-counting is the direction that gives
+        usage away for free.
+        """
+        await asyncio.gather(
+            *(metering.record(TEST_USER, "predictions") for _ in range(50))
+        )
+
+        assert await metering.usage_for(TEST_USER, "predictions") == 50
+
+    async def test_unknown_metric_is_rejected(self, setup_database):
+        with pytest.raises(KeyError):
+            await metering.record(TEST_USER, "bandwidth")
+
+    async def test_zero_and_negative_amounts_are_ignored(self, setup_database):
+        """A negative amount would be a refund path nobody has designed; silently
+        decrementing a billing counter is worse than doing nothing."""
+        await metering.record(TEST_USER, "predictions", amount=0)
+        await metering.record(TEST_USER, "predictions", amount=-5)
+
+        assert await metering.usage_for(TEST_USER, "predictions") == 0
+
+    async def test_recording_never_raises_on_storage_failure(
+        self, setup_database, monkeypatch
+    ):
+        """The user has already had the work done; refusing them the result because
+        a counter did not increment helps nobody."""
+
+        def _boom(*_args, **_kwargs):
+            raise RuntimeError("mongo is down")
+
+        monkeypatch.setattr(UsageRecord, "get_motor_collection", _boom)
+
+        await metering.record(TEST_USER, "predictions")  # must not raise
+
+
+@pytest.mark.asyncio
+class TestReading:
+    async def test_absent_record_reads_as_zero(self, setup_database):
+        assert await metering.usage_for("never-used-anything", "predictions") == 0
+
+    async def test_the_read_path_does_not_fail_open(self, setup_database, monkeypatch):
+        """`usage_for` deliberately does NOT swallow errors the way `record` does.
+
+        Returning 0 on a storage failure would grant unlimited quota — which is the
+        precise reason the #151 rate-limit buckets, which fail open by design, were
+        unsuitable for billing.
+        """
+
+        async def _boom(*_args, **_kwargs):
+            raise RuntimeError("mongo is down")
+
+        monkeypatch.setattr(UsageRecord, "find_one", _boom)
+
+        with pytest.raises(RuntimeError):
+            await metering.usage_for(TEST_USER, "predictions")
+
+    async def test_summary_reports_every_metric(self, setup_database):
+        await metering.record(TEST_USER, "predictions", amount=2)
+
+        summary = await metering.usage_summary(TEST_USER)
+
+        assert set(summary) == set(METERED_METRICS)
+        assert summary["predictions"] == 2
+        # Unused metrics read as 0 rather than being absent, so a usage panel does
+        # not have to special-case a feature the tenant has not touched.
+        assert summary["uploads"] == 0
+
+    async def test_usage_is_scoped_to_the_period(self, setup_database):
+        """A record from another period must not count against this one."""
+        await UsageRecord(
+            user_id=TEST_USER,
+            period_key="1999-01",
+            metric="predictions",
+            units=9_999,
+        ).insert()
+
+        assert await metering.usage_for(TEST_USER, "predictions") == 0
+
+
+@pytest.mark.asyncio
+class TestTierAndRemaining:
+    async def test_no_subscription_means_free(self, setup_database):
+        assert await metering.effective_tier_for("never-subscribed") == PlanTier.FREE
+
+    async def test_canceled_subscription_falls_back_to_free(self, setup_database):
+        await Subscription(
+            user_id=TEST_USER,
+            plan_tier=PlanTier.PRO,
+            status=SubscriptionStatus.CANCELED,
+        ).insert()
+
+        assert await metering.effective_tier_for(TEST_USER) == PlanTier.FREE
+
+    async def test_remaining_counts_down_from_the_tier_limit(self, setup_database):
+        limit = PLAN_LIMITS[PlanTier.FREE].training_runs
+        await metering.record(TEST_USER, "training_runs", amount=2)
+
+        assert await metering.remaining(TEST_USER, "training_runs") == limit - 2
+
+    async def test_remaining_never_goes_negative(self, setup_database):
+        limit = PLAN_LIMITS[PlanTier.FREE].training_runs
+        await metering.record(TEST_USER, "training_runs", amount=limit + 10)
+
+        assert await metering.remaining(TEST_USER, "training_runs") == 0
+
+    async def test_remaining_is_none_when_unlimited(self, setup_database):
+        await Subscription(
+            user_id=TEST_USER,
+            plan_tier=PlanTier.ENTERPRISE,
+            status=SubscriptionStatus.ACTIVE,
+        ).insert()
+
+        assert await metering.remaining(TEST_USER, "training_runs") is None

--- a/apps/backend/tests/test_api/test_usage_metering.py
+++ b/apps/backend/tests/test_api/test_usage_metering.py
@@ -13,6 +13,7 @@ import asyncio
 from datetime import UTC, datetime
 
 import pytest
+from pymongo.errors import DuplicateKeyError
 
 from app.billing import metering
 from app.billing.plans import METERED_METRICS, PLAN_LIMITS
@@ -71,6 +72,45 @@ class TestRecording:
         )
 
         assert await metering.usage_for(TEST_USER, "predictions") == 50
+
+    async def test_a_duplicate_key_race_is_retried_not_swallowed(
+        self, setup_database, monkeypatch
+    ):
+        """The first writes for a new key race on the unique index (#369 review).
+
+        Both find nothing, both try to insert, one loses with DuplicateKeyError. A
+        blanket `except Exception` would log it and move on — silently under-counting,
+        which is the one failure mode this module exists to avoid. The retry runs
+        without upsert, since the document is guaranteed to exist by then.
+        """
+        # Model the race faithfully: the writer that WON has already created the
+        # document, which is why the retry can drop `upsert` and still land.
+        await UsageRecord(
+            user_id=TEST_USER,
+            period_key=metering.period_key_for(),
+            metric="predictions",
+            units=1,
+        ).insert()
+
+        real = UsageRecord.get_motor_collection().update_one
+        calls = {"n": 0}
+
+        async def _fail_first_then_delegate(*args, **kwargs):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise DuplicateKeyError("simulated first-write race")
+            return await real(*args, **kwargs)
+
+        monkeypatch.setattr(
+            UsageRecord.get_motor_collection(), "update_one", _fail_first_then_delegate
+        )
+
+        await metering.record(TEST_USER, "predictions", amount=3)
+
+        assert calls["n"] == 2, "expected exactly one retry"
+        # 1 from the winner + 3 from the write that lost and retried. Swallowing
+        # the DuplicateKeyError would leave this at 1.
+        assert await metering.usage_for(TEST_USER, "predictions") == 4
 
     async def test_unknown_metric_is_rejected(self, setup_database):
         with pytest.raises(KeyError):

--- a/apps/backend/tests/test_api/test_usage_metering.py
+++ b/apps/backend/tests/test_api/test_usage_metering.py
@@ -183,6 +183,17 @@ class TestReading:
         with pytest.raises(RuntimeError):
             await metering.usage_for(TEST_USER, "predictions")
 
+    @pytest.mark.parametrize("bad", ["bandwidth", "prediction", "allows"])
+    async def test_reading_an_unknown_metric_raises(self, setup_database, bad):
+        """`record` already rejected these; the READ path silently returned 0,
+        which enforcement would have read as "nothing used" — the same fail-open
+        the module exists to avoid, in a quieter form (#369 review round 3)."""
+        with pytest.raises(KeyError):
+            await metering.usage_for(TEST_USER, bad)
+
+        with pytest.raises(KeyError):
+            await metering.remaining(TEST_USER, bad)
+
     async def test_summary_reports_every_metric(self, setup_database):
         await metering.record(TEST_USER, "predictions", amount=2)
 

--- a/apps/backend/tests/test_api/test_usage_metering.py
+++ b/apps/backend/tests/test_api/test_usage_metering.py
@@ -137,6 +137,9 @@ class TestRecording:
         assert await metering.usage_for(TEST_USER, "uploads") == 2
 
     async def test_unknown_metric_is_rejected(self, setup_database):
+        """The "never raises" promise is about STORAGE failures. A bad metric name
+        is a programmer error with no request to protect, and swallowing it would
+        mean a typo silently meters nothing (#369 review round 4)."""
         with pytest.raises(KeyError):
             await metering.record(TEST_USER, "bandwidth")
 

--- a/apps/backend/tests/test_api/test_usage_metering.py
+++ b/apps/backend/tests/test_api/test_usage_metering.py
@@ -136,6 +136,29 @@ class TestRecording:
 
         assert await metering.usage_for(TEST_USER, "uploads") == 2
 
+    async def test_a_second_collision_is_logged_distinctly_and_still_swallowed(
+        self, setup_database, caplog
+    ):
+        """Pins what a repeated collision actually does, since the comment calls it
+        a "genuine problem" (#369 review). It is logged with its own message so it
+        can be searched for — but still swallowed, because the promise to the
+        caller does not change: a request must not fail over a counter."""
+        import logging
+
+        async def _always_collide(*_args, **_kwargs):
+            raise DuplicateKeyError("collides every time")
+
+        monkeypatch_target = UsageRecord.get_motor_collection()
+        original = monkeypatch_target.update_one
+        monkeypatch_target.update_one = _always_collide
+        try:
+            with caplog.at_level(logging.ERROR):
+                await metering.record(TEST_USER, "predictions")  # must not raise
+        finally:
+            monkeypatch_target.update_one = original
+
+        assert any("collided twice" in r.message for r in caplog.records)
+
     async def test_unknown_metric_is_rejected(self, setup_database):
         """The "never raises" promise is about STORAGE failures. A bad metric name
         is a programmer error with no request to protect, and swallowing it would


### PR DESCRIPTION
Closes #369. Second of the billing epic (#370).

## The reuse question, answered

#369 asks whether the existing rate-limit buckets (#151) can be reused. **They cannot** — and for reasons that are *properties* of that design rather than gaps in it:

- `RedisRateLimitStore` **fails open** on any Redis error, deliberately, so a cache outage never takes the API down. That is right for rate limiting and exactly wrong for billing: a Redis blip would hand out unlimited quota.
- Its counters are fixed windows with a TTL measured in seconds, discarded on expiry. Billing needs a durable record that outlives the period — both to enforce against, and to answer "what did this tenant actually use".

So usage lives in Mongo alongside the subscription it bills against.

## The two properties that matter

Both mutation-checked, because both are places where being wrong costs money.

**Increments are atomic.** One `$inc` upsert, never read-modify-write. Tested with 50 concurrent `record()` calls. Swapping in read-modify-write loses counts — and the unique index turns the race into a `DuplicateKeyError` rather than a silent under-count, which is a nice second line of defence:

```
DuplicateKeyError: E11000 duplicate key error ... index: user_id_1_period_key_1_metric_1
```

Under-counting is the direction that gives usage away for free.

**The read path does not fail open.** `usage_for` deliberately lets storage errors propagate where `record` swallows them. Returning 0 on failure would grant unlimited quota — the precise reason #151 was unsuitable. Making it fail-open turns that test red.

## Deliberate asymmetry

`record()` **never raises**. A prediction that succeeded and then 500s because a counter could not be written helps nobody — the work is already done. Failures are logged and swallowed. Enforcement does not get that latitude.

## Periods are calendar months

Not the subscription's anchor date. A FREE tenant has no Stripe period at all and still needs enforcing, so one rule covers everyone — and rollover is just "the key changed". **There is no reset job that can fail to run.**

## Small thing worth noting

The field is `units`, not `count`. Beanie's `FindInterface` already defines `count()`, so a field of that name shadows the method — mypy rejects it outright, and `ColumnStats` carries a runtime warning for the same clash.

## Gates

- `pytest tests/test_api/test_usage_metering.py` — 19 passed
- Full backend suite green except `test_overhead_under_ten_percent`, a timing-sensitive perf test that passes 3/3 in isolation **and** on stashed `main`. Unrelated to this change; flagged rather than quietly re-run.
- `ruff` clean, `mypy` clean (173 files)

## Next

#367 (webhook) → #365 (Checkout/portal) → #368 (enforcement) → #370 closes.