### PR TITLE
feat: Stripe Checkout + customer portal (#365)

### DIFF
--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -5,7 +5,9 @@ MONGODB_URI=mongodb://localhost:27017/
 MONGODB_DB=narrative-modeling
 
 # CORS
-BACKEND_CORS_ORIGINS=[http://localhost:3000]
+# JSON array or comma-separated. Bracketed-unquoted is tolerated, but a plain
+# comma-separated list is the least ambiguous form.
+BACKEND_CORS_ORIGINS=http://localhost:3000,http://localhost:3001
 
 # Redis (shared by the cache service and the rate-limit middleware). Leave empty
 # to run without Redis — the limiter then uses a process-local in-memory store.

--- a/apps/backend/app/api/routes/billing.py
+++ b/apps/backend/app/api/routes/billing.py
@@ -19,7 +19,7 @@ from pydantic import BaseModel, Field
 
 from app.auth.nextauth_auth import get_current_user_id
 from app.billing import metering, stripe_client
-from app.billing.plans import UNLIMITED, limits_for
+from app.billing.plans import limits_for
 from app.config import settings
 from app.models.subscription import PlanTier, Subscription
 
@@ -214,4 +214,4 @@ async def open_portal(
         ) from exc
 
 
-__all__ = ["router", "UNLIMITED"]
+__all__ = ["router"]

--- a/apps/backend/app/api/routes/billing.py
+++ b/apps/backend/app/api/routes/billing.py
@@ -1,0 +1,149 @@
+"""Billing endpoints the frontend calls (#365).
+
+Three routes, all scoped to the caller's own tenant:
+
+* `GET  /billing/status`   — what this tenant is on, and what it has used
+* `POST /billing/checkout` — start a paid subscription
+* `POST /billing/portal`   — manage an existing one
+
+`user_id` always comes from the authenticated session, never from the request
+body. A tenant id accepted from a caller would let anyone start a subscription
+against — or read the usage of — someone else's account.
+"""
+
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field
+
+from app.auth.nextauth_auth import get_current_user_id
+from app.billing import metering, stripe_client
+from app.billing.plans import UNLIMITED, limits_for
+from app.config import settings
+from app.models.subscription import PlanTier, Subscription
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+class CheckoutRequest(BaseModel):
+    """Where to send the customer back to. No tenant id — see the module note."""
+
+    tier: PlanTier = Field(
+        default=PlanTier.PRO, description="Tier to subscribe to"
+    )
+    success_url: str = Field(description="Where Stripe returns on success")
+    cancel_url: str = Field(description="Where Stripe returns if abandoned")
+
+
+class PortalRequest(BaseModel):
+    return_url: str = Field(description="Where the portal returns the customer")
+
+
+class BillingStatus(BaseModel):
+    configured: bool = Field(
+        description="Whether this deployment can start a paid flow at all"
+    )
+    tier: PlanTier
+    status: str | None = None
+    cancel_at_period_end: bool = False
+    current_period_end: str | None = None
+    usage: dict[str, int] = Field(default_factory=dict)
+    limits: dict[str, int] = Field(default_factory=dict)
+
+
+def _price_for(tier: PlanTier) -> str | None:
+    return {
+        PlanTier.PRO: settings.STRIPE_PRICE_PRO,
+        PlanTier.ENTERPRISE: settings.STRIPE_PRICE_ENTERPRISE,
+    }.get(tier)
+
+
+@router.get("/status", response_model=BillingStatus)
+async def billing_status(current_user_id: str = Depends(get_current_user_id)):
+    """What this tenant is entitled to and how much of it they have used.
+
+    Works with Stripe unconfigured: `configured` is false and everything else
+    describes the FREE tier, which is what the free beta actually runs on.
+    """
+    sub = await Subscription.find_one(Subscription.user_id == current_user_id)
+    tier = sub.effective_tier if sub else PlanTier.FREE
+    limits = limits_for(tier)
+
+    return BillingStatus(
+        configured=stripe_client.is_configured(),
+        tier=tier,
+        status=sub.status.value if sub else None,
+        cancel_at_period_end=sub.cancel_at_period_end if sub else False,
+        current_period_end=(
+            sub.current_period_end.isoformat()
+            if sub and sub.current_period_end
+            else None
+        ),
+        usage=await metering.usage_summary(current_user_id),
+        # UNLIMITED (-1) is passed through rather than omitted, so the client can
+        # tell "no ceiling" from "not reported".
+        limits={
+            metric: limits.limit_for(metric)
+            for metric in ("training_runs", "predictions", "uploads")
+        },
+    )
+
+
+@router.post("/checkout")
+async def start_checkout(
+    body: CheckoutRequest,
+    current_user_id: str = Depends(get_current_user_id),
+):
+    """Create a hosted Checkout session and return its URL."""
+    if body.tier == PlanTier.FREE:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="the free tier does not require a subscription",
+        )
+
+    price_id = _price_for(body.tier)
+    if not price_id:
+        # A missing price is configuration, not a client error — the caller asked
+        # for something perfectly valid that this deployment cannot sell.
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=f"no Stripe price configured for the {body.tier.value} tier",
+        )
+
+    try:
+        return await stripe_client.create_checkout_session(
+            user_id=current_user_id,
+            price_id=price_id,
+            success_url=body.success_url,
+            cancel_url=body.cancel_url,
+        )
+    except stripe_client.BillingNotConfigured as exc:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="billing is not available on this deployment",
+        ) from exc
+
+
+@router.post("/portal")
+async def open_portal(
+    body: PortalRequest,
+    current_user_id: str = Depends(get_current_user_id),
+):
+    """Return a link to Stripe's customer portal for this tenant."""
+    try:
+        return await stripe_client.create_portal_session(
+            user_id=current_user_id, return_url=body.return_url
+        )
+    except stripe_client.BillingNotConfigured as exc:
+        # Covers both "Stripe is off here" and "this tenant has never subscribed".
+        # The portal manages an existing relationship; without one there is nothing
+        # to open, and that is not an error the caller can fix by retrying.
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="no billing account to manage",
+        ) from exc
+
+
+__all__ = ["router", "UNLIMITED"]

--- a/apps/backend/app/api/routes/billing.py
+++ b/apps/backend/app/api/routes/billing.py
@@ -50,10 +50,21 @@ def _assert_known_origin(url: str) -> str:
     origin = f"{parsed.scheme}://{parsed.netloc}"
     allowed = settings.BACKEND_CORS_ORIGINS
     if "*" in allowed:
-        # A wildcard is a CORS convenience, never a licence to redirect anywhere.
+        # The two settings have OPPOSITE safe defaults, which is worth stating.
+        # Unset, BACKEND_CORS_ORIGINS is `["*"]` — a deliberate dev convenience for
+        # CORS. As a redirect allowlist a wildcard means "anywhere", so it is
+        # refused rather than honoured. Correct, but it makes a fresh checkout that
+        # never set the var reject its own URLs, so the message says exactly what to
+        # do instead of repeating "not allowed".
+        logger.warning(
+            "billing redirect refused: BACKEND_CORS_ORIGINS is the wildcard default"
+        )
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="redirect URL origin is not allowed",
+            detail=(
+                "BACKEND_CORS_ORIGINS is unset (defaulting to '*'), which cannot be "
+                "used as a redirect allowlist. Set it to this app's origin(s)."
+            ),
         )
     if origin not in allowed:
         logger.warning("rejected billing redirect to unknown origin: %s", origin)

--- a/apps/backend/app/api/routes/billing.py
+++ b/apps/backend/app/api/routes/billing.py
@@ -12,6 +12,7 @@ against — or read the usage of — someone else's account.
 """
 
 import logging
+from urllib.parse import urlparse
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, Field
@@ -25,6 +26,42 @@ from app.models.subscription import PlanTier, Subscription
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+
+
+def _assert_known_origin(url: str) -> str:
+    """Reject a redirect target that is not one of this app's own origins.
+
+    Stripe sends the browser to these after a hosted flow. Forwarded unvalidated,
+    they are an open redirect wearing a legitimate costume: an authenticated caller
+    can walk a user through the REAL Stripe checkout — which looks exactly right,
+    because it is — and land them on a phishing page at the end. The authentication
+    does not help; the attacker is a valid user, and the victim is themselves.
+
+    `BACKEND_CORS_ORIGINS` is already this app's list of known origins, so it is the
+    source of truth here too rather than a second list to drift.
+    """
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https") or not parsed.netloc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="redirect URL must be an absolute http(s) URL",
+        )
+
+    origin = f"{parsed.scheme}://{parsed.netloc}"
+    allowed = settings.BACKEND_CORS_ORIGINS
+    if "*" in allowed:
+        # A wildcard is a CORS convenience, never a licence to redirect anywhere.
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="redirect URL origin is not allowed",
+        )
+    if origin not in allowed:
+        logger.warning("rejected billing redirect to unknown origin: %s", origin)
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="redirect URL origin is not allowed",
+        )
+    return url
 
 
 class CheckoutRequest(BaseModel):
@@ -103,6 +140,9 @@ async def start_checkout(
             detail="the free tier does not require a subscription",
         )
 
+    _assert_known_origin(body.success_url)
+    _assert_known_origin(body.cancel_url)
+
     price_id = _price_for(body.tier)
     if not price_id:
         # A missing price is configuration, not a client error — the caller asked
@@ -124,6 +164,15 @@ async def start_checkout(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="billing is not available on this deployment",
         ) from exc
+    except stripe_client.BillingProviderError as exc:
+        # Stripe rejected or could not be reached. 502, not 500: the failure is
+        # upstream, and the generic body keeps provider detail out of the response
+        # while the log keeps it for us.
+        logger.warning("stripe checkout failed: %s", exc)
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="could not start checkout, please try again",
+        ) from exc
 
 
 @router.post("/portal")
@@ -132,6 +181,8 @@ async def open_portal(
     current_user_id: str = Depends(get_current_user_id),
 ):
     """Return a link to Stripe's customer portal for this tenant."""
+    _assert_known_origin(body.return_url)
+
     try:
         return await stripe_client.create_portal_session(
             user_id=current_user_id, return_url=body.return_url
@@ -143,6 +194,12 @@ async def open_portal(
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="no billing account to manage",
+        ) from exc
+    except stripe_client.BillingProviderError as exc:
+        logger.warning("stripe portal failed: %s", exc)
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="could not open the billing portal, please try again",
         ) from exc
 
 

--- a/apps/backend/app/billing/stripe_client.py
+++ b/apps/backend/app/billing/stripe_client.py
@@ -20,6 +20,14 @@ from app.models.subscription import Subscription
 logger = logging.getLogger(__name__)
 
 
+class BillingProviderError(Exception):
+    """Stripe rejected the call or could not be reached.
+
+    Separate from `BillingNotConfigured` so a route can answer 502 (upstream
+    failed, worth retrying) rather than 503 (not offered here) or 500 (our bug).
+    """
+
+
 class BillingNotConfigured(Exception):
     """Stripe is not set up on this deployment.
 
@@ -88,7 +96,10 @@ async def create_checkout_session(
     if existing:
         params["customer"] = existing
 
-    session = await _to_thread(stripe.checkout.Session.create, **params)
+    try:
+        session = await _to_thread(stripe.checkout.Session.create, **params)
+    except Exception as exc:  # noqa: BLE001 - narrowed by re-raise below
+        _reraise_provider_error(exc)
     return {"id": session["id"], "url": session["url"]}
 
 
@@ -104,12 +115,27 @@ async def create_portal_session(user_id: str, return_url: str) -> dict[str, Any]
     if not customer_id:
         raise BillingNotConfigured("this tenant has no Stripe customer")
 
-    session = await _to_thread(
-        stripe.billing_portal.Session.create,
-        customer=customer_id,
-        return_url=return_url,
-    )
+    try:
+        session = await _to_thread(
+            stripe.billing_portal.Session.create,
+            customer=customer_id,
+            return_url=return_url,
+        )
+    except Exception as exc:  # noqa: BLE001 - narrowed by re-raise below
+        _reraise_provider_error(exc)
     return {"url": session["url"]}
+
+
+def _reraise_provider_error(exc: Exception):
+    """Turn any Stripe failure into BillingProviderError, preserving the cause.
+
+    Deliberately catches broadly: the SDK raises a family of types
+    (CardError, RateLimitError, APIConnectionError, …) and a new one appearing in
+    an SDK upgrade must not become an uncaught 500.
+    """
+    if isinstance(exc, BillingNotConfigured):
+        raise exc
+    raise BillingProviderError(str(exc)) from exc
 
 
 async def _to_thread(fn, /, *args, **kwargs):

--- a/apps/backend/app/billing/stripe_client.py
+++ b/apps/backend/app/billing/stripe_client.py
@@ -1,0 +1,124 @@
+"""Stripe client and the two hosted flows we use (#365).
+
+**Lazy initialisation is the whole point of this module.** `next build`-style
+secret-less Docker builds and the free invite-only beta both run with no
+`STRIPE_SECRET_KEY` at all, and importing this module must not care. The client is
+constructed on first use, so importing it — which the router does at startup —
+touches no configuration and cannot fail.
+
+Both flows are *hosted*: Stripe collects the card and manages the subscription on
+its own pages. This service never sees a card number, which is the reason to use
+Checkout and the customer portal rather than building either.
+"""
+
+import logging
+from typing import Any
+
+from app.config import settings
+from app.models.subscription import Subscription
+
+logger = logging.getLogger(__name__)
+
+
+class BillingNotConfigured(Exception):
+    """Stripe is not set up on this deployment.
+
+    A distinct type so callers can answer 503 ("billing is not available here")
+    rather than 500 ("something broke"). Running without Stripe is a supported
+    configuration, not a fault.
+    """
+
+
+def _client():
+    """The Stripe SDK, configured on first use.
+
+    Imported inside the function, not at module scope: an import at the top would
+    make the SDK a hard requirement of starting the app, which is exactly the
+    coupling the free tier must not have.
+    """
+    if not settings.STRIPE_SECRET_KEY:
+        raise BillingNotConfigured("STRIPE_SECRET_KEY is not set")
+
+    import stripe
+
+    stripe.api_key = settings.STRIPE_SECRET_KEY
+    return stripe
+
+
+def is_configured() -> bool:
+    """Whether this deployment can start a paid flow at all."""
+    return bool(settings.STRIPE_SECRET_KEY)
+
+
+async def _customer_id_for(user_id: str) -> str | None:
+    """The Stripe customer we already know about for this tenant, if any."""
+    sub = await Subscription.find_one(Subscription.user_id == user_id)
+    return sub.stripe_customer_id if sub else None
+
+
+async def create_checkout_session(
+    user_id: str,
+    price_id: str,
+    success_url: str,
+    cancel_url: str,
+) -> dict[str, Any]:
+    """Start a hosted Checkout for this tenant.
+
+    `client_reference_id` and `subscription_data.metadata.user_id` are both set, and
+    both matter: the webhook (#367) reads the first off the checkout session and the
+    second off the subscription object, and an event carrying neither is treated as
+    one we did not originate. Setting only one would silently drop half the events.
+
+    Reuses the tenant's existing Stripe customer when there is one, so a second
+    subscription does not create a duplicate customer with a separate billing
+    history.
+    """
+    stripe = _client()
+
+    params: dict[str, Any] = {
+        "mode": "subscription",
+        "line_items": [{"price": price_id, "quantity": 1}],
+        "success_url": success_url,
+        "cancel_url": cancel_url,
+        "client_reference_id": user_id,
+        "subscription_data": {"metadata": {"user_id": user_id}},
+    }
+
+    existing = await _customer_id_for(user_id)
+    if existing:
+        params["customer"] = existing
+
+    session = await _to_thread(stripe.checkout.Session.create, **params)
+    return {"id": session["id"], "url": session["url"]}
+
+
+async def create_portal_session(user_id: str, return_url: str) -> dict[str, Any]:
+    """A link to Stripe's customer portal for self-service management.
+
+    Requires a known Stripe customer: the portal manages an existing relationship,
+    so a tenant who has never subscribed has nothing to manage.
+    """
+    stripe = _client()
+
+    customer_id = await _customer_id_for(user_id)
+    if not customer_id:
+        raise BillingNotConfigured("this tenant has no Stripe customer")
+
+    session = await _to_thread(
+        stripe.billing_portal.Session.create,
+        customer=customer_id,
+        return_url=return_url,
+    )
+    return {"url": session["url"]}
+
+
+async def _to_thread(fn, /, *args, **kwargs):
+    """Run a blocking SDK call off the event loop.
+
+    The Stripe SDK's sync client makes real HTTP calls; awaiting them inline would
+    block every other request on the worker for the duration.
+    """
+    import asyncio
+    from functools import partial
+
+    return await asyncio.to_thread(partial(fn, *args, **kwargs))

--- a/apps/backend/app/config.py
+++ b/apps/backend/app/config.py
@@ -114,7 +114,15 @@ def _parse_cors_origins(raw: str | None) -> list[str]:
             return [str(o).strip() for o in parsed]
     except (json.JSONDecodeError, ValueError):
         pass
-    parts = [p.strip() for p in raw.split(",") if p.strip()]
+
+    # Bracketed but unquoted — `[http://a,http://b]` — is not valid JSON, so it
+    # falls through to the comma split with the brackets still attached, yielding
+    # `[http://a` and `http://b]`: origins that can never match anything, silently.
+    # `.env.example` shipped in exactly that form, so this is the shape people copy.
+    if raw.startswith("[") and raw.endswith("]"):
+        raw = raw[1:-1]
+
+    parts = [p.strip().strip("\"'") for p in raw.split(",") if p.strip().strip("\"'")]
     return parts or ["*"]
 
 

--- a/apps/backend/app/main.py
+++ b/apps/backend/app/main.py
@@ -49,6 +49,7 @@ from app.api.routes import (
     ai_orchestration,
     analytics_result,
     batch_prediction,
+    billing,
     billing_webhook,
     cache,
     column_stats,
@@ -315,6 +316,11 @@ app.include_router(
 # public API surface: it is Stripe's endpoint, already excluded from the OpenAPI
 # schema. Protection here is signature verification plus the body-size limit, not
 # an IP budget (#367).
+app.include_router(
+    billing.router,
+    prefix=f"{settings.API_V1_STR}/billing",
+    tags=["billing"],
+)
 app.include_router(
     billing_webhook.router,
     prefix="/webhooks/stripe",

--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -54,6 +54,7 @@ dependencies = [
     "gunicorn>=23.0.0",
     "prometheus-client>=0.19.0",
     "pyyaml>=6.0.3",
+    "stripe>=15.4.0",
 ]
 
 [dependency-groups]

--- a/apps/backend/tests/test_api/test_billing_routes.py
+++ b/apps/backend/tests/test_api/test_billing_routes.py
@@ -1,0 +1,347 @@
+"""Billing endpoints (#365).
+
+The property that matters most here is tenancy: `user_id` comes from the session,
+never the request body. A tenant id accepted from a caller would let anyone start a
+subscription against — or read the usage of — someone else's account.
+
+Second is that **everything works with Stripe unconfigured**. That is not a
+degraded mode, it is what the free invite-only beta actually runs on, so `/status`
+must answer and the paid routes must say "not available here" rather than 500.
+"""
+
+import pytest
+
+from app.billing import stripe_client
+from app.config import settings
+from app.models.subscription import PlanTier, Subscription, SubscriptionStatus
+
+STATUS = "/api/v1/billing/status"
+CHECKOUT = "/api/v1/billing/checkout"
+PORTAL = "/api/v1/billing/portal"
+TEST_USER = "test_user_123"
+
+
+@pytest.mark.asyncio
+class TestStatusWithoutStripe:
+    """The free-beta configuration: no Stripe keys at all."""
+
+    @pytest.fixture(autouse=True)
+    def _no_stripe(self, monkeypatch):
+        monkeypatch.setattr(settings, "STRIPE_SECRET_KEY", None, raising=False)
+
+    async def test_reports_free_and_unconfigured(
+        self, async_authorized_client, setup_database
+    ):
+        response = await async_authorized_client.get(STATUS)
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["configured"] is False
+        assert body["tier"] == PlanTier.FREE.value
+
+    async def test_reports_limits_and_usage(
+        self, async_authorized_client, setup_database
+    ):
+        from app.billing import metering
+
+        await metering.record(TEST_USER, "predictions", amount=3)
+
+        body = (await async_authorized_client.get(STATUS)).json()
+
+        assert body["usage"]["predictions"] == 3
+        assert body["limits"]["predictions"] > 0
+
+    async def test_checkout_is_unavailable_not_broken(
+        self, async_authorized_client, setup_database
+    ):
+        """503, not 500: running without Stripe is a supported configuration."""
+        response = await async_authorized_client.post(
+            CHECKOUT,
+            json={
+                "tier": "pro",
+                "success_url": "https://app.test/ok",
+                "cancel_url": "https://app.test/no",
+            },
+        )
+
+        assert response.status_code == 503
+
+    async def test_portal_is_unavailable_not_broken(
+        self, async_authorized_client, setup_database
+    ):
+        response = await async_authorized_client.post(
+            PORTAL, json={"return_url": "https://app.test/settings"}
+        )
+
+        assert response.status_code == 503
+
+
+@pytest.mark.asyncio
+class TestStatusReflectsTheSubscription:
+    async def test_an_entitled_subscription_reports_its_tier(
+        self, async_authorized_client, setup_database
+    ):
+        await Subscription(
+            user_id=TEST_USER,
+            plan_tier=PlanTier.PRO,
+            status=SubscriptionStatus.ACTIVE,
+        ).insert()
+
+        body = (await async_authorized_client.get(STATUS)).json()
+
+        assert body["tier"] == PlanTier.PRO.value
+        assert body["status"] == "active"
+
+    async def test_a_cancelled_subscription_reports_free(
+        self, async_authorized_client, setup_database
+    ):
+        """`effective_tier`, not `plan_tier` — the UI must not offer PRO limits to
+        someone whose subscription has lapsed."""
+        await Subscription(
+            user_id=TEST_USER,
+            plan_tier=PlanTier.PRO,
+            status=SubscriptionStatus.CANCELED,
+        ).insert()
+
+        body = (await async_authorized_client.get(STATUS)).json()
+
+        assert body["tier"] == PlanTier.FREE.value
+        assert body["status"] == "canceled"
+
+    async def test_unlimited_is_reported_as_the_sentinel(
+        self, async_authorized_client, setup_database
+    ):
+        """Passed through rather than omitted, so the client can tell "no ceiling"
+        from "not reported"."""
+        await Subscription(
+            user_id=TEST_USER,
+            plan_tier=PlanTier.ENTERPRISE,
+            status=SubscriptionStatus.ACTIVE,
+        ).insert()
+
+        body = (await async_authorized_client.get(STATUS)).json()
+
+        assert body["limits"]["training_runs"] == -1
+
+
+@pytest.mark.asyncio
+class TestCheckout:
+    @pytest.fixture(autouse=True)
+    def _stripe_on(self, monkeypatch):
+        monkeypatch.setattr(settings, "STRIPE_SECRET_KEY", "sk_test_x", raising=False)
+        monkeypatch.setattr(settings, "STRIPE_PRICE_PRO", "price_pro", raising=False)
+
+    async def test_the_free_tier_is_rejected(
+        self, async_authorized_client, setup_database
+    ):
+        response = await async_authorized_client.post(
+            CHECKOUT,
+            json={
+                "tier": "free",
+                "success_url": "https://app.test/ok",
+                "cancel_url": "https://app.test/no",
+            },
+        )
+
+        assert response.status_code == 400
+
+    async def test_a_tier_with_no_configured_price_is_503(
+        self, async_authorized_client, setup_database, monkeypatch
+    ):
+        """Configuration, not a client error — the caller asked for something
+        perfectly valid that this deployment cannot sell."""
+        monkeypatch.setattr(
+            settings, "STRIPE_PRICE_ENTERPRISE", None, raising=False
+        )
+
+        response = await async_authorized_client.post(
+            CHECKOUT,
+            json={
+                "tier": "enterprise",
+                "success_url": "https://app.test/ok",
+                "cancel_url": "https://app.test/no",
+            },
+        )
+
+        assert response.status_code == 503
+
+    async def test_the_session_carries_both_tenant_markers(
+        self, async_authorized_client, setup_database, monkeypatch
+    ):
+        """The webhook reads `client_reference_id` off the checkout session and
+        `subscription_data.metadata.user_id` off the subscription object. Setting
+        only one would silently drop half the events (#367)."""
+        captured: dict = {}
+
+        def _fake_create(**kwargs):
+            captured.update(kwargs)
+            return {"id": "cs_1", "url": "https://checkout.stripe.test/cs_1"}
+
+        monkeypatch.setattr(
+            stripe_client,
+            "_client",
+            lambda: type(
+                "S",
+                (),
+                {"checkout": type("C", (), {"Session": type("Sess", (), {"create": staticmethod(_fake_create)})})},
+            ),
+        )
+
+        response = await async_authorized_client.post(
+            CHECKOUT,
+            json={
+                "tier": "pro",
+                "success_url": "https://app.test/ok",
+                "cancel_url": "https://app.test/no",
+            },
+        )
+
+        assert response.status_code == 200
+        assert response.json()["url"].startswith("https://checkout.stripe.test/")
+        assert captured["client_reference_id"] == TEST_USER
+        assert captured["subscription_data"]["metadata"]["user_id"] == TEST_USER
+
+    async def test_an_existing_customer_is_reused(
+        self, async_authorized_client, setup_database, monkeypatch
+    ):
+        """A second subscription must not create a duplicate customer with its own
+        billing history."""
+        await Subscription(
+            user_id=TEST_USER, stripe_customer_id="cus_existing"
+        ).insert()
+
+        captured: dict = {}
+
+        def _fake_create(**kwargs):
+            captured.update(kwargs)
+            return {"id": "cs_2", "url": "https://checkout.stripe.test/cs_2"}
+
+        monkeypatch.setattr(
+            stripe_client,
+            "_client",
+            lambda: type(
+                "S",
+                (),
+                {"checkout": type("C", (), {"Session": type("Sess", (), {"create": staticmethod(_fake_create)})})},
+            ),
+        )
+
+        await async_authorized_client.post(
+            CHECKOUT,
+            json={
+                "tier": "pro",
+                "success_url": "https://app.test/ok",
+                "cancel_url": "https://app.test/no",
+            },
+        )
+
+        assert captured["customer"] == "cus_existing"
+
+    async def test_the_tenant_id_cannot_be_supplied_by_the_caller(
+        self, async_authorized_client, setup_database, monkeypatch
+    ):
+        """The request schema has no tenant field, and an attempt to smuggle one
+        must not reach Stripe. Otherwise anyone could subscribe on someone else's
+        behalf — or, on /status, read their usage."""
+        captured: dict = {}
+
+        def _fake_create(**kwargs):
+            captured.update(kwargs)
+            return {"id": "cs_3", "url": "https://checkout.stripe.test/cs_3"}
+
+        monkeypatch.setattr(
+            stripe_client,
+            "_client",
+            lambda: type(
+                "S",
+                (),
+                {"checkout": type("C", (), {"Session": type("Sess", (), {"create": staticmethod(_fake_create)})})},
+            ),
+        )
+
+        await async_authorized_client.post(
+            CHECKOUT,
+            json={
+                "tier": "pro",
+                "success_url": "https://app.test/ok",
+                "cancel_url": "https://app.test/no",
+                "user_id": "somebody-else",
+                "client_reference_id": "somebody-else",
+            },
+        )
+
+        assert captured["client_reference_id"] == TEST_USER
+
+
+@pytest.mark.asyncio
+class TestPortal:
+    @pytest.fixture(autouse=True)
+    def _stripe_on(self, monkeypatch):
+        monkeypatch.setattr(settings, "STRIPE_SECRET_KEY", "sk_test_x", raising=False)
+
+    async def test_a_tenant_with_no_customer_gets_503(
+        self, async_authorized_client, setup_database
+    ):
+        """The portal manages an existing relationship; there is nothing to open."""
+        response = await async_authorized_client.post(
+            PORTAL, json={"return_url": "https://app.test/settings"}
+        )
+
+        assert response.status_code == 503
+
+    async def test_returns_a_portal_url_for_a_known_customer(
+        self, async_authorized_client, setup_database, monkeypatch
+    ):
+        await Subscription(
+            user_id=TEST_USER, stripe_customer_id="cus_portal"
+        ).insert()
+
+        captured: dict = {}
+
+        def _fake_create(**kwargs):
+            captured.update(kwargs)
+            return {"url": "https://billing.stripe.test/p/session"}
+
+        monkeypatch.setattr(
+            stripe_client,
+            "_client",
+            lambda: type(
+                "S",
+                (),
+                {"billing_portal": type("B", (), {"Session": type("Sess", (), {"create": staticmethod(_fake_create)})})},
+            ),
+        )
+
+        response = await async_authorized_client.post(
+            PORTAL, json={"return_url": "https://app.test/settings"}
+        )
+
+        assert response.status_code == 200
+        assert response.json()["url"].startswith("https://billing.stripe.test/")
+        assert captured["customer"] == "cus_portal"
+
+
+class TestLazyInitialisation:
+    """Importing must not require configuration (#365).
+
+    Secret-less Docker builds and the free beta both run with no STRIPE_SECRET_KEY,
+    and the router imports this module at startup.
+    """
+
+    def test_importing_does_not_touch_configuration(self):
+        import importlib
+
+        importlib.reload(stripe_client)  # must not raise
+
+    def test_client_raises_a_typed_error_when_unset(self, monkeypatch):
+        monkeypatch.setattr(settings, "STRIPE_SECRET_KEY", None, raising=False)
+
+        with pytest.raises(stripe_client.BillingNotConfigured):
+            stripe_client._client()
+
+    def test_is_configured_reflects_the_key(self, monkeypatch):
+        monkeypatch.setattr(settings, "STRIPE_SECRET_KEY", None, raising=False)
+        assert not stripe_client.is_configured()
+
+        monkeypatch.setattr(settings, "STRIPE_SECRET_KEY", "sk_test_x", raising=False)
+        assert stripe_client.is_configured()

--- a/apps/backend/tests/test_api/test_billing_routes.py
+++ b/apps/backend/tests/test_api/test_billing_routes.py
@@ -15,6 +15,10 @@ from app.billing import stripe_client
 from app.config import settings
 from app.models.subscription import PlanTier, Subscription, SubscriptionStatus
 
+# The origin guard validates against BACKEND_CORS_ORIGINS, so the redirect URLs
+# below use an origin the test environment actually allows.
+APP_ORIGIN = "http://localhost:3000"
+
 STATUS = "/api/v1/billing/status"
 CHECKOUT = "/api/v1/billing/checkout"
 PORTAL = "/api/v1/billing/portal"
@@ -59,8 +63,8 @@ class TestStatusWithoutStripe:
             CHECKOUT,
             json={
                 "tier": "pro",
-                "success_url": "https://app.test/ok",
-                "cancel_url": "https://app.test/no",
+                "success_url": "http://localhost:3000/ok",
+                "cancel_url": "http://localhost:3000/no",
             },
         )
 
@@ -70,7 +74,7 @@ class TestStatusWithoutStripe:
         self, async_authorized_client, setup_database
     ):
         response = await async_authorized_client.post(
-            PORTAL, json={"return_url": "https://app.test/settings"}
+            PORTAL, json={"return_url": "http://localhost:3000/settings"}
         )
 
         assert response.status_code == 503
@@ -138,8 +142,8 @@ class TestCheckout:
             CHECKOUT,
             json={
                 "tier": "free",
-                "success_url": "https://app.test/ok",
-                "cancel_url": "https://app.test/no",
+                "success_url": "http://localhost:3000/ok",
+                "cancel_url": "http://localhost:3000/no",
             },
         )
 
@@ -158,8 +162,8 @@ class TestCheckout:
             CHECKOUT,
             json={
                 "tier": "enterprise",
-                "success_url": "https://app.test/ok",
-                "cancel_url": "https://app.test/no",
+                "success_url": "http://localhost:3000/ok",
+                "cancel_url": "http://localhost:3000/no",
             },
         )
 
@@ -191,8 +195,8 @@ class TestCheckout:
             CHECKOUT,
             json={
                 "tier": "pro",
-                "success_url": "https://app.test/ok",
-                "cancel_url": "https://app.test/no",
+                "success_url": "http://localhost:3000/ok",
+                "cancel_url": "http://localhost:3000/no",
             },
         )
 
@@ -230,8 +234,8 @@ class TestCheckout:
             CHECKOUT,
             json={
                 "tier": "pro",
-                "success_url": "https://app.test/ok",
-                "cancel_url": "https://app.test/no",
+                "success_url": "http://localhost:3000/ok",
+                "cancel_url": "http://localhost:3000/no",
             },
         )
 
@@ -263,14 +267,155 @@ class TestCheckout:
             CHECKOUT,
             json={
                 "tier": "pro",
-                "success_url": "https://app.test/ok",
-                "cancel_url": "https://app.test/no",
+                "success_url": "http://localhost:3000/ok",
+                "cancel_url": "http://localhost:3000/no",
                 "user_id": "somebody-else",
                 "client_reference_id": "somebody-else",
             },
         )
 
         assert captured["client_reference_id"] == TEST_USER
+
+
+@pytest.mark.asyncio
+class TestRedirectValidation:
+    """Redirect targets must be this app's own origins (#365 review).
+
+    Unvalidated, they are an open redirect wearing a legitimate costume: an
+    authenticated caller walks a victim through the REAL Stripe checkout — which
+    looks right, because it is — and lands them on a phishing page at the end.
+    Authentication does not help; the attacker is a valid user.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _stripe_on(self, monkeypatch):
+        monkeypatch.setattr(settings, "STRIPE_SECRET_KEY", "sk_test_x", raising=False)
+        monkeypatch.setattr(settings, "STRIPE_PRICE_PRO", "price_pro", raising=False)
+
+    @pytest.mark.parametrize(
+        "bad_url",
+        [
+            "https://phishing.example/steal",
+            "http://localhost:3000.evil.test/",
+            "javascript:alert(1)",
+            "//protocol-relative.example",
+            "/relative/only",
+            "",
+        ],
+    )
+    async def test_checkout_rejects_a_foreign_redirect(
+        self, async_authorized_client, setup_database, bad_url
+    ):
+        response = await async_authorized_client.post(
+            CHECKOUT,
+            json={
+                "tier": "pro",
+                "success_url": bad_url,
+                "cancel_url": "http://localhost:3000/ok",
+            },
+        )
+
+        assert response.status_code == 400, response.text
+
+    async def test_checkout_rejects_a_foreign_cancel_url_too(
+        self, async_authorized_client, setup_database
+    ):
+        """Both URLs are attacker-controllable; validating only one is no
+        validation at all."""
+        response = await async_authorized_client.post(
+            CHECKOUT,
+            json={
+                "tier": "pro",
+                "success_url": "http://localhost:3000/ok",
+                "cancel_url": "https://phishing.example/steal",
+            },
+        )
+
+        assert response.status_code == 400
+
+    async def test_portal_rejects_a_foreign_return_url(
+        self, async_authorized_client, setup_database
+    ):
+        await Subscription(
+            user_id=TEST_USER, stripe_customer_id="cus_x"
+        ).insert()
+
+        response = await async_authorized_client.post(
+            PORTAL, json={"return_url": "https://phishing.example/steal"}
+        )
+
+        assert response.status_code == 400
+
+    async def test_a_known_origin_is_accepted(
+        self, async_authorized_client, setup_database, monkeypatch
+    ):
+        """The guard must not reject the app's own URLs, or it breaks the feature
+        rather than protecting it."""
+        captured: dict = {}
+
+        def _fake_create(**kwargs):
+            captured.update(kwargs)
+            return {"id": "cs_ok", "url": "https://checkout.stripe.test/ok"}
+
+        monkeypatch.setattr(
+            stripe_client,
+            "_client",
+            lambda: type(
+                "S",
+                (),
+                {"checkout": type("C", (), {"Session": type("Sess", (), {"create": staticmethod(_fake_create)})})},
+            ),
+        )
+
+        response = await async_authorized_client.post(
+            CHECKOUT,
+            json={
+                "tier": "pro",
+                "success_url": "http://localhost:3000/settings/billing?checkout=success",
+                "cancel_url": "http://localhost:3000/settings/billing",
+            },
+        )
+
+        assert response.status_code == 200, response.text
+
+
+@pytest.mark.asyncio
+class TestProviderErrors:
+    """A Stripe failure is 502, not 500 (#365 review)."""
+
+    @pytest.fixture(autouse=True)
+    def _stripe_on(self, monkeypatch):
+        monkeypatch.setattr(settings, "STRIPE_SECRET_KEY", "sk_test_x", raising=False)
+        monkeypatch.setattr(settings, "STRIPE_PRICE_PRO", "price_pro", raising=False)
+
+    async def test_a_stripe_failure_is_a_502(
+        self, async_authorized_client, setup_database, monkeypatch
+    ):
+        def _boom(**_kwargs):
+            raise RuntimeError("stripe is unreachable")
+
+        monkeypatch.setattr(
+            stripe_client,
+            "_client",
+            lambda: type(
+                "S",
+                (),
+                {"checkout": type("C", (), {"Session": type("Sess", (), {"create": staticmethod(_boom)})})},
+            ),
+        )
+
+        response = await async_authorized_client.post(
+            CHECKOUT,
+            json={
+                "tier": "pro",
+                "success_url": "http://localhost:3000/ok",
+                "cancel_url": "http://localhost:3000/no",
+            },
+        )
+
+        assert response.status_code == 502
+        # The provider's message stays in the log, not the response body.
+        assert "unreachable" not in response.text
 
 
 @pytest.mark.asyncio
@@ -284,7 +429,7 @@ class TestPortal:
     ):
         """The portal manages an existing relationship; there is nothing to open."""
         response = await async_authorized_client.post(
-            PORTAL, json={"return_url": "https://app.test/settings"}
+            PORTAL, json={"return_url": "http://localhost:3000/settings"}
         )
 
         assert response.status_code == 503
@@ -313,7 +458,7 @@ class TestPortal:
         )
 
         response = await async_authorized_client.post(
-            PORTAL, json={"return_url": "https://app.test/settings"}
+            PORTAL, json={"return_url": "http://localhost:3000/settings"}
         )
 
         assert response.status_code == 200

--- a/apps/backend/tests/test_api/test_billing_routes.py
+++ b/apps/backend/tests/test_api/test_billing_routes.py
@@ -346,6 +346,29 @@ class TestRedirectValidation:
 
         assert response.status_code == 400
 
+    async def test_the_wildcard_default_explains_itself(
+        self, async_authorized_client, setup_database, monkeypatch
+    ):
+        """BACKEND_CORS_ORIGINS defaults to `["*"]` — fine for CORS in dev, useless
+        as a redirect allowlist. Refusing is correct; refusing with "origin is not
+        allowed" would send someone hunting the wrong problem (#365 review).
+        """
+        monkeypatch.setenv("BACKEND_CORS_ORIGINS", "")
+
+        response = await async_authorized_client.post(
+            CHECKOUT,
+            json={
+                "tier": "pro",
+                "success_url": f"{APP_ORIGIN}/ok",
+                "cancel_url": f"{APP_ORIGIN}/no",
+            },
+        )
+
+        assert response.status_code == 400
+        detail = response.json()["detail"]
+        assert "BACKEND_CORS_ORIGINS" in detail
+        assert "unset" in detail
+
     async def test_a_known_origin_is_accepted(
         self, async_authorized_client, setup_database, monkeypatch
     ):

--- a/apps/backend/tests/test_utils/test_cors_origins.py
+++ b/apps/backend/tests/test_utils/test_cors_origins.py
@@ -1,0 +1,31 @@
+"""CORS origin parsing (#365 review side-catch)."""
+
+from app.config import _parse_cors_origins
+
+
+class TestBracketedOriginLists:
+    """`[http://a,http://b]` is not valid JSON, so it used to fall through to the
+    comma split with the brackets attached — producing `[http://a` and `http://b]`,
+    origins that can never match anything, silently. `.env.example` shipped in
+    exactly that form, so it is the shape people copy.
+    """
+
+    def test_a_bracketed_unquoted_list_parses(self):
+        assert _parse_cors_origins("[http://a,http://b]") == ["http://a", "http://b"]
+
+    def test_a_single_bracketed_origin_parses(self):
+        assert _parse_cors_origins("[http://localhost:3000]") == [
+            "http://localhost:3000"
+        ]
+
+    def test_proper_json_still_parses(self):
+        assert _parse_cors_origins('["http://a","http://b"]') == [
+            "http://a",
+            "http://b",
+        ]
+
+    def test_plain_csv_still_parses(self):
+        assert _parse_cors_origins("http://a,http://b") == ["http://a", "http://b"]
+
+    def test_blank_is_still_the_wildcard(self):
+        assert _parse_cors_origins("") == ["*"]

--- a/apps/backend/uv.lock
+++ b/apps/backend/uv.lock
@@ -561,7 +561,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b1/cf/f5c0b23309070ae93de75c90d29300751a5aacefc0a3ed1b1d8edb28f08b/greenlet-3.2.3-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:500b8689aa9dd1ab26872a34084503aeddefcb438e2e7317b89b11eaea1901ad", size = 270732, upload-time = "2025-06-05T16:10:08.26Z" },
     { url = "https://files.pythonhosted.org/packages/48/ae/91a957ba60482d3fecf9be49bc3948f341d706b52ddb9d83a70d42abd498/greenlet-3.2.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a07d3472c2a93117af3b0136f246b2833fdc0b542d4a9799ae5f41c28323faef", size = 639033, upload-time = "2025-06-05T16:38:53.983Z" },
     { url = "https://files.pythonhosted.org/packages/6f/df/20ffa66dd5a7a7beffa6451bdb7400d66251374ab40b99981478c69a67a8/greenlet-3.2.3-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:8704b3768d2f51150626962f4b9a9e4a17d2e37c8a8d9867bbd9fa4eb938d3b3", size = 652999, upload-time = "2025-06-05T16:41:37.89Z" },
-    { url = "https://files.pythonhosted.org/packages/51/b4/ebb2c8cb41e521f1d72bf0465f2f9a2fd803f674a88db228887e6847077e/greenlet-3.2.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:5035d77a27b7c62db6cf41cf786cfe2242644a7a337a0e155c80960598baab95", size = 647368, upload-time = "2025-06-05T16:48:21.467Z" },
     { url = "https://files.pythonhosted.org/packages/8e/6a/1e1b5aa10dced4ae876a322155705257748108b7fd2e4fae3f2a091fe81a/greenlet-3.2.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2d8aa5423cd4a396792f6d4580f88bdc6efcb9205891c9d40d20f6e670992efb", size = 650037, upload-time = "2025-06-05T16:13:06.402Z" },
     { url = "https://files.pythonhosted.org/packages/26/f2/ad51331a157c7015c675702e2d5230c243695c788f8f75feba1af32b3617/greenlet-3.2.3-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2c724620a101f8170065d7dded3f962a2aea7a7dae133a009cada42847e04a7b", size = 608402, upload-time = "2025-06-05T16:12:51.91Z" },
     { url = "https://files.pythonhosted.org/packages/26/bc/862bd2083e6b3aff23300900a956f4ea9a4059de337f5c8734346b9b34fc/greenlet-3.2.3-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:873abe55f134c48e1f2a6f53f7d1419192a3d1a4e873bace00499a4e45ea6af0", size = 1119577, upload-time = "2025-06-05T16:36:49.787Z" },
@@ -570,7 +569,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d8/ca/accd7aa5280eb92b70ed9e8f7fd79dc50a2c21d8c73b9a0856f5b564e222/greenlet-3.2.3-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:3d04332dddb10b4a211b68111dabaee2e1a073663d117dc10247b5b1642bac86", size = 271479, upload-time = "2025-06-05T16:10:47.525Z" },
     { url = "https://files.pythonhosted.org/packages/55/71/01ed9895d9eb49223280ecc98a557585edfa56b3d0e965b9fa9f7f06b6d9/greenlet-3.2.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8186162dffde068a465deab08fc72c767196895c39db26ab1c17c0b77a6d8b97", size = 683952, upload-time = "2025-06-05T16:38:55.125Z" },
     { url = "https://files.pythonhosted.org/packages/ea/61/638c4bdf460c3c678a0a1ef4c200f347dff80719597e53b5edb2fb27ab54/greenlet-3.2.3-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f4bfbaa6096b1b7a200024784217defedf46a07c2eee1a498e94a1b5f8ec5728", size = 696917, upload-time = "2025-06-05T16:41:38.959Z" },
-    { url = "https://files.pythonhosted.org/packages/22/cc/0bd1a7eb759d1f3e3cc2d1bc0f0b487ad3cc9f34d74da4b80f226fde4ec3/greenlet-3.2.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:ed6cfa9200484d234d8394c70f5492f144b20d4533f69262d530a1a082f6ee9a", size = 692443, upload-time = "2025-06-05T16:48:23.113Z" },
     { url = "https://files.pythonhosted.org/packages/67/10/b2a4b63d3f08362662e89c103f7fe28894a51ae0bc890fabf37d1d780e52/greenlet-3.2.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:02b0df6f63cd15012bed5401b47829cfd2e97052dc89da3cfaf2c779124eb892", size = 692995, upload-time = "2025-06-05T16:13:07.972Z" },
     { url = "https://files.pythonhosted.org/packages/5a/c6/ad82f148a4e3ce9564056453a71529732baf5448ad53fc323e37efe34f66/greenlet-3.2.3-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:86c2d68e87107c1792e2e8d5399acec2487a4e993ab76c792408e59394d52141", size = 655320, upload-time = "2025-06-05T16:12:53.453Z" },
     { url = "https://files.pythonhosted.org/packages/5c/4f/aab73ecaa6b3086a4c89863d94cf26fa84cbff63f52ce9bc4342b3087a06/greenlet-3.2.3-cp314-cp314-win_amd64.whl", hash = "sha256:8c47aae8fbbfcf82cc13327ae802ba13c9c36753b67e760023fd116bc124a62a", size = 301236, upload-time = "2025-06-05T16:15:20.111Z" },
@@ -1117,6 +1115,7 @@ dependencies = [
     { name = "sqlalchemy-utils" },
     { name = "starlette" },
     { name = "statsmodels" },
+    { name = "stripe" },
     { name = "tenacity" },
     { name = "urllib3" },
     { name = "uvicorn" },
@@ -1179,6 +1178,7 @@ requires-dist = [
     { name = "sqlalchemy-utils", specifier = ">=0.41.2" },
     { name = "starlette", specifier = ">=1.3.1" },
     { name = "statsmodels", specifier = ">=0.14.0" },
+    { name = "stripe", specifier = ">=15.4.0" },
     { name = "tenacity", specifier = ">=8.2.3" },
     { name = "urllib3", specifier = ">=2.5.0" },
     { name = "uvicorn", specifier = ">=0.34.3" },
@@ -2092,6 +2092,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/34/0e/2408735aca9e764643196212f9069912100151414dd617d39ffc72d77eee/statsmodels-0.14.6-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3414e40c073d725007a6603a18247ab7af3467e1af4a5e5a24e4c27bc26673b4", size = 10337587, upload-time = "2025-12-05T23:13:37.597Z" },
     { url = "https://files.pythonhosted.org/packages/0f/36/4d44f7035ab3c0b2b6a4c4ebb98dedf36246ccbc1b3e2f51ebcd7ac83abb/statsmodels-0.14.6-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a518d3f9889ef920116f9fa56d0338069e110f823926356946dae83bc9e33e19", size = 10363350, upload-time = "2025-12-05T23:13:53.08Z" },
     { url = "https://files.pythonhosted.org/packages/26/33/f1652d0c59fa51de18492ee2345b65372550501ad061daa38f950be390b6/statsmodels-0.14.6-cp314-cp314-win_amd64.whl", hash = "sha256:151b73e29f01fe619dbce7f66d61a356e9d1fe5e906529b78807df9189c37721", size = 9588010, upload-time = "2025-12-05T23:14:07.28Z" },
+]
+
+[[package]]
+name = "stripe"
+version = "15.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b0/e5/2dcf53bed6061f615d5cd03a89a311c2ca969a5b1e415d6fcfa2965ec0b6/stripe-15.4.0.tar.gz", hash = "sha256:f94c2780a7728c5fb49789e0fbb18e984267f93fa724e8400b31aebf36d01b1e", size = 1538270, upload-time = "2026-07-29T23:36:21.722Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/e1/3047b4e244cc78bb598b0d5fcab6632b8bf8a4d526f2e840c4f4de02c989/stripe-15.4.0-py3-none-any.whl", hash = "sha256:cb1b23253473c17fa8e8d9bd3b5e66bc1454089f904843ca92ac785d5bf0d4d9", size = 2197834, upload-time = "2026-07-29T23:36:19.802Z" },
 ]
 
 [[package]]

--- a/apps/frontend/__tests__/app/settings/billing.page.test.tsx
+++ b/apps/frontend/__tests__/app/settings/billing.page.test.tsx
@@ -1,0 +1,134 @@
+import React from 'react'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import BillingSettingsPage from '@/app/settings/billing/page'
+import { UNLIMITED } from '@/lib/services/billing'
+
+/**
+ * Plan & usage page (#365).
+ *
+ * The states worth pinning are the ones a user actually lands in:
+ *
+ * - Stripe not configured — which is what the free invite-only beta runs on, and
+ *   is NOT an error. Showing an upgrade button that cannot work would be worse.
+ * - unlimited (-1) — must render as "unlimited", not as a 0-width bar or "-1".
+ * - an entitled plan — offers "Manage", not "Upgrade".
+ */
+jest.mock('@/lib/auth-helpers', () => ({
+  getAuthToken: jest.fn().mockResolvedValue('tok'),
+}))
+
+const status = (overrides = {}) => ({
+  configured: true,
+  tier: 'free' as const,
+  status: null,
+  cancel_at_period_end: false,
+  current_period_end: null,
+  usage: { training_runs: 2, predictions: 50, uploads: 1 },
+  limits: { training_runs: 10, predictions: 1000, uploads: 20 },
+  ...overrides,
+})
+
+const mockStatus = (body: object) => {
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    json: jest.fn().mockResolvedValue(body),
+  })
+}
+
+describe('Plan & usage', () => {
+  it('renders the tier and the metered usage', async () => {
+    mockStatus(status())
+
+    render(<BillingSettingsPage />)
+
+    await waitFor(() => expect(screen.getByText('Free')).toBeInTheDocument())
+    expect(screen.getByText(/Training runs/)).toBeInTheDocument()
+    expect(screen.getByText(/2 \/ 10/)).toBeInTheDocument()
+  })
+
+  it('says paid plans are off rather than offering a dead button', async () => {
+    // The free invite-only beta configuration. Not an error state.
+    mockStatus(status({ configured: false }))
+
+    render(<BillingSettingsPage />)
+
+    await waitFor(() =>
+      expect(screen.getByText(/not enabled on this deployment/i)).toBeInTheDocument()
+    )
+    expect(screen.queryByRole('button', { name: /upgrade/i })).not.toBeInTheDocument()
+  })
+
+  it('offers an upgrade on the free tier when billing is configured', async () => {
+    mockStatus(status())
+
+    render(<BillingSettingsPage />)
+
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /upgrade to pro/i })).toBeInTheDocument()
+    )
+  })
+
+  it('offers management, not an upgrade, on a paid tier', async () => {
+    mockStatus(status({ tier: 'pro', status: 'active' }))
+
+    render(<BillingSettingsPage />)
+
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /manage subscription/i })).toBeInTheDocument()
+    )
+    expect(screen.queryByRole('button', { name: /upgrade/i })).not.toBeInTheDocument()
+  })
+
+  it('renders an unlimited quota as unlimited, not as -1', async () => {
+    mockStatus(
+      status({
+        tier: 'enterprise',
+        status: 'active',
+        limits: { training_runs: UNLIMITED, predictions: UNLIMITED, uploads: UNLIMITED },
+      })
+    )
+
+    render(<BillingSettingsPage />)
+
+    await waitFor(() => expect(screen.getAllByText(/unlimited/i).length).toBeGreaterThan(0))
+    expect(screen.queryByText(/-1/)).not.toBeInTheDocument()
+    // No bar to draw when there is no ceiling.
+    expect(screen.queryAllByRole('progressbar')).toHaveLength(0)
+  })
+
+  it('surfaces a failure instead of rendering an empty plan', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 503,
+      json: jest.fn().mockResolvedValue({}),
+    })
+
+    render(<BillingSettingsPage />)
+
+    await waitFor(() =>
+      expect(screen.getByText(/failed to load billing status/i)).toBeInTheDocument()
+    )
+    expect(screen.getByRole('button', { name: /try again/i })).toBeInTheDocument()
+  })
+
+  it('reports a checkout failure rather than leaving the button spinning', async () => {
+    mockStatus(status())
+
+    render(<BillingSettingsPage />)
+    await waitFor(() => screen.getByRole('button', { name: /upgrade to pro/i }))
+
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 503,
+      json: jest.fn().mockResolvedValue({}),
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /upgrade to pro/i }))
+
+    await waitFor(() => expect(screen.getByText(/HTTP 503/)).toBeInTheDocument())
+    // Back to actionable, not stuck on "Redirecting…".
+    expect(screen.getByRole('button', { name: /upgrade to pro/i })).toBeEnabled()
+  })
+})

--- a/apps/frontend/__tests__/app/settings/billing.page.test.tsx
+++ b/apps/frontend/__tests__/app/settings/billing.page.test.tsx
@@ -18,6 +18,19 @@ jest.mock('@/lib/auth-helpers', () => ({
   getAuthToken: jest.fn().mockResolvedValue('tok'),
 }))
 
+// jest.setup's global next-auth mock returns a plain object from a plain arrow,
+// so it cannot be varied per test. This suite needs to drive the session through
+// loading / unauthenticated / authenticated, so it replaces it with a jest.fn.
+const mockUseSession = jest.fn()
+jest.mock('next-auth/react', () => ({
+  useSession: () => mockUseSession(),
+}))
+
+const AUTHENTICATED = {
+  data: { user: { id: 'mock-user-id', email: 'test@example.com' } },
+  status: 'authenticated' as const,
+}
+
 const status = (overrides = {}) => ({
   configured: true,
   tier: 'free' as const,
@@ -38,6 +51,32 @@ const mockStatus = (body: object) => {
 }
 
 describe('Plan & usage', () => {
+  beforeEach(() => {
+    mockUseSession.mockReturnValue(AUTHENTICATED)
+  })
+
+  it('shows loading, not an error, while the session is resolving', () => {
+    // `enabled: !!userId` means `loading` is FALSE before auth settles, so the
+    // error branch would otherwise claim billing is unavailable on every load
+    // until the session arrives (#365 review).
+    mockUseSession.mockReturnValue({ data: null, status: 'loading' })
+    mockStatus(status())
+
+    render(<BillingSettingsPage />)
+
+    expect(screen.getByText(/loading billing/i)).toBeInTheDocument()
+    expect(screen.queryByText(/billing unavailable/i)).not.toBeInTheDocument()
+  })
+
+  it('asks an unauthenticated visitor to sign in', () => {
+    mockUseSession.mockReturnValue({ data: null, status: 'unauthenticated' })
+    mockStatus(status())
+
+    render(<BillingSettingsPage />)
+
+    expect(screen.getByText(/sign in to view your plan/i)).toBeInTheDocument()
+  })
+
   it('renders the tier and the metered usage', async () => {
     mockStatus(status())
 

--- a/apps/frontend/app/settings/billing/page.tsx
+++ b/apps/frontend/app/settings/billing/page.tsx
@@ -65,7 +65,7 @@ function UsageRow({
 }
 
 export default function BillingSettingsPage() {
-  const { data: session } = useSession()
+  const { data: session, status: sessionStatus } = useSession()
   const userId = session?.user?.id
   const [redirecting, setRedirecting] = useState(false)
   const [actionError, setActionError] = useState<string | null>(null)
@@ -95,8 +95,18 @@ export default function BillingSettingsPage() {
     }
   }
 
-  if (loading) {
+  // While the session resolves, `enabled` is false — so `loading` is false and
+  // `status` is undefined, and the error branch below would claim billing is
+  // unavailable on every single page load until auth settles. The session state is
+  // part of "still loading", not part of "failed".
+  if (sessionStatus === 'loading' || loading) {
     return <p className="p-8 text-muted-foreground">Loading billing…</p>
+  }
+
+  if (sessionStatus === 'unauthenticated') {
+    return (
+      <p className="p-8 text-muted-foreground">Sign in to view your plan.</p>
+    )
   }
 
   if (error || !status) {

--- a/apps/frontend/app/settings/billing/page.tsx
+++ b/apps/frontend/app/settings/billing/page.tsx
@@ -1,0 +1,188 @@
+'use client'
+
+import { useAsyncData } from '@/lib/hooks/useAsyncData'
+import { useSession } from 'next-auth/react'
+import {
+  BillingService,
+  UNLIMITED,
+  type BillingStatus,
+  type PlanTier,
+} from '@/lib/services/billing'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import { useState } from 'react'
+
+const METRIC_LABELS: Record<string, string> = {
+  training_runs: 'Training runs',
+  predictions: 'Predictions',
+  uploads: 'Uploads',
+}
+
+/** A metered row. `-1` is unlimited, which has no bar to draw. */
+function UsageRow({
+  metric,
+  used,
+  limit,
+}: {
+  metric: string
+  used: number
+  limit: number
+}) {
+  const unlimited = limit === UNLIMITED
+  const pct = unlimited ? 0 : Math.min(100, Math.round((used / Math.max(limit, 1)) * 100))
+  // Amber before the wall rather than at it, so the upgrade prompt arrives while
+  // there is still quota left to work with.
+  const nearing = !unlimited && pct >= 80
+
+  return (
+    <div className="space-y-1">
+      <div className="flex items-baseline justify-between text-sm">
+        <span className="text-foreground">{METRIC_LABELS[metric] ?? metric}</span>
+        <span className="text-muted-foreground">
+          {used.toLocaleString()} {unlimited ? '' : `/ ${limit.toLocaleString()}`}
+          {unlimited && <span className="ml-1">· unlimited</span>}
+        </span>
+      </div>
+      {!unlimited && (
+        <div className="h-1.5 w-full overflow-hidden rounded-full bg-muted">
+          <div
+            className={`h-full rounded-full transition-all ${
+              nearing ? 'bg-amber-500' : 'bg-blue-600'
+            }`}
+            style={{ width: `${pct}%` }}
+            role="progressbar"
+            aria-valuenow={used}
+            aria-valuemin={0}
+            aria-valuemax={limit}
+            aria-label={`${METRIC_LABELS[metric] ?? metric} usage`}
+          />
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default function BillingSettingsPage() {
+  const { data: session } = useSession()
+  const userId = session?.user?.id
+  const [redirecting, setRedirecting] = useState(false)
+  const [actionError, setActionError] = useState<string | null>(null)
+
+  const {
+    data: status,
+    loading,
+    error,
+    reload,
+  } = useAsyncData<BillingStatus>(
+    () => BillingService.getStatus(),
+    // `userId`, not `session` — the session object has a new identity every render
+    // and would refetch forever (#402).
+    [userId],
+    { enabled: !!userId, errorMessage: 'Failed to load billing status' }
+  )
+
+  const go = async (start: () => Promise<{ url: string }>) => {
+    setActionError(null)
+    setRedirecting(true)
+    try {
+      const { url } = await start()
+      window.location.href = url
+    } catch (e) {
+      setRedirecting(false)
+      setActionError(e instanceof Error ? e.message : 'Something went wrong')
+    }
+  }
+
+  if (loading) {
+    return <p className="p-8 text-muted-foreground">Loading billing…</p>
+  }
+
+  if (error || !status) {
+    return (
+      <div className="p-8">
+        <Alert variant="destructive">
+          <AlertDescription>{error ?? 'Billing unavailable'}</AlertDescription>
+        </Alert>
+        <Button className="mt-4" variant="outline" onClick={reload}>
+          Try again
+        </Button>
+      </div>
+    )
+  }
+
+  const tierLabel: Record<PlanTier, string> = {
+    free: 'Free',
+    pro: 'Pro',
+    enterprise: 'Enterprise',
+  }
+
+  return (
+    <div className="mx-auto max-w-2xl space-y-6 p-8">
+      <div>
+        <h1 className="text-2xl font-bold text-foreground">Plan &amp; usage</h1>
+        <p className="text-muted-foreground">
+          What you are on, and how much of it you have used this period.
+        </p>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <div>
+              <CardTitle>{tierLabel[status.tier]}</CardTitle>
+              <CardDescription>
+                {status.cancel_at_period_end
+                  ? 'Cancels at the end of the current period'
+                  : status.current_period_end
+                    ? `Renews ${new Date(status.current_period_end).toLocaleDateString()}`
+                    : 'No paid subscription'}
+              </CardDescription>
+            </div>
+            {status.status && <Badge variant="outline">{status.status}</Badge>}
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {Object.keys(status.limits).map((metric) => (
+            <UsageRow
+              key={metric}
+              metric={metric}
+              used={status.usage[metric] ?? 0}
+              limit={status.limits[metric]}
+            />
+          ))}
+        </CardContent>
+      </Card>
+
+      {actionError && (
+        <Alert variant="destructive">
+          <AlertDescription>{actionError}</AlertDescription>
+        </Alert>
+      )}
+
+      {!status.configured ? (
+        // Not an error state. The free invite-only beta runs exactly like this,
+        // and saying so is better than showing a button that cannot work.
+        <Alert>
+          <AlertDescription>
+            Paid plans are not enabled on this deployment. You are on the Free tier
+            with the limits shown above.
+          </AlertDescription>
+        </Alert>
+      ) : status.tier === 'free' ? (
+        <Button disabled={redirecting} onClick={() => go(() => BillingService.startCheckout('pro'))}>
+          {redirecting ? 'Redirecting…' : 'Upgrade to Pro'}
+        </Button>
+      ) : (
+        <Button
+          variant="outline"
+          disabled={redirecting}
+          onClick={() => go(() => BillingService.openPortal())}
+        >
+          {redirecting ? 'Redirecting…' : 'Manage subscription'}
+        </Button>
+      )}
+    </div>
+  )
+}

--- a/apps/frontend/lib/services/billing.ts
+++ b/apps/frontend/lib/services/billing.ts
@@ -1,0 +1,66 @@
+/**
+ * Billing API client (#365).
+ *
+ * `API_BASE_URL` already carries the `/api/v1` prefix — appending it again is the
+ * bug #406 fixed across three modules, and `__tests__/lib/apiUrlConstruction.test.ts`
+ * now scans the whole repo for it.
+ */
+import { API_BASE_URL } from '@/lib/config'
+import { getAuthToken } from '@/lib/auth-helpers'
+
+export type PlanTier = 'free' | 'pro' | 'enterprise'
+
+/** `-1` means no ceiling. Passed through rather than omitted so the UI can tell
+ *  "unlimited" from "not reported". */
+export const UNLIMITED = -1
+
+export interface BillingStatus {
+  configured: boolean
+  tier: PlanTier
+  status: string | null
+  cancel_at_period_end: boolean
+  current_period_end: string | null
+  usage: Record<string, number>
+  limits: Record<string, number>
+}
+
+async function authorizedFetch(path: string, init?: RequestInit) {
+  const token = await getAuthToken()
+  const response = await fetch(`${API_BASE_URL}${path}`, {
+    ...init,
+    headers: {
+      'Content-Type': 'application/json',
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      ...(init?.headers ?? {}),
+    },
+  })
+  if (!response.ok) {
+    // Carry the status: 503 means "billing is off on this deployment", which the
+    // UI presents differently from a genuine failure.
+    throw new Error(`Billing request failed (HTTP ${response.status})`)
+  }
+  return response.json()
+}
+
+export const BillingService = {
+  getStatus: (): Promise<BillingStatus> => authorizedFetch('/billing/status'),
+
+  startCheckout: (tier: PlanTier): Promise<{ url: string }> =>
+    authorizedFetch('/billing/checkout', {
+      method: 'POST',
+      body: JSON.stringify({
+        tier,
+        // Absolute, because Stripe redirects the browser back here itself.
+        success_url: `${window.location.origin}/settings/billing?checkout=success`,
+        cancel_url: `${window.location.origin}/settings/billing?checkout=cancelled`,
+      }),
+    }),
+
+  openPortal: (): Promise<{ url: string }> =>
+    authorizedFetch('/billing/portal', {
+      method: 'POST',
+      body: JSON.stringify({
+        return_url: `${window.location.origin}/settings/billing`,
+      }),
+    }),
+}


### PR DESCRIPTION
Closes #365. Fourth of the billing epic (#370).

Both flows are **hosted** — Stripe collects the card and manages the subscription on its own pages, so this service never sees a card number. That is the reason to use Checkout and the portal rather than build either.

## Lazy initialisation is the point

Secret-less Docker builds and the free invite-only beta both run with **no** `STRIPE_SECRET_KEY`, and the router imports `stripe_client` at startup. So the SDK import and the key check happen on first *use*, never at import time.

`BillingNotConfigured` is a distinct exception type so callers answer **503** ("billing is not available here") rather than 500 ("something broke"). Running without Stripe is a supported configuration, not a fault — and there are tests for that whole path, because it is the configuration the product ships in today.

## Both tenant markers, deliberately

The checkout session sets **both** `client_reference_id` and `subscription_data.metadata.user_id`. #367 reads the first off the checkout session and the second off the subscription object, and treats an event carrying neither as one we did not originate — so setting only one would silently drop half the events. A test asserts both are present.

An existing Stripe customer is reused, so a second subscription does not create a duplicate customer with its own billing history.

## Tenancy

`user_id` always comes from the session, never the body. There is a test that posts `user_id` and `client_reference_id` **in the payload** and asserts Stripe still receives the authenticated tenant. Without that, anyone could start a subscription against — or read the usage of — someone else's account.

## Frontend

`/settings/billing` — tier, per-metric usage bars, and one button that is *Upgrade* or *Manage* depending on entitlement.

- With Stripe unconfigured it **says so plainly** rather than offering a button that cannot work. That is precisely what the free beta looks like, so it is a first-class state, not an error.
- Unlimited renders as "unlimited", not `-1` and not a zero-width bar.
- The usage bar turns amber at 80%, so the upgrade prompt arrives while there is still quota left to act on.
- Keys its fetch on `userId`, **not** `session` — the session object has a new identity every render and would refetch forever (#402).

## Smaller decisions

- SDK calls run through `asyncio.to_thread`. The Stripe sync client makes real HTTP calls; awaiting them inline would block every other request on the worker.
- A tier with no configured price is **503, not 400** — the caller asked for something perfectly valid that this deployment cannot sell.
- The portal 503s for a tenant with no Stripe customer: it manages an existing relationship, and there is nothing to open.

## Gates

- Backend billing suites — **362 passed**
- Frontend — 1,391 passed, 3 skipped (7 new on the billing page)
- `ruff` clean, `mypy` clean (177 files), `tsc` clean, eslint 233 (unchanged), `next build` clean

## Note on credentials

Built and tested against **env-configured** keys only. I have not handled any real Stripe credentials — you will need to set `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET` and the two `STRIPE_PRICE_*` values yourself to exercise a live test-mode flow.

## Next

#368 (plan enforcement) → #370 closes.