### PR TITLE
chore(frontend): upgrade mongodb driver 6 → 7 (#344)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -269,6 +269,18 @@ jobs:
     name: Frontend Unit Tests
     timeout-minutes: 10
     runs-on: ubuntu-latest
+    services:
+      # For the @auth/mongodb-adapter compatibility check below. Digest-pinned to
+      # the same image as the backend jobs (#176).
+      mongodb:
+        image: mongo:7.0@sha256:8ecb514b00bdcc0bde67ef4e6c330385377a9dc68e24ee94e28c07c891647348
+        ports:
+          - 27017:27017
+        options: >-
+          --health-cmd "mongosh --quiet --eval 'db.adminCommand({ping:1})'"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -284,6 +296,14 @@ jobs:
         run: npm test -- --coverage --watchAll=false
         env:
           CI: true
+      # We run mongodb 7 against an adapter whose peer range says ^6, forced with
+      # an `overrides` entry (#344). That silences npm's warning, so this is what
+      # replaces it: the adapter's real methods against a real mongod. Cannot be a
+      # jest test — the adapter is ESM-only and next/jest ignores all of
+      # node_modules for transforms.
+      - name: Check @auth/mongodb-adapter against the installed driver
+        working-directory: apps/frontend
+        run: npm run check:adapter
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -269,10 +269,47 @@ jobs:
     name: Frontend Unit Tests
     timeout-minutes: 10
     runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: apps/frontend/package-lock.json
+      - name: Install dependencies
+        working-directory: apps/frontend
+        run: npm ci
+      - name: Run unit tests with coverage
+        working-directory: apps/frontend
+        run: npm test -- --coverage --watchAll=false
+        env:
+          CI: true
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        with:
+          files: apps/frontend/coverage/lcov.info
+          flags: frontend-unit
+          name: frontend-unit-tests
+          fail_ci_if_error: false
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+  frontend-adapter-compat:
+    name: Frontend Adapter Compatibility
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    # Its OWN job, deliberately. We run mongodb 7 against an adapter whose peer
+    # range says ^6, forced with an `overrides` entry (#344) — that silences npm's
+    # warning, so this replaces it by exercising the adapter's real methods against
+    # a real mongod. It needs a service container, and folding it into
+    # frontend-unit made 1393 tests that never touched a database newly dependent
+    # on Docker Hub being up. It isn't; that failure is what prompted this split.
+    #
+    # Not a jest test: the adapter is ESM-only and next/jest's transformIgnore-
+    # Patterns covers all of node_modules, so our config cannot reach it.
     services:
-      # For the @auth/mongodb-adapter compatibility check below. Digest-pinned to
-      # the same image as the backend jobs (#176).
       mongodb:
+        # Digest-pinned to the same image as the backend jobs (#176).
         image: mongo:7.0@sha256:8ecb514b00bdcc0bde67ef4e6c330385377a9dc68e24ee94e28c07c891647348
         ports:
           - 27017:27017
@@ -291,28 +328,9 @@ jobs:
       - name: Install dependencies
         working-directory: apps/frontend
         run: npm ci
-      - name: Run unit tests with coverage
-        working-directory: apps/frontend
-        run: npm test -- --coverage --watchAll=false
-        env:
-          CI: true
-      # We run mongodb 7 against an adapter whose peer range says ^6, forced with
-      # an `overrides` entry (#344). That silences npm's warning, so this is what
-      # replaces it: the adapter's real methods against a real mongod. Cannot be a
-      # jest test — the adapter is ESM-only and next/jest ignores all of
-      # node_modules for transforms.
       - name: Check @auth/mongodb-adapter against the installed driver
         working-directory: apps/frontend
         run: npm run check:adapter
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
-        with:
-          files: apps/frontend/coverage/lcov.info
-          flags: frontend-unit
-          name: frontend-unit-tests
-          fail_ci_if_error: false
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   frontend-docker-build:
     name: Frontend Docker Build
@@ -589,6 +607,7 @@ jobs:
       - frontend-lint
       - frontend-typecheck-build
       - frontend-unit
+      - frontend-adapter-compat
       - frontend-docker-build
       - mcp-tests
       - shell-lint

--- a/apps/frontend/eslint.config.mjs
+++ b/apps/frontend/eslint.config.mjs
@@ -34,6 +34,9 @@ const eslintConfig = defineConfig([
       "**/__tests__/**",
       "e2e/**",
       "jest.setup.*",
+      // Developer CLI checks. Printing IS the output — check:adapter (#344) is a
+      // pass/fail report a human and CI both read off stdout.
+      "scripts/**",
     ],
     rules: {
       "no-console": "off",

--- a/apps/frontend/package-lock.json
+++ b/apps/frontend/package-lock.json
@@ -36,7 +36,7 @@
         "jspdf": "^4.2.1",
         "jspdf-autotable": "^5.0.8",
         "lucide-react": "^1.27.0",
-        "mongodb": "6.20.0",
+        "mongodb": "^7.5.0",
         "next": "16.2.12",
         "next-auth": "5.0.0-beta.32",
         "next-themes": "^0.4.6",
@@ -2700,9 +2700,9 @@
       "license": "MIT"
     },
     "node_modules/@mongodb-js/saslprep": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.3.0.tgz",
-      "integrity": "sha512-zlayKCsIjYb7/IdfqxorK5+xUMyi4vOKcFy10wKJYc63NSdKI8mNME+uJqfatkPmOSMMUiojrL58IePKBm3gvQ==",
+      "version": "1.4.13",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.4.13.tgz",
+      "integrity": "sha512-E3Sv4eCYAlKYUTx8S3ioQcDUscOif+8zZ5OnW1IzJ+Tt+EO+ke8mn+Y3FX6N1H79picwbdOavVOb1jPi2EOyrg==",
       "license": "MIT",
       "dependencies": {
         "sparse-bitfield": "^3.0.3"
@@ -5370,9 +5370,9 @@
       "license": "MIT"
     },
     "node_modules/@types/whatwg-url": {
-      "version": "11.0.5",
-      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-11.0.5.tgz",
-      "integrity": "sha512-coYR071JRaHa+xoEvvYqvnIHaVqaYrLPbsufM9BF63HkwI5Lgmy2QR8Q5K/lYDYo5AK82wOvSOS0UsLTpTG7uQ==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-13.0.0.tgz",
+      "integrity": "sha512-N8WXpbE6Wgri7KUSvrmQcqrMllKZ9uxkYWMt+mCSGwNc0Hsw9VQTW7ApqI4XNrx6/SaM2QQJCzMPDEXE058s+Q==",
       "license": "MIT",
       "dependencies": {
         "@types/webidl-conversions": "*"
@@ -6384,12 +6384,12 @@
       }
     },
     "node_modules/bson": {
-      "version": "6.10.4",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-6.10.4.tgz",
-      "integrity": "sha512-WIsKqkSC0ABoBJuT1LEX+2HEvNmNKKgnTAyd0fL8qzK4SH2i9NXg+t08YtdZp/V9IZ33cxe3iV4yM0qg8lMQng==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-7.3.1.tgz",
+      "integrity": "sha512-h/C0qe6857pQhcSJHLfsR1uYGj98Ge3wKAD3Ed9KqH3wcVh+BM4Jq4xISD7vs9OPuT07n+q3QQVjslJ286j6ag==",
       "license": "Apache-2.0",
       "engines": {
-        "node": ">=16.20.1"
+        "node": ">=20.19.0"
       }
     },
     "node_modules/buffer-from": {
@@ -12406,27 +12406,27 @@
       }
     },
     "node_modules/mongodb": {
-      "version": "6.20.0",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.20.0.tgz",
-      "integrity": "sha512-Tl6MEIU3K4Rq3TSHd+sZQqRBoGlFsOgNrH5ltAcFBV62Re3Fd+FcaVf8uSEQFOJ51SDowDVttBTONMfoYWrWlQ==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-7.5.0.tgz",
+      "integrity": "sha512-5FnrEDLnvp6ycUOGLNLLU33BfCx2qmp2mJjGPDwKLruYsVzXVSK5fsGpoDXvsXJwBfBsD7ebMRdawbDxC2814g==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@mongodb-js/saslprep": "^1.3.0",
-        "bson": "^6.10.4",
-        "mongodb-connection-string-url": "^3.0.2"
+        "@mongodb-js/saslprep": "^1.4.11",
+        "bson": "^7.2.0",
+        "mongodb-connection-string-url": "^7.0.1"
       },
       "engines": {
-        "node": ">=16.20.1"
+        "node": ">=20.19.0"
       },
       "peerDependencies": {
-        "@aws-sdk/credential-providers": "^3.188.0",
-        "@mongodb-js/zstd": "^1.1.0 || ^2.0.0",
-        "gcp-metadata": "^5.2.0",
-        "kerberos": "^2.0.1",
-        "mongodb-client-encryption": ">=6.0.0 <7",
+        "@aws-sdk/credential-providers": "^3.806.0",
+        "@mongodb-js/zstd": "^7.0.0",
+        "gcp-metadata": "^7.0.1",
+        "kerberos": "^7.0.0",
+        "mongodb-client-encryption": "^7.2.0",
         "snappy": "^7.3.2",
-        "socks": "^2.7.1"
+        "socks": "^2.8.6"
       },
       "peerDependenciesMeta": {
         "@aws-sdk/credential-providers": {
@@ -12453,13 +12453,16 @@
       }
     },
     "node_modules/mongodb-connection-string-url": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-3.0.2.tgz",
-      "integrity": "sha512-rMO7CGo/9BFwyZABcKAWL8UJwH/Kc2x0g72uhDWzG48URRax5TCIcJ7Rc3RZqffZzO/Gwff/jyKwCU9TN8gehA==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-7.0.2.tgz",
+      "integrity": "sha512-ZoS07RoFqpKYQwAk59qmrx8+jJHNHU30UjlU96QktiGn1ltvDr+vCznLX5DiUBLEpMAHatHNWV1nM/74ul66kA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@types/whatwg-url": "^11.0.2",
-        "whatwg-url": "^14.1.0 || ^13.0.0"
+        "@types/whatwg-url": "^13.0.0",
+        "whatwg-url": "^14.1.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/motion-dom": {

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -19,7 +19,8 @@
     "test:e2e:all": "./test-e2e.sh --project=chromium-full --project=firefox-full --project=webkit-full",
     "test:e2e:ui": "./test-e2e.sh --ui",
     "test:e2e:debug": "./test-e2e.sh --debug",
-    "test:e2e:report": "playwright show-report"
+    "test:e2e:report": "playwright show-report",
+    "check:adapter": "node scripts/check-auth-adapter.mjs"
   },
   "dependencies": {
     "@auth/mongodb-adapter": "^3.11.3",
@@ -49,7 +50,7 @@
     "jspdf": "^4.2.1",
     "jspdf-autotable": "^5.0.8",
     "lucide-react": "^1.27.0",
-    "mongodb": "6.20.0",
+    "mongodb": "^7.5.0",
     "next": "16.2.12",
     "next-auth": "5.0.0-beta.32",
     "next-themes": "^0.4.6",
@@ -96,6 +97,7 @@
     "next": {
       "postcss": "^8.5.15"
     },
-    "sharp": "^0.35.3"
+    "sharp": "^0.35.3",
+    "mongodb": "$mongodb"
   }
 }

--- a/apps/frontend/scripts/check-auth-adapter.mjs
+++ b/apps/frontend/scripts/check-auth-adapter.mjs
@@ -38,48 +38,54 @@ console.log('driver:', (await import('mongodb/package.json', { with: { type: 'js
 console.log('adapter peer range: mongodb ^6 (overridden deliberately — see above)')
 console.log('')
 
-const adapter = MongoDBAdapter(client, { databaseName: DB })
-const email = `probe-${Date.now()}@example.com`
+try {
+  const adapter = MongoDBAdapter(client, { databaseName: DB })
+  const email = `probe-${Date.now()}@example.com`
 
-const user = await adapter.createUser({ id: 'x', email, emailVerified: null, name: 'Probe' })
-ok('createUser returns a 24-hex id', /^[0-9a-f]{24}$/.test(user.id))
+  const user = await adapter.createUser({ id: 'x', email, emailVerified: null, name: 'Probe' })
+  ok('createUser returns a 24-hex id', /^[0-9a-f]{24}$/.test(user.id))
 
-const fetched = await adapter.getUser(user.id)
-ok('getUser round-trips', fetched?.email === email)
+  const fetched = await adapter.getUser(user.id)
+  ok('getUser round-trips', fetched?.email === email)
 
-const byEmail = await adapter.getUserByEmail(email)
-ok('getUserByEmail round-trips', byEmail?.id === user.id)
+  const byEmail = await adapter.getUserByEmail(email)
+  ok('getUserByEmail round-trips', byEmail?.id === user.id)
 
-await adapter.linkAccount({
-  userId: user.id, type: 'oauth', provider: 'github',
-  providerAccountId: 'gh-123', access_token: 'tok',
-})
-const byAccount = await adapter.getUserByAccount({ provider: 'github', providerAccountId: 'gh-123' })
-ok('getUserByAccount (every repeat sign-in)', byAccount?.id === user.id)
+  await adapter.linkAccount({
+    userId: user.id, type: 'oauth', provider: 'github',
+    providerAccountId: 'gh-123', access_token: 'tok',
+  })
+  const byAccount = await adapter.getUserByAccount({ provider: 'github', providerAccountId: 'gh-123' })
+  ok('getUserByAccount (every repeat sign-in)', byAccount?.id === user.id)
 
-const updated = await adapter.updateUser({ id: user.id, name: 'Renamed' })
-ok('updateUser', updated.name === 'Renamed')
+  const updated = await adapter.updateUser({ id: user.id, name: 'Renamed' })
+  ok('updateUser', updated.name === 'Renamed')
 
-await adapter.createSession({ sessionToken: 't1', userId: user.id, expires: new Date(Date.now() + 60000) })
-const sess = await adapter.getSessionAndUser('t1')
-ok('getSessionAndUser (every authed request)', sess?.user?.id === user.id)
+  await adapter.createSession({ sessionToken: 't1', userId: user.id, expires: new Date(Date.now() + 60000) })
+  const sess = await adapter.getSessionAndUser('t1')
+  ok('getSessionAndUser (every authed request)', sess?.user?.id === user.id)
 
-await adapter.updateSession({ sessionToken: 't1', expires: new Date(Date.now() + 120000) })
-ok('updateSession', !!(await adapter.getSessionAndUser('t1')))
+  await adapter.updateSession({ sessionToken: 't1', expires: new Date(Date.now() + 120000) })
+  ok('updateSession', !!(await adapter.getSessionAndUser('t1')))
 
-await adapter.deleteSession('t1')
-ok('deleteSession', (await adapter.getSessionAndUser('t1')) === null)
+  await adapter.deleteSession('t1')
+  ok('deleteSession', (await adapter.getSessionAndUser('t1')) === null)
 
-// BSON handling is the thing a driver major is most likely to move.
-const raw = await client.db(DB).collection('users').findOne({ email })
-ok('_id stored as a real ObjectId', raw?._id?.toHexString?.() === user.id)
+  // BSON handling is the thing a driver major is most likely to move.
+  const raw = await client.db(DB).collection('users').findOne({ email })
+  ok('_id stored as a real ObjectId', raw?._id?.toHexString?.() === user.id)
 
-await adapter.unlinkAccount({ provider: 'github', providerAccountId: 'gh-123' })
-ok('unlinkAccount', (await adapter.getUserByAccount({ provider: 'github', providerAccountId: 'gh-123' })) === null)
+  await adapter.unlinkAccount({ provider: 'github', providerAccountId: 'gh-123' })
+  ok('unlinkAccount', (await adapter.getUserByAccount({ provider: 'github', providerAccountId: 'gh-123' })) === null)
 
-await adapter.deleteUser(user.id)
-ok('deleteUser', (await adapter.getUser(user.id)) === null)
-
-await client.db(DB).dropDatabase()
-await client.close()
+  await adapter.deleteUser(user.id)
+  ok('deleteUser', (await adapter.getUser(user.id)) === null)
+} finally {
+  // Drop and disconnect even when an assertion throws. In CI the mongod is an
+  // ephemeral service container so it would not matter, but the script accepts
+  // TEST_MONGODB_URI precisely so it can be pointed at a long-lived instance —
+  // and there a failed run would otherwise leave this database behind forever.
+  await client.db(DB).dropDatabase().catch(() => {})
+  await client.close().catch(() => {})
+}
 console.log(process.exitCode ? '\nRESULT: adapter is NOT compatible' : '\nRESULT: adapter works on this driver')

--- a/apps/frontend/scripts/check-auth-adapter.mjs
+++ b/apps/frontend/scripts/check-auth-adapter.mjs
@@ -1,0 +1,85 @@
+// Does @auth/mongodb-adapter actually work on the installed mongodb driver? (#344)
+//
+// WHY THIS EXISTS. The adapter declares `peerDependencies: { mongodb: "^6" }`, and
+// we run mongodb 7 with an `overrides` entry that forces a single copy into the
+// tree. That override is the whole reason the 6 -> 7 bump was possible — the peer
+// range turned out to be a conservative maintainer claim, not a real
+// incompatibility, and every adapter method NextAuth uses passes against a real
+// mongod on 7.x.
+//
+// The cost of overriding a peer range is that npm will no longer warn us when the
+// claim becomes true. This script is what replaces that warning: it exercises the
+// adapter's real methods against a real database, so a future driver or adapter
+// bump that genuinely breaks fails here loudly instead of in production sign-in.
+//
+// Cannot be a jest test: the adapter is ESM-only (an `import` condition and no
+// `require`), and next/jest's own transformIgnorePatterns matches all of
+// node_modules, so no moduleNameMapper or transform override in our config can
+// reach it. A standalone node script is the shortest thing that actually runs.
+//
+// Usage: npm run check:adapter    (needs mongod on localhost:27017)
+import { MongoClient, ServerApiVersion } from 'mongodb'
+import { MongoDBAdapter } from '@auth/mongodb-adapter'
+
+const DB = 'nma_adapter_compat_probe'
+const URI = process.env.TEST_MONGODB_URI ?? 'mongodb://localhost:27017'
+const client = new MongoClient(URI, {
+  serverApi: { version: ServerApiVersion.v1, strict: false, deprecationErrors: true },
+  serverSelectionTimeoutMS: 3000,
+})
+
+const ok = (label, cond) => {
+  console.log(`${cond ? 'PASS' : 'FAIL'}  ${label}`)
+  if (!cond) process.exitCode = 1
+}
+
+await client.connect()
+console.log('driver:', (await import('mongodb/package.json', { with: { type: 'json' } })).default.version)
+console.log('adapter peer range: mongodb ^6 (overridden deliberately — see above)')
+console.log('')
+
+const adapter = MongoDBAdapter(client, { databaseName: DB })
+const email = `probe-${Date.now()}@example.com`
+
+const user = await adapter.createUser({ id: 'x', email, emailVerified: null, name: 'Probe' })
+ok('createUser returns a 24-hex id', /^[0-9a-f]{24}$/.test(user.id))
+
+const fetched = await adapter.getUser(user.id)
+ok('getUser round-trips', fetched?.email === email)
+
+const byEmail = await adapter.getUserByEmail(email)
+ok('getUserByEmail round-trips', byEmail?.id === user.id)
+
+await adapter.linkAccount({
+  userId: user.id, type: 'oauth', provider: 'github',
+  providerAccountId: 'gh-123', access_token: 'tok',
+})
+const byAccount = await adapter.getUserByAccount({ provider: 'github', providerAccountId: 'gh-123' })
+ok('getUserByAccount (every repeat sign-in)', byAccount?.id === user.id)
+
+const updated = await adapter.updateUser({ id: user.id, name: 'Renamed' })
+ok('updateUser', updated.name === 'Renamed')
+
+await adapter.createSession({ sessionToken: 't1', userId: user.id, expires: new Date(Date.now() + 60000) })
+const sess = await adapter.getSessionAndUser('t1')
+ok('getSessionAndUser (every authed request)', sess?.user?.id === user.id)
+
+await adapter.updateSession({ sessionToken: 't1', expires: new Date(Date.now() + 120000) })
+ok('updateSession', !!(await adapter.getSessionAndUser('t1')))
+
+await adapter.deleteSession('t1')
+ok('deleteSession', (await adapter.getSessionAndUser('t1')) === null)
+
+// BSON handling is the thing a driver major is most likely to move.
+const raw = await client.db(DB).collection('users').findOne({ email })
+ok('_id stored as a real ObjectId', raw?._id?.toHexString?.() === user.id)
+
+await adapter.unlinkAccount({ provider: 'github', providerAccountId: 'gh-123' })
+ok('unlinkAccount', (await adapter.getUserByAccount({ provider: 'github', providerAccountId: 'gh-123' })) === null)
+
+await adapter.deleteUser(user.id)
+ok('deleteUser', (await adapter.getUser(user.id)) === null)
+
+await client.db(DB).dropDatabase()
+await client.close()
+console.log(process.exitCode ? '\nRESULT: adapter is NOT compatible' : '\nRESULT: adapter works on this driver')


### PR DESCRIPTION
Closes #344.

## The blocker was assumed, not measured

#344 was filed as "breaking major; CI fails until migrated", on the strength of `@auth/mongodb-adapter` declaring `peerDependencies: { mongodb: "^6" }`. I had been repeating that reading, including earlier in this session.

A peer range is a maintainer's compatibility *claim*. It is not a test result. So I ran the adapter's real methods against a real mongod on driver 7.5.0:

```
driver: 7.5.0
adapter peer range: mongodb ^6 (overridden deliberately)

PASS  createUser returns a 24-hex id
PASS  getUser round-trips
PASS  getUserByEmail round-trips
PASS  getUserByAccount (every repeat sign-in)
PASS  updateUser
PASS  getSessionAndUser (every authed request)
PASS  updateSession
PASS  deleteSession
PASS  _id stored as a real ObjectId
PASS  unlinkAccount
PASS  deleteUser

RESULT: adapter works on this driver
```

Every method NextAuth drives during sign-in and on every authenticated request. Including `_id` BSON handling, which is what a driver major is most likely to move.

## What changed

- `mongodb` `^6.20.0` → `^7.5.0`
- An `overrides` entry pins the tree to one driver copy, so the adapter cannot resolve a second one alongside. Verified: `npm ls mongodb` shows `@auth/mongodb-adapter` deduped onto 7.5.0.

Our own mongodb surface is three symbols — `MongoClient`, `ServerApiVersion` in `lib/db.ts`, and `MongoDBAdapter(client)` in `auth.ts`.

## The cost of the override, and what pays for it

Overriding a peer range silences npm's warning for the case where the claim *becomes* true. So `scripts/check-auth-adapter.mjs` replaces that warning and runs in CI against a mongod service.

I checked it can actually fail, because a green check that cannot go red is worse than no check:

| Condition | Exit |
|---|---|
| Healthy | 0 |
| One adapter assertion broken (simulated incompatibility) | 1 |
| No database reachable | 1 |

That last row matters — it does **not** skip itself green when mongod is missing, which is the usual way an integration check quietly stops testing anything.

It is a script rather than a jest test for a specific reason: the adapter is ESM-only (an `import` condition, no `require`), and `next/jest`'s own `transformIgnorePatterns` matches all of `node_modules`, so no `moduleNameMapper` or transform override in our config can reach it. I tried; the fix is in next/jest, not here. A standalone script was the shortest thing that actually runs.

## Gates

`tsc --noEmit` clean · **1393 tests pass** (112 suites) · lint **233/280, 0 errors** · production `next build` succeeds.

`scripts/` joins `__tests__/` and `e2e/` in the `no-console` relaxation — printing is the entire output of a pass/fail CLI check. That is a deliberate narrowing, not a widened ignore: the ceiling is untouched at 280 and errors stay at 0.

## Note on #391

I re-ran the same experiment for the eslint 9 → 10 bump. That one is **genuinely** blocked — `eslint-plugin-react@7.37.5` calls `context.getFilename()`, removed in eslint 10, and it throws at *rule load* so it cannot be disabled around. Evidence posted on #391. The two issues looked identical from the peer ranges alone and are not.