### PR TITLE
ops(backup): script the automatable half of the backup posture (#299)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -312,7 +312,6 @@ jobs:
             -t narrative-frontend:ci \
             apps/frontend
 
-  # ── MCP ────────────────────────────────────────────────────────────────────
   shell-lint:
     name: Shell Lint (shellcheck)
     timeout-minutes: 5
@@ -332,7 +331,13 @@ jobs:
         run: |
           shopt -s globstar nullglob
           shellcheck --severity=warning scripts/**/*.sh
+      # Lint proves syntax, not behaviour. The lifecycle merge in
+      # configure-s3-backup.sh is the destructive-if-wrong part, so it gets real
+      # tests against a stubbed `aws` — no AWS account needed.
+      - name: ops script behaviour tests
+        run: ./scripts/ops/test-configure-s3-backup.sh
 
+  # ── MCP ────────────────────────────────────────────────────────────────────
   mcp-tests:
     name: MCP Tests
     timeout-minutes: 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -313,6 +313,26 @@ jobs:
             apps/frontend
 
   # ── MCP ────────────────────────────────────────────────────────────────────
+  shell-lint:
+    name: Shell Lint (shellcheck)
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      # scripts/ops/* mutate and audit production infrastructure (#299), so a
+      # typo there is more expensive than a typo in application code. shellcheck
+      # ships on the GitHub runner image — no install step.
+      #
+      # severity=warning, not the default: the existing scripts carry `info`
+      # findings that are correct as written (preflight_staging_env.sh writes a
+      # literal compose file, so SC2016's "expressions don't expand in single
+      # quotes" is the point). Everything tracked passes at this level today, so
+      # the gate covers the whole directory rather than only the new files.
+      - name: shellcheck
+        run: |
+          shopt -s globstar nullglob
+          shellcheck --severity=warning scripts/**/*.sh
+
   mcp-tests:
     name: MCP Tests
     timeout-minutes: 10
@@ -546,6 +566,7 @@ jobs:
       - frontend-unit
       - frontend-docker-build
       - mcp-tests
+      - shell-lint
       - e2e-smoke
     runs-on: ubuntu-latest
     steps:

--- a/docs/deployment/DATA_ERASURE_AND_BACKUP_RUNBOOK.md
+++ b/docs/deployment/DATA_ERASURE_AND_BACKUP_RUNBOOK.md
@@ -51,7 +51,12 @@ Automated equivalent: `tests/test_integration/test_erasure_cascade.py`.
 
 ## 2. MongoDB Atlas backups (enable in Atlas)
 
-> No IaC in this repo manages Atlas — configure in the Atlas UI / Admin API.
+> Enabling is a console/Admin-API action needing real Atlas credentials, so it
+> stays manual. **Verifying is not** — `./scripts/ops/verify-backup-config.sh`
+> checks `backupEnabled`, `pitEnabled` and the hourly/daily/weekly snapshot policy
+> over the Atlas Admin API when `ATLAS_PUBLIC_KEY` / `ATLAS_PRIVATE_KEY` /
+> `ATLAS_GROUP_ID` / `ATLAS_CLUSTER_NAME` are set, and says SKIP rather than
+> passing silently when they are not.
 
 1. **Cloud Backup** → cluster → **Backup** → enable **Cloud Backup** (snapshots).
 2. Snapshot policy: hourly (2-day retention) + daily (7-day) + weekly (4-week);
@@ -73,7 +78,18 @@ Automated equivalent: `tests/test_integration/test_erasure_cascade.py`.
 
 ## 3. S3 versioning + lifecycle (enable on the bucket)
 
-> Configure on the app bucket (`AWS_BUCKET_NAME`) in the S3 console / IaC.
+> **Scripted (#299).** Do not click through the console:
+>
+> ```bash
+> AWS_BUCKET_NAME=<prod-bucket> ./scripts/ops/configure-s3-backup.sh --dry-run
+> AWS_BUCKET_NAME=<prod-bucket> ./scripts/ops/configure-s3-backup.sh
+> ```
+>
+> Idempotent, and it refuses to run without credentials or a reachable bucket
+> rather than half-applying. It covers steps 1 and 2 below; **MFA-delete (3.4)
+> stays manual** because S3 requires the root account's MFA token on the request.
+> The steps are kept here because a script is not a substitute for knowing what
+> it does — and for the case where you are configuring by hand.
 
 1. **Versioning:** enable **Bucket Versioning** — protects against accidental
    deletes/overwrites and makes the cascade-erasure's `DeleteObject`s create
@@ -94,7 +110,22 @@ delete-object --version-id <marker>`); confirm the object is readable again.
 
 ---
 
-## 4. Drill log
+## 4. Verifying the posture
+
+Before and after every drill, and quarterly regardless:
+
+```bash
+AWS_BUCKET_NAME=<prod-bucket> ./scripts/ops/verify-backup-config.sh
+```
+
+Read-only, and **exits non-zero when anything required is missing** — so it is
+evidence, not reassurance. Paste its output into the drill log rather than
+writing "backups verified". It reports `MANUAL` for MFA-delete and `SKIP` for
+Atlas without API credentials instead of quietly counting them as passes.
+
+---
+
+## 5. Drill log
 
 | Date | Drill | RTO | RPO | Operator | Notes |
 |---|---|---|---|---|---|

--- a/scripts/ops/configure-s3-backup.sh
+++ b/scripts/ops/configure-s3-backup.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+#
+# Apply the S3 half of the backup posture (#299 / AC3 of #259).
+#
+# Replaces "click through the S3 console following section 3 of the runbook" with
+# one idempotent command. Safe to re-run: enabling versioning that is already on
+# is a no-op, and the lifecycle configuration is declared whole, so re-running
+# converges rather than appending duplicate rules.
+#
+# It does NOT touch MFA-delete. That genuinely cannot be scripted here — S3
+# requires the root account's MFA serial and a current token on the request, so it
+# stays a console step in the runbook, deliberately.
+#
+# Usage:
+#   AWS_BUCKET_NAME=my-bucket ./scripts/ops/configure-s3-backup.sh          # apply
+#   AWS_BUCKET_NAME=my-bucket ./scripts/ops/configure-s3-backup.sh --dry-run
+#
+# Credentials come from the ambient AWS CLI configuration (profile, SSO, env, or
+# instance role). This script never takes, prints, or stores a credential.
+
+set -euo pipefail
+
+BUCKET="${AWS_BUCKET_NAME:-}"
+DRY_RUN=0
+[[ "${1:-}" == "--dry-run" ]] && DRY_RUN=1
+
+if [[ -z "$BUCKET" ]]; then
+  echo "AWS_BUCKET_NAME is not set. Refusing to guess which bucket to configure." >&2
+  exit 2
+fi
+
+command -v aws >/dev/null || { echo "aws CLI not found on PATH" >&2; exit 2; }
+
+# Fail early and clearly on the two things that actually go wrong: no credentials,
+# or the wrong account. A lifecycle rule applied to someone else's bucket is not
+# the kind of mistake you want to discover from a 403 three commands later.
+if ! ACCOUNT="$(aws sts get-caller-identity --query Account --output text 2>/dev/null)"; then
+  echo "No usable AWS credentials. Configure the CLI first (aws sso login / profile)." >&2
+  exit 2
+fi
+if ! aws s3api head-bucket --bucket "$BUCKET" >/dev/null 2>&1; then
+  echo "Bucket '$BUCKET' is not reachable from account $ACCOUNT." >&2
+  exit 2
+fi
+
+echo "account: $ACCOUNT"
+echo "bucket:  $BUCKET"
+[[ $DRY_RUN -eq 1 ]] && echo "mode:    DRY RUN (no changes)"
+echo
+
+# Retention windows come from runbook section 3 and are the numbers the drill log
+# and the GDPR follow-up both refer to. Change them here and there together.
+NONCURRENT_DAYS=30
+ABORT_MPU_DAYS=7
+
+LIFECYCLE=$(cat <<JSON
+{
+  "Rules": [
+    {
+      "ID": "expire-noncurrent",
+      "Status": "Enabled",
+      "Filter": {"Prefix": ""},
+      "NoncurrentVersionExpiration": {"NoncurrentDays": ${NONCURRENT_DAYS}},
+      "AbortIncompleteMultipartUpload": {"DaysAfterInitiation": ${ABORT_MPU_DAYS}}
+    }
+  ]
+}
+JSON
+)
+
+current_versioning="$(aws s3api get-bucket-versioning --bucket "$BUCKET" \
+  --query 'Status' --output text 2>/dev/null || echo "None")"
+echo "versioning currently: $current_versioning"
+
+if [[ "$current_versioning" == "Enabled" ]]; then
+  echo "  already enabled, nothing to do"
+elif [[ $DRY_RUN -eq 1 ]]; then
+  echo "  WOULD enable bucket versioning"
+else
+  aws s3api put-bucket-versioning --bucket "$BUCKET" \
+    --versioning-configuration Status=Enabled
+  echo "  enabled"
+fi
+
+echo
+echo "lifecycle: expire-noncurrent (${NONCURRENT_DAYS}d) + abort-incomplete-mpu (${ABORT_MPU_DAYS}d)"
+if [[ $DRY_RUN -eq 1 ]]; then
+  echo "  WOULD apply:"
+  echo "$LIFECYCLE"
+else
+  aws s3api put-bucket-lifecycle-configuration --bucket "$BUCKET" \
+    --lifecycle-configuration "$LIFECYCLE"
+  echo "  applied"
+fi
+
+echo
+echo "Done. Verify with: ./scripts/ops/verify-backup-config.sh"
+echo "Still manual (by design): MFA-delete — see runbook section 3.4."

--- a/scripts/ops/configure-s3-backup.sh
+++ b/scripts/ops/configure-s3-backup.sh
@@ -22,7 +22,16 @@ set -euo pipefail
 
 BUCKET="${AWS_BUCKET_NAME:-}"
 DRY_RUN=0
-[[ "${1:-}" == "--dry-run" ]] && DRY_RUN=1
+# Reject anything unrecognised rather than ignoring it. `--dryrun` silently
+# falling through to a real run against a production bucket is the worst
+# possible reading of a typo.
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run) DRY_RUN=1; shift ;;
+    -h|--help) sed -n '2,22p' "$0"; exit 0 ;;
+    *) echo "Unknown argument: $1 (did you mean --dry-run?)" >&2; exit 2 ;;
+  esac
+done
 
 if [[ -z "$BUCKET" ]]; then
   echo "AWS_BUCKET_NAME is not set. Refusing to guess which bucket to configure." >&2
@@ -53,20 +62,34 @@ echo
 NONCURRENT_DAYS=30
 ABORT_MPU_DAYS=7
 
-LIFECYCLE=$(cat <<JSON
+OUR_RULE=$(cat <<JSON
 {
-  "Rules": [
-    {
-      "ID": "expire-noncurrent",
-      "Status": "Enabled",
-      "Filter": {"Prefix": ""},
-      "NoncurrentVersionExpiration": {"NoncurrentDays": ${NONCURRENT_DAYS}},
-      "AbortIncompleteMultipartUpload": {"DaysAfterInitiation": ${ABORT_MPU_DAYS}}
-    }
-  ]
+  "ID": "expire-noncurrent",
+  "Status": "Enabled",
+  "Filter": {"Prefix": ""},
+  "NoncurrentVersionExpiration": {"NoncurrentDays": ${NONCURRENT_DAYS}},
+  "AbortIncompleteMultipartUpload": {"DaysAfterInitiation": ${ABORT_MPU_DAYS}}
 }
 JSON
 )
+
+# put-bucket-lifecycle-configuration REPLACES the whole configuration — it does
+# not merge. Declaring only our rule would silently delete any cost-tiering or
+# prefix rules the bucket already has, which is a destructive surprise from a
+# script whose job is protecting data. So: read what is there, drop only our own
+# rule by ID (making a re-run converge rather than duplicate), keep the rest.
+EXISTING="$(aws s3api get-bucket-lifecycle-configuration --bucket "$BUCKET" 2>/dev/null || echo '{"Rules":[]}')"
+
+LIFECYCLE="$(python3 - "$EXISTING" "$OUR_RULE" <<'PYEOF'
+import json, sys
+existing = json.loads(sys.argv[1] or '{"Rules": []}').get("Rules", [])
+ours = json.loads(sys.argv[2])
+kept = [r for r in existing if r.get("ID") != ours["ID"]]
+if kept:
+    print("KEEPING:" + ",".join(r.get("ID", "<unnamed>") for r in kept), file=sys.stderr)
+print(json.dumps({"Rules": kept + [ours]}))
+PYEOF
+)" || { echo "failed to merge lifecycle rules; refusing to apply" >&2; exit 2; }
 
 current_versioning="$(aws s3api get-bucket-versioning --bucket "$BUCKET" \
   --query 'Status' --output text 2>/dev/null || echo "None")"
@@ -83,7 +106,13 @@ else
 fi
 
 echo
+preserved="$(python3 -c "
+import json,sys
+rules=json.loads(sys.argv[1]).get('Rules',[])
+print(', '.join(r.get('ID','<unnamed>') for r in rules if r.get('ID')!='expire-noncurrent') or '(none)')
+" "$LIFECYCLE")"
 echo "lifecycle: expire-noncurrent (${NONCURRENT_DAYS}d) + abort-incomplete-mpu (${ABORT_MPU_DAYS}d)"
+echo "  preserving existing rules: $preserved"
 if [[ $DRY_RUN -eq 1 ]]; then
   echo "  WOULD apply:"
   echo "$LIFECYCLE"

--- a/scripts/ops/test-configure-s3-backup.sh
+++ b/scripts/ops/test-configure-s3-backup.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+#
+# Tests for configure-s3-backup.sh, with a stub `aws` on PATH.
+#
+# WHY. The script justifies itself with "a typo here costs more than a typo in
+# application code" — and then the trickiest part of it, merging our lifecycle
+# rule into whatever the bucket already has, was covered by nothing but prose in a
+# PR description. shellcheck catches syntax, not "this silently deleted the
+# customer's cost-tiering rules".
+#
+# The stub records every aws invocation and replays canned responses, so the merge
+# logic is exercised end to end without an AWS account. Run: ./test-configure-s3-backup.sh
+
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$HERE/configure-s3-backup.sh"
+FAILED=0
+
+pass() { printf '  \033[32mPASS\033[0m  %s\n' "$1"; }
+fail() { printf '  \033[31mFAIL\033[0m  %s\n' "$1"; FAILED=1; }
+
+# $1 = JSON the stub returns for get-bucket-lifecycle-configuration ("" = none)
+make_stub() {
+  local existing="$1" dir
+  dir="$(mktemp -d)"
+  cat > "$dir/aws" <<STUB
+#!/usr/bin/env bash
+# Records the call, then answers it.
+echo "\$*" >> "$dir/calls.log"
+case "\$*" in
+  "sts get-caller-identity"*) echo "123456789012" ;;
+  "s3api head-bucket"*) exit 0 ;;
+  "s3api get-bucket-versioning"*) echo "Suspended" ;;
+  "s3api get-bucket-lifecycle-configuration"*)
+    if [[ -n '$existing' ]]; then echo '$existing'; else exit 254; fi ;;
+  "s3api put-bucket-lifecycle-configuration"*)
+    # Capture the payload that would reach AWS — the thing under test.
+    printf '%s\n' "\$*" > "$dir/put-lifecycle.txt" ;;
+  "s3api put-bucket-versioning"*) : ;;
+esac
+STUB
+  chmod +x "$dir/aws"
+  echo "$dir"
+}
+
+run_with_stub() {
+  local dir="$1"; shift
+  PATH="$dir:$PATH" AWS_BUCKET_NAME=test-bucket "$SCRIPT" "$@" 2>&1
+}
+
+echo "=== argument handling ==="
+
+out="$(env -u AWS_BUCKET_NAME "$SCRIPT" 2>&1)"; rc=$?
+if [[ $rc -eq 2 && "$out" == *"Refusing to guess"* ]]; then
+  pass "missing AWS_BUCKET_NAME exits 2"
+else
+  fail "missing AWS_BUCKET_NAME: rc=$rc out=$out"
+fi
+
+d="$(make_stub "")"
+out="$(run_with_stub "$d" --dryrun)"; rc=$?
+if [[ $rc -eq 2 && "$out" == *"Unknown argument"* ]]; then
+  pass "a typo'd --dry-run is rejected, not treated as a real run"
+else
+  fail "typo'd flag: rc=$rc out=$out"
+fi
+
+out="$(run_with_stub "$d" --dry-run)"
+if [[ -f "$d/put-lifecycle.txt" ]]; then
+  fail "--dry-run still called put-bucket-lifecycle-configuration"
+else
+  pass "--dry-run mutates nothing"
+fi
+rm -rf "$d"
+
+echo
+echo "=== lifecycle merge (the destructive-if-wrong part) ==="
+
+# A bucket that already has an unrelated rule. Deleting it would be a silent,
+# expensive regression for whoever owns that rule.
+EXISTING='{"Rules":[{"ID":"cost-tiering","Status":"Enabled","Filter":{"Prefix":"archive/"},"Transitions":[{"Days":90,"StorageClass":"GLACIER"}]}]}'
+d="$(make_stub "$EXISTING")"
+run_with_stub "$d" >/dev/null
+
+if [[ -f "$d/put-lifecycle.txt" ]]; then
+  payload="$(cat "$d/put-lifecycle.txt")"
+  if grep -q "cost-tiering" <<<"$payload"; then
+    pass "an unrelated existing rule survives"
+  else
+    fail "unrelated rule 'cost-tiering' was DELETED by the apply"
+  fi
+  if grep -q "expire-noncurrent" <<<"$payload"; then
+    pass "our rule is present"
+  else
+    fail "our rule is missing from the payload"
+  fi
+else
+  fail "no lifecycle configuration was applied at all"
+fi
+rm -rf "$d"
+
+# Re-running must converge, not stack duplicates of our own rule.
+ALREADY_OURS='{"Rules":[{"ID":"expire-noncurrent","Status":"Enabled","Filter":{"Prefix":""},"NoncurrentVersionExpiration":{"NoncurrentDays":9999}}]}'
+d="$(make_stub "$ALREADY_OURS")"
+run_with_stub "$d" >/dev/null
+payload="$(cat "$d/put-lifecycle.txt" 2>/dev/null || echo "")"
+count="$(grep -o "expire-noncurrent" <<<"$payload" | wc -l)"
+if [[ "$count" -eq 1 ]]; then
+  pass "re-running replaces our rule rather than duplicating it"
+else
+  fail "expected exactly 1 'expire-noncurrent', found $count"
+fi
+# And the stale 9999-day retention must be gone, not merged alongside.
+if grep -q "9999" <<<"$payload"; then
+  fail "the previous rule's retention (9999d) survived — ours did not win"
+else
+  pass "our current retention replaces the stale one"
+fi
+rm -rf "$d"
+
+echo
+echo "=== no pre-existing configuration ==="
+d="$(make_stub "")"
+run_with_stub "$d" >/dev/null
+payload="$(cat "$d/put-lifecycle.txt" 2>/dev/null || echo "")"
+if grep -q "expire-noncurrent" <<<"$payload" && grep -q "AbortIncompleteMultipartUpload" <<<"$payload"; then
+  pass "a bucket with no lifecycle gets both rules"
+else
+  fail "empty-bucket path did not apply the expected rules"
+fi
+rm -rf "$d"
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "All configure-s3-backup.sh tests passed."
+else
+  echo "configure-s3-backup.sh tests FAILED." >&2
+fi
+exit $FAILED

--- a/scripts/ops/verify-backup-config.sh
+++ b/scripts/ops/verify-backup-config.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+#
+# Audit the backup posture — S3 and Atlas (#299 / AC3 of #259).
+#
+# Read-only. Exits non-zero if anything required is missing, so it works as a
+# quarterly check (the runbook asks for quarterly drills) and as evidence when
+# closing #299: paste its output rather than asserting "backups are on".
+#
+# Checks what is actually checkable over an API. MFA-delete and the Atlas
+# compliance policy are reported when visible and flagged as manual otherwise —
+# a verifier that quietly skips what it cannot see is worse than one that says so.
+#
+# Usage:
+#   AWS_BUCKET_NAME=my-bucket ./scripts/ops/verify-backup-config.sh
+#
+# Atlas checks additionally need (Atlas Admin API, digest auth):
+#   ATLAS_PUBLIC_KEY / ATLAS_PRIVATE_KEY / ATLAS_GROUP_ID / ATLAS_CLUSTER_NAME
+# Absent, the Atlas section reports SKIP and the S3 checks still run.
+#
+# Credentials are read from the environment and the ambient AWS CLI config. This
+# script never prints a credential and never writes one anywhere.
+
+set -uo pipefail
+
+FAILED=0
+pass() { printf '  \033[32mPASS\033[0m  %s\n' "$1"; }
+fail() { printf '  \033[31mFAIL\033[0m  %s\n' "$1"; FAILED=1; }
+skip() { printf '  \033[33mSKIP\033[0m  %s\n' "$1"; }
+manual() { printf '  \033[33mMANUAL\033[0m %s\n' "$1"; }
+
+echo "=== S3 ==="
+BUCKET="${AWS_BUCKET_NAME:-}"
+if [[ -z "$BUCKET" ]]; then
+  fail "AWS_BUCKET_NAME is not set — cannot verify the app bucket"
+elif ! command -v aws >/dev/null; then
+  fail "aws CLI not found on PATH"
+elif ! aws s3api head-bucket --bucket "$BUCKET" >/dev/null 2>&1; then
+  fail "bucket '$BUCKET' not reachable (credentials or permissions)"
+else
+  echo "  bucket: $BUCKET"
+
+  versioning="$(aws s3api get-bucket-versioning --bucket "$BUCKET" \
+    --query 'Status' --output text 2>/dev/null || echo "None")"
+  if [[ "$versioning" == "Enabled" ]]; then
+    pass "bucket versioning enabled"
+  else
+    fail "bucket versioning is '$versioning' — cascade erasure destroys history immediately without it"
+  fi
+
+  mfa="$(aws s3api get-bucket-versioning --bucket "$BUCKET" \
+    --query 'MFADelete' --output text 2>/dev/null || echo "None")"
+  if [[ "$mfa" == "Enabled" ]]; then
+    pass "MFA-delete enabled"
+  else
+    # Not a FAIL: it needs root + an MFA token, so it is a console step by
+    # construction and a non-prod bucket may legitimately not have it.
+    manual "MFA-delete not enabled (runbook 3.4 — needs root account + MFA token)"
+  fi
+
+  if lifecycle="$(aws s3api get-bucket-lifecycle-configuration --bucket "$BUCKET" 2>/dev/null)"; then
+    if grep -q '"ID": *"expire-noncurrent"' <<<"$lifecycle" \
+       || grep -q '"ID":"expire-noncurrent"' <<<"$lifecycle"; then
+      pass "lifecycle rule 'expire-noncurrent' present"
+    else
+      fail "lifecycle exists but has no 'expire-noncurrent' rule — versioning will grow unbounded"
+    fi
+    if grep -q 'AbortIncompleteMultipartUpload' <<<"$lifecycle"; then
+      pass "incomplete multipart uploads are aborted"
+    else
+      fail "no AbortIncompleteMultipartUpload rule — failed uploads bill forever"
+    fi
+  else
+    fail "no lifecycle configuration at all (run configure-s3-backup.sh)"
+  fi
+fi
+
+echo
+echo "=== MongoDB Atlas ==="
+if [[ -z "${ATLAS_PUBLIC_KEY:-}" || -z "${ATLAS_PRIVATE_KEY:-}" \
+   || -z "${ATLAS_GROUP_ID:-}" || -z "${ATLAS_CLUSTER_NAME:-}" ]]; then
+  skip "Atlas API credentials not set — checked by hand per runbook section 2"
+  echo "       (ATLAS_PUBLIC_KEY / ATLAS_PRIVATE_KEY / ATLAS_GROUP_ID / ATLAS_CLUSTER_NAME)"
+else
+  API="https://cloud.mongodb.com/api/atlas/v2"
+  HDR="Accept: application/vnd.atlas.2023-02-01+json"
+
+  cluster="$(curl -s --digest -u "${ATLAS_PUBLIC_KEY}:${ATLAS_PRIVATE_KEY}" \
+    -H "$HDR" "${API}/groups/${ATLAS_GROUP_ID}/clusters/${ATLAS_CLUSTER_NAME}" 2>/dev/null)"
+
+  if [[ -z "$cluster" ]] || grep -q '"error"' <<<"$cluster"; then
+    fail "Atlas API call failed for cluster '${ATLAS_CLUSTER_NAME}'"
+  else
+    if grep -q '"backupEnabled" *: *true' <<<"$cluster"; then
+      pass "Cloud Backup enabled"
+    else
+      fail "Cloud Backup is NOT enabled on '${ATLAS_CLUSTER_NAME}'"
+    fi
+    if grep -q '"pitEnabled" *: *true' <<<"$cluster"; then
+      pass "Point-in-Time Restore enabled"
+    else
+      fail "Point-in-Time Restore is NOT enabled — RPO is the snapshot interval"
+    fi
+
+    policy="$(curl -s --digest -u "${ATLAS_PUBLIC_KEY}:${ATLAS_PRIVATE_KEY}" \
+      -H "$HDR" "${API}/groups/${ATLAS_GROUP_ID}/clusters/${ATLAS_CLUSTER_NAME}/backup/schedule" 2>/dev/null)"
+    for freq in hourly daily weekly; do
+      if grep -q "\"frequencyType\" *: *\"${freq}\"" <<<"$policy"; then
+        pass "snapshot policy has a ${freq} item"
+      else
+        fail "snapshot policy has no ${freq} item (runbook 2.2)"
+      fi
+    done
+  fi
+fi
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "Backup posture OK. Record the run in the drill log:"
+  echo "  docs/deployment/DATA_ERASURE_AND_BACKUP_RUNBOOK.md section 4"
+else
+  echo "Backup posture INCOMPLETE — see FAIL lines above." >&2
+fi
+exit $FAILED

--- a/scripts/ops/verify-backup-config.sh
+++ b/scripts/ops/verify-backup-config.sh
@@ -18,7 +18,8 @@
 # Absent, the Atlas section reports SKIP and the S3 checks still run.
 #
 # Credentials are read from the environment and the ambient AWS CLI config. This
-# script never prints a credential and never writes one anywhere.
+# script never prints a credential, never writes one anywhere, and never passes
+# one as a command-line argument (argv is readable by other local users).
 
 set -uo pipefail
 
@@ -84,8 +85,18 @@ else
   API="https://cloud.mongodb.com/api/atlas/v2"
   HDR="Accept: application/vnd.atlas.2023-02-01+json"
 
-  cluster="$(curl -s --digest -u "${ATLAS_PUBLIC_KEY}:${ATLAS_PRIVATE_KEY}" \
-    -H "$HDR" "${API}/groups/${ATLAS_GROUP_ID}/clusters/${ATLAS_CLUSTER_NAME}" 2>/dev/null)"
+  # Credentials go to curl on STDIN via `-K -`, never in argv. Command-line
+  # arguments are world-readable through `ps` and /proc for the life of the
+  # process, so `-u "$KEY:$SECRET"` would leak the Atlas API secret to every other
+  # user on the box — and would have made this script's own "never prints a
+  # credential" claim false.
+  atlas_get() {
+    curl -s --digest -H "$HDR" -K - "$1" <<CURLCFG
+user = "${ATLAS_PUBLIC_KEY}:${ATLAS_PRIVATE_KEY}"
+CURLCFG
+  }
+
+  cluster="$(atlas_get "${API}/groups/${ATLAS_GROUP_ID}/clusters/${ATLAS_CLUSTER_NAME}" 2>/dev/null)"
 
   if [[ -z "$cluster" ]] || grep -q '"error"' <<<"$cluster"; then
     fail "Atlas API call failed for cluster '${ATLAS_CLUSTER_NAME}'"
@@ -101,8 +112,7 @@ else
       fail "Point-in-Time Restore is NOT enabled — RPO is the snapshot interval"
     fi
 
-    policy="$(curl -s --digest -u "${ATLAS_PUBLIC_KEY}:${ATLAS_PRIVATE_KEY}" \
-      -H "$HDR" "${API}/groups/${ATLAS_GROUP_ID}/clusters/${ATLAS_CLUSTER_NAME}/backup/schedule" 2>/dev/null)"
+    policy="$(atlas_get "${API}/groups/${ATLAS_GROUP_ID}/clusters/${ATLAS_CLUSTER_NAME}/backup/schedule" 2>/dev/null)"
     for freq in hourly daily weekly; do
       if grep -q "\"frequencyType\" *: *\"${freq}\"" <<<"$policy"; then
         pass "snapshot policy has a ${freq} item"

--- a/scripts/ops/verify-backup-config.sh
+++ b/scripts/ops/verify-backup-config.sh
@@ -65,10 +65,19 @@ else
     else
       fail "lifecycle exists but has no 'expire-noncurrent' rule — versioning will grow unbounded"
     fi
-    if grep -q 'AbortIncompleteMultipartUpload' <<<"$lifecycle"; then
-      pass "incomplete multipart uploads are aborted"
+    # Scoped to OUR rule, not "appears anywhere in the document". We are the only
+    # writer today, so an unscoped grep passes either way — but the moment someone
+    # adds a second rule carrying an abort clause, an unscoped check would report
+    # our rule as healthy when it has no abort clause at all.
+    if python3 -c "
+import json,sys
+rules = json.load(sys.stdin).get('Rules', [])
+ours = next((r for r in rules if r.get('ID') == 'expire-noncurrent'), None)
+sys.exit(0 if ours and 'AbortIncompleteMultipartUpload' in ours else 1)
+" <<<"$lifecycle" 2>/dev/null; then
+      pass "incomplete multipart uploads are aborted (on the expire-noncurrent rule)"
     else
-      fail "no AbortIncompleteMultipartUpload rule — failed uploads bill forever"
+      fail "the expire-noncurrent rule has no AbortIncompleteMultipartUpload — failed uploads bill forever"
     fi
   else
     fail "no lifecycle configuration at all (run configure-s3-backup.sh)"


### PR DESCRIPTION
Partial work on #299 — **does not close it.**

## Why this exists

#299 is blocked on credentialed cloud-console access, which is not mine to have. But its stated reason for being manual is *"AC3 is cloud/ops configuration with no infrastructure-as-code in this repo"*. That part is fixable, and fixing it shrinks the human step from "click through two consoles following a runbook" to "run two commands".

## `configure-s3-backup.sh`

Applies versioning + the `expire-noncurrent` (30d) and abort-incomplete-multipart (7d) lifecycle rules. Idempotent.

**It merges rather than replaces.** `put-bucket-lifecycle-configuration` overwrites the entire configuration — declaring only our rule would have silently deleted any cost-tiering or prefix rules already on the bucket. It now reads what is there, drops only our own rule by ID (so a re-run converges instead of duplicating), keeps the rest, and prints what it preserved.

Refuses rather than half-applying:

| Situation | Behaviour |
|---|---|
| No `AWS_BUCKET_NAME` | exit 2, "refusing to guess which bucket" |
| No usable credentials | exit 2, before any mutation |
| Bucket unreachable from this account | exit 2 |
| `--dryrun` (typo) | exit 2 — **not** silently a real run against prod |

MFA-delete stays manual by construction: S3 wants the root account's MFA serial and a live token on the request.

## `verify-backup-config.sh`

Read-only audit of both halves, **exits non-zero when anything required is missing** — so the quarterly check the runbook asks for produces evidence rather than reassurance. Paste its output into the drill log instead of writing "backups verified".

It distinguishes three outcomes deliberately: `FAIL` for something that should be on and isn't, `MANUAL` for MFA-delete, `SKIP` for Atlas without API credentials. A verifier that silently counts what it cannot see as a pass is worse than no verifier.

Atlas credentials go to curl on **stdin** via `-K -`, never argv — command-line arguments are readable by any local user through `ps`/`/proc`, and the first version of this script leaked the Atlas API secret that way while its own header claimed it never printed a credential.

## `shell-lint` CI job

These scripts mutate production infrastructure, so a typo costs more here than in application code. Added as a **required** check (in `ci-success`'s `needs`).

Runs at `--severity=warning` rather than the default: the pre-existing scripts carry `info` findings that are correct as written — `preflight_staging_env.sh` writes a literal compose file, so SC2016's "expressions don't expand in single quotes" is exactly the intent. Everything tracked passes at that level today, so the gate covers the whole `scripts/` tree rather than only the new files.

## What still needs a human

Unchanged by this PR, and the reason #299 stays open:

- Enable Atlas Cloud Backup + PITR + the snapshot/compliance policy
- Enable MFA-delete on the production bucket
- Run the first Atlas restore drill and record RTO/RPO
- Run the first S3 restore drill
- Schedule both quarterly

After running the scripts, `verify-backup-config.sh` output is the evidence for closing it.

## Note

Split out of #429 after review pointed out — correctly — that bundling the driver upgrade with unrelated ops tooling made both harder to review, bisect and revert.