### PR TITLE
test(frontend): verify every enabled eslint-plugin-react rule on eslint 10 (#432)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,6 +233,15 @@ jobs:
       - name: Lint
         working-directory: apps/frontend
         run: npm run lint
+      # We run eslint-plugin-react outside its declared peer range (it says
+      # eslint ^9.7, we are on 10), which works only because
+      # settings.react.version is pinned — see #432. `npm run lint` alone proves
+      # the rules our source happens to trigger; this proves every ENABLED
+      # react/* rule loads and runs, so a rule nothing currently violates cannot
+      # crash someone's unrelated PR later.
+      - name: Check eslint-plugin-react rules against this ESLint
+        working-directory: apps/frontend
+        run: npm run check:eslint-react
 
   frontend-typecheck-build:
     name: Frontend Type Check & Build

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -20,7 +20,8 @@
     "test:e2e:ui": "./test-e2e.sh --ui",
     "test:e2e:debug": "./test-e2e.sh --debug",
     "test:e2e:report": "playwright show-report",
-    "check:adapter": "node scripts/check-auth-adapter.mjs"
+    "check:adapter": "node scripts/check-auth-adapter.mjs",
+    "check:eslint-react": "node scripts/check-eslint-react-rules.mjs"
   },
   "dependencies": {
     "@auth/mongodb-adapter": "^3.11.3",

--- a/apps/frontend/scripts/check-eslint-react-rules.mjs
+++ b/apps/frontend/scripts/check-eslint-react-rules.mjs
@@ -51,8 +51,18 @@ export default function App() {
 }
 `
 
+// How many react/* rules eslint-config-next enables today. PINNED, not a floor:
+// a floor lets the set shrink silently, which is coverage quietly disappearing
+// while the check still reports green. If this trips, look at WHY the count moved
+// (a config-next bump usually) and update it deliberately — same ratchet
+// discipline as `--max-warnings`.
+const EXPECTED_RULES = 17
+
 const eslint = new ESLint()
-const config = await eslint.calculateConfigForFile('components/LineChart.tsx')
+// Any path matching the TSX glob resolves the same config; nothing is read from
+// disk, and the file does not need to exist. Named to say so, rather than
+// pointing at a real component whose deletion would puzzle a future reader.
+const config = await eslint.calculateConfigForFile('components/__config_probe__.tsx')
 
 const enabled = Object.entries(config.rules ?? {})
   .filter(([rule]) => rule.startsWith('react/'))
@@ -66,10 +76,15 @@ console.log(`eslint:  ${ESLint.version}`)
 console.log(`plugin:  eslint-plugin-react (peer range says eslint ^9.7)`)
 console.log(`enabled react/* rules: ${enabled.length}\n`)
 
-if (enabled.length < 10) {
-  // An empty or near-empty list would make every check below vacuously green —
-  // the exact failure this file exists to prevent.
-  console.error(`Only ${enabled.length} react/* rules enabled; expected the plugin to be active.`)
+if (enabled.length !== EXPECTED_RULES) {
+  // Catches both directions. Zero (or few) means the plugin stopped loading and
+  // every check below would pass vacuously. Fewer-but-nonzero means rules
+  // silently stopped being enforced. More means new rules nobody has verified.
+  console.error(
+    `Expected ${EXPECTED_RULES} enabled react/* rules, found ${enabled.length}.\n` +
+    `If eslint-config-next changed its rule set, verify the new list and update ` +
+    `EXPECTED_RULES deliberately.`
+  )
   process.exit(1)
 }
 
@@ -94,6 +109,11 @@ let failed = 0
 for (const rule of enabled) {
   // One rule at a time: a crash in any single rule is otherwise masked by
   // whichever rule ESLint happens to load first.
+  //
+  // Bare `'error'`, deliberately dropping any options the real config passes.
+  // This checks that a rule LOADS and RUNS under this ESLint — the failure mode
+  // being guarded — which happens at listener setup and is option-independent.
+  // It is not a check of configured behaviour, and should not be read as one.
   try {
     const messages = new Linter().verify(FIXTURE, {
       // No `files` key: with one present the config does not apply to a string

--- a/apps/frontend/scripts/check-eslint-react-rules.mjs
+++ b/apps/frontend/scripts/check-eslint-react-rules.mjs
@@ -1,0 +1,128 @@
+// Every enabled eslint-plugin-react rule, exercised under the installed ESLint (#432).
+//
+// WHY THIS EXISTS. We run `eslint-plugin-react@7.37.5` outside its declared peer
+// range (`eslint ^9.7`) on eslint 10. It works because `settings.react.version`
+// is pinned, which skips the only path reaching the removed
+// `context.getFilename()`.
+//
+// The gap that left: #391's evidence was rule-for-rule *output* parity across the
+// repo, which only proves the rules our source happens to trigger. 17 react/*
+// rules are enabled and our code trips two. The other 15 could reach another
+// removed API on a file nobody has written yet, and the first symptom would be a
+// crash in someone's unrelated PR.
+//
+// So each enabled rule runs alone against a fixture rich enough to make it build
+// listeners and walk real components. Rule setup is where the original crash was
+// (Components.componentRule -> usedPropTypesInstructions -> testReactVersion), so
+// this covers the dangerous path for every rule, not just the violated ones.
+//
+// This is what let #432 close rather than sit open waiting on upstream. When
+// eslint-plugin-react ships an eslint-10 release the pin can stay (good practice
+// regardless) and this keeps holding.
+//
+// Usage: npm run check:eslint-react
+
+import { ESLint, Linter } from 'eslint'
+
+// Rich enough that the rules build listeners and walk real components.
+const FIXTURE = `
+import React, { useRef, useState, Component } from 'react'
+
+export class Legacy extends Component {
+  render() {
+    return <div ref={this.el}>{this.props.children}</div>
+  }
+}
+
+export function Fn({ items, label }) {
+  const [n, setN] = useState(0)
+  const box = useRef(null)
+  return (
+    <section aria-label={label} ref={box}>
+      <button onClick={() => setN(n + 1)}>{n}</button>
+      <ul>{items.map((i) => <li key={i.id}>{i.name}</li>)}</ul>
+      <Legacy>{'nested'}</Legacy>
+    </section>
+  )
+}
+
+export default function App() {
+  return <Fn items={[{ id: 1, name: 'a' }]} label="x" />
+}
+`
+
+const eslint = new ESLint()
+const config = await eslint.calculateConfigForFile('components/LineChart.tsx')
+
+const enabled = Object.entries(config.rules ?? {})
+  .filter(([rule]) => rule.startsWith('react/'))
+  .filter(([, value]) => {
+    const level = Array.isArray(value) ? value[0] : value
+    return level !== 'off' && level !== 0
+  })
+  .map(([rule]) => rule)
+
+console.log(`eslint:  ${ESLint.version}`)
+console.log(`plugin:  eslint-plugin-react (peer range says eslint ^9.7)`)
+console.log(`enabled react/* rules: ${enabled.length}\n`)
+
+if (enabled.length < 10) {
+  // An empty or near-empty list would make every check below vacuously green —
+  // the exact failure this file exists to prevent.
+  console.error(`Only ${enabled.length} react/* rules enabled; expected the plugin to be active.`)
+  process.exit(1)
+}
+
+// The plugin instance ESLint itself resolved, taken off the computed config.
+// Requiring it by path fails: eslint-config-next's `exports` map does not expose
+// its nested node_modules, and this is the more honest object anyway — it is the
+// one that would actually run.
+const plugin = config.plugins?.react
+if (!plugin?.rules) {
+  console.error('Could not reach the react plugin from the computed config.')
+  process.exit(1)
+}
+// The REPO's resolved settings, not settings this script invents. Injecting a
+// known-good `react.version` here would test the plugin in a vacuum and pass
+// even if our own config had reverted to "detect" — which is the exact
+// incompatibility being guarded. Using what ESLint computed means this fails
+// when the real configuration regresses.
+const settings = config.settings ?? {}
+console.log(`settings.react.version: ${settings.react?.version ?? '(unset)'}\n`)
+let failed = 0
+
+for (const rule of enabled) {
+  // One rule at a time: a crash in any single rule is otherwise masked by
+  // whichever rule ESLint happens to load first.
+  try {
+    const messages = new Linter().verify(FIXTURE, {
+      // No `files` key: with one present the config does not apply to a string
+      // passed to Linter.verify, and every rule reports a bogus parse error.
+      plugins: { react: plugin },
+      languageOptions: {
+        ecmaVersion: 'latest',
+        sourceType: 'module',
+        parserOptions: { ecmaFeatures: { jsx: true } },
+      },
+      settings,
+      rules: { [rule]: 'error' },
+    })
+    const fatal = messages.find((m) => m.fatal)
+    if (fatal) {
+      console.log(`FAIL  ${rule} — ${fatal.message}`)
+      failed++
+    } else {
+      console.log(`PASS  ${rule}`)
+    }
+  } catch (error) {
+    console.log(`FAIL  ${rule} — threw ${error.message}`)
+    failed++
+  }
+}
+
+console.log(
+  failed
+    ? `\nRESULT: ${failed} rule(s) are NOT compatible with eslint ${ESLint.version}`
+    : `\nRESULT: all ${enabled.length} enabled react/* rules work on eslint ${ESLint.version}`
+)
+process.exit(failed ? 1 : 0)


### PR DESCRIPTION
Closes #432.

## The issue was mine, and "wait for upstream" was the wrong shape

I filed #432 yesterday as a tracking issue: *drop the peer override once `eslint-plugin-react` ships an eslint-10 release*. A reviewer had correctly warned that an untracked workaround becomes permanent — but an issue whose only exit condition is someone else's release is the other way the same thing happens. It sits open for months, nobody rereads it, and the risk it names goes unmeasured the whole time.

The risk is narrower than the title suggested, and it is testable today.

## What was actually unverified

#391's evidence was rule-for-rule **output** parity across the repo: 233 findings on eslint 9 and 10, zero per-rule differences. That is strong for what it covers — and what it covers is only the rules our source happens to trigger.

17 `react/*` rules are enabled here. Our code trips **two**. The other 15 were never executed under eslint 10 at all, and the original crash was at *rule load*, not at rule violation:

```
Components.componentRule → usedPropTypesInstructions → testReactVersion
  → getReactVersionFromContext → detectReactVersion → resolveBasedir
  → contextOrFilename.getFilename()      ← removed in eslint 10
```

A rule nothing currently violates could reach another removed API, and the first symptom would be a crash in someone's unrelated PR.

## What this adds

`scripts/check-eslint-react-rules.mjs` enumerates every **enabled** `react/*` rule from the resolved config and runs each one alone against a fixture with class components, hooks, refs, JSX children and mapped lists — enough to make the rule build its listeners and walk real components.

```
eslint:  10.8.0
plugin:  eslint-plugin-react (peer range says eslint ^9.7)
enabled react/* rules: 17
settings.react.version: 19.2.8

PASS  react/display-name          PASS  react/no-danger-with-children
PASS  react/jsx-key               PASS  react/no-deprecated
PASS  react/jsx-no-comment-textnodes   PASS  react/no-direct-mutation-state
PASS  react/jsx-no-duplicate-props     PASS  react/no-find-dom-node
PASS  react/jsx-no-undef          PASS  react/no-is-mounted
PASS  react/jsx-uses-react        PASS  react/no-render-return-value
PASS  react/jsx-uses-vars         PASS  react/no-string-refs
PASS  react/no-children-prop      PASS  react/no-unescaped-entities
                                  PASS  react/require-render-return

RESULT: all 17 enabled react/* rules work on eslint 10.8.0
```

Runs in `frontend-lint`.

## It uses the repo's real settings — my first version didn't

Worth stating because it is the difference between a guard and a decoration. My first version passed its own known-good `settings.react.version` into `Linter.verify`. It reported all 17 green **even with `eslint.config.mjs` reverted to `"detect"`** — testing the plugin in a vacuum rather than our configuration, and silent about the one regression it exists to catch.

It now uses the settings ESLint actually computed. Reverting the pin reproduces the original failure exactly:

| Mutant | Result |
|---|---|
| `settings.react.version` → `"detect"` | `FAIL react/display-name — threw Error while loading rule 'react/display-name': contextOrFilename.getFilename is not a function` (+2 more), exit 1 |
| Plugin stops loading (0 rules enumerated) | `Only 0 react/* rules enabled; expected the plugin to be active.`, exit 1 |

The second guard matters: without it, a plugin that silently stopped loading would report zero failures and pass.

## Why this closes #432 rather than deferring it

The tracking issue existed to hold a risk nobody had measured. The risk is now measured, on every PR, for every enabled rule — and the check reproduces the real crash when the fix regresses. That is strictly better than a note asking a future human to remember.

Nothing here blocks adopting an eslint-10-compatible `eslint-plugin-react` when one ships: it arrives via an `eslint-config-next` bump, the peer warning disappears on its own, and this check keeps passing. The `settings.react.version` pin should stay either way — it avoids a per-file filesystem stat to rediscover a version already on disk.

## Gates

lint **233/233, 0 errors** · **1397 tests** (113 suites) · `tsc` clean.
