### PR TITLE
ops(backup): schedule the backup verification (#299)

### DIFF
--- a/.github/workflows/backup-verify.yml
+++ b/.github/workflows/backup-verify.yml
@@ -44,10 +44,21 @@ jobs:
         id: gate
         env:
           AWS_ROLE: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          AWS_REGION_SECRET: ${{ secrets.AWS_REGION }}
           ATLAS_KEY: ${{ secrets.ATLAS_PUBLIC_KEY }}
         run: |
-          if [ -n "$AWS_ROLE" ]; then echo "aws=true" >> "$GITHUB_OUTPUT"; else echo "aws=false" >> "$GITHUB_OUTPUT"; fi
-          if [ -z "$AWS_ROLE" ] && [ -z "$ATLAS_KEY" ]; then
+          # AWS counts as configured only with BOTH the role and the region.
+          # configure-aws-credentials hard-fails without a region, and that error
+          # reads like a broken workflow rather than a missing secret.
+          if [ -n "$AWS_ROLE" ] && [ -n "$AWS_REGION_SECRET" ]; then
+            echo "aws=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "aws=false" >> "$GITHUB_OUTPUT"
+            if [ -n "$AWS_ROLE" ]; then
+              echo "::warning::AWS_ROLE_TO_ASSUME is set but AWS_REGION is not — skipping the S3 checks."
+            fi
+          fi
+          if { [ -z "$AWS_ROLE" ] || [ -z "$AWS_REGION_SECRET" ]; } && [ -z "$ATLAS_KEY" ]; then
             echo "configured=false" >> "$GITHUB_OUTPUT"
             echo "::warning::Backup verification is not configured — see #299. Set AWS_ROLE_TO_ASSUME / ATLAS_PUBLIC_KEY and friends."
             {
@@ -61,6 +72,11 @@ jobs:
               echo "3. Add the secrets listed at the top of this workflow"
               echo
               echo "Until then this job passes without verifying anything — deliberately."
+              echo
+              echo "| half | configured |"
+              echo "|---|---|"
+              echo "| S3 | $( [ -n "$AWS_ROLE" ] && [ -n "$AWS_REGION_SECRET" ] && echo yes || echo no ) |"
+              echo "| Atlas | $( [ -n "$ATLAS_KEY" ] && echo yes || echo no ) |"
             } >> "$GITHUB_STEP_SUMMARY"
           else
             echo "configured=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/backup-verify.yml
+++ b/.github/workflows/backup-verify.yml
@@ -1,0 +1,123 @@
+name: Backup Posture Verification
+
+# Closes the "schedule the drills quarterly" item of #299 (AC3 of #259).
+#
+# The runbook asks for a quarterly check, and a quarterly check that lives only in
+# a runbook is one nobody runs. This runs `verify-backup-config.sh` on a schedule
+# against the real cloud accounts, so the backup posture is monitored rather than
+# assumed.
+#
+# SECRET-GATED, like deploy.yml. Before the secrets exist this reports "not
+# configured" and passes: a monthly red X on a repo where backups are not set up
+# yet is noise, and noise gets workflows disabled. Once configured, a failure is
+# real and fails the run.
+#
+# Required secrets (all optional — S3 and Atlas are checked independently):
+#   AWS_ROLE_TO_ASSUME + AWS_REGION + AWS_BUCKET_NAME   → S3 checks
+#   ATLAS_PUBLIC_KEY + ATLAS_PRIVATE_KEY
+#     + ATLAS_GROUP_ID + ATLAS_CLUSTER_NAME             → Atlas checks
+
+on:
+  schedule:
+    # 1st of the month, 09:00 UTC. More often than the quarterly drill on purpose:
+    # verification is read-only and cheap, and catching a disabled backup policy
+    # within a month beats catching it within a quarter.
+    - cron: '0 9 1 * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write # OIDC for the AWS role; no long-lived keys in secrets
+
+jobs:
+  verify:
+    name: Verify backups are configured
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # Secrets are read into a step's env and the decision exported as an output.
+      # The `secrets` context is not usable in an `if:` expression, which is why
+      # deploy.yml gates the same way — same pattern here.
+      - name: Check whether this is configured at all
+        id: gate
+        env:
+          AWS_ROLE: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          ATLAS_KEY: ${{ secrets.ATLAS_PUBLIC_KEY }}
+        run: |
+          if [ -n "$AWS_ROLE" ]; then echo "aws=true" >> "$GITHUB_OUTPUT"; else echo "aws=false" >> "$GITHUB_OUTPUT"; fi
+          if [ -z "$AWS_ROLE" ] && [ -z "$ATLAS_KEY" ]; then
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::Backup verification is not configured — see #299. Set AWS_ROLE_TO_ASSUME / ATLAS_PUBLIC_KEY and friends."
+            {
+              echo "## Backup verification not configured"
+              echo
+              echo "No cloud credentials are set, so nothing was checked."
+              echo "This is expected until the #299 operator steps are done:"
+              echo
+              echo "1. Enable Atlas Cloud Backup + PITR + the snapshot policy"
+              echo "2. Run \`scripts/ops/configure-s3-backup.sh\` against the prod bucket"
+              echo "3. Add the secrets listed at the top of this workflow"
+              echo
+              echo "Until then this job passes without verifying anything — deliberately."
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Configure AWS credentials
+        if: steps.gate.outputs.aws == 'true'
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Verify backup posture
+        if: steps.gate.outputs.configured == 'true'
+        env:
+          AWS_BUCKET_NAME: ${{ secrets.AWS_BUCKET_NAME }}
+          ATLAS_PUBLIC_KEY: ${{ secrets.ATLAS_PUBLIC_KEY }}
+          ATLAS_PRIVATE_KEY: ${{ secrets.ATLAS_PRIVATE_KEY }}
+          ATLAS_GROUP_ID: ${{ secrets.ATLAS_GROUP_ID }}
+          ATLAS_CLUSTER_NAME: ${{ secrets.ATLAS_CLUSTER_NAME }}
+        run: |
+          # `set +e`, deliberately: GitHub runs this under `bash -e`, so a FAILING
+          # verification — the case this job exists to report — would abort the
+          # step before the summary is written. The summary is the whole point.
+          set +e
+          set -o pipefail
+          ./scripts/ops/verify-backup-config.sh 2>&1 | tee /tmp/verify.txt
+          status=$?
+          {
+            echo "## Backup posture"
+            echo
+            echo '```'
+            cat /tmp/verify.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit $status
+
+      - name: Remind about the quarterly restore drill
+        if: steps.gate.outputs.configured == 'true'
+        run: |
+          # Month-checked here rather than in an `if:`. Matching on
+          # github.event.schedule needs the exact cron string to appear in
+          # `on.schedule`; an earlier version compared against a quarterly cron
+          # that was never registered, so this could only ever fire on a manual
+          # dispatch.
+          month=$(date -u +%m)
+          case "$month" in
+            01|04|07|10) ;;
+            *) echo "Not a quarter-start month ($month); no drill reminder."; exit 0 ;;
+          esac
+          # Verification proves the config exists. Only a drill proves a restore
+          # actually works, and that part still needs a human.
+          {
+            echo
+            echo "### Quarterly restore drill due"
+            echo
+            echo "Config verification does not prove a restore works. Run both drills"
+            echo "from \`docs/deployment/DATA_ERASURE_AND_BACKUP_RUNBOOK.md\` and record"
+            echo "RTO/RPO in the drill log."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -383,6 +383,21 @@ jobs:
       # tests against a stubbed `aws` — no AWS account needed.
       - name: ops script behaviour tests
         run: ./scripts/ops/test-configure-s3-backup.sh
+      # shellcheck's scripts/**/*.sh glob cannot see the bash inside workflow
+      # `run:` blocks, and that is where three subtle bugs hid in #434 (a lost
+      # summary under `bash -e`, a never-matching cron comparison). actionlint
+      # shellchecks embedded run: blocks and validates expression contexts.
+      - name: actionlint
+        run: |
+          # info-level shellcheck codes are ignored: the remaining ones are
+          # correct as written (single quotes that intentionally do not expand,
+          # unquoted expansions that cannot word-split). Everything at warning and
+          # above passes today, so this gate covers every workflow rather than a
+          # curated subset — same ratchet discipline as `--max-warnings`.
+          docker run --rm -v "$PWD:/repo" -w /repo \
+            rhysd/actionlint@sha256:b1934ee5f1c509618f2508e6eb47ee0d3520686341fec936f3b79331f9315667 \
+            -color \
+            -ignore 'shellcheck reported issue in this script: SC(2016|2086|2129|2001):info'
 
   # ── MCP ────────────────────────────────────────────────────────────────────
   mcp-tests:
@@ -488,7 +503,7 @@ jobs:
             -e MINIO_ROOT_PASSWORD=minioadmin \
             minio/minio server /data
           echo "Waiting for MinIO to become healthy..."
-          for i in $(seq 1 30); do
+          for _ in $(seq 1 30); do
             if curl -sf http://localhost:9000/minio/health/live > /dev/null; then
               echo "MinIO is ready"
               exit 0

--- a/.github/workflows/perf-tests.yml
+++ b/.github/workflows/perf-tests.yml
@@ -71,7 +71,7 @@ jobs:
             -e MINIO_ROOT_PASSWORD=minioadmin \
             minio/minio server /data
           echo "Waiting for MinIO to become healthy..."
-          for i in $(seq 1 30); do
+          for _ in $(seq 1 30); do
             if curl -sf http://localhost:9000/minio/health/live > /dev/null; then
               echo "MinIO is ready"
               exit 0

--- a/docs/deployment/DATA_ERASURE_AND_BACKUP_RUNBOOK.md
+++ b/docs/deployment/DATA_ERASURE_AND_BACKUP_RUNBOOK.md
@@ -112,7 +112,14 @@ delete-object --version-id <marker>`); confirm the object is readable again.
 
 ## 4. Verifying the posture
 
-Before and after every drill, and quarterly regardless:
+**Automated (#299).** `.github/workflows/backup-verify.yml` runs the verifier on
+the 1st of each month and posts the result to the workflow run's summary, and
+reminds about the restore drill in January/April/July/October. It is secret-gated:
+until the cloud credentials are added it reports "not configured" and passes,
+deliberately, because a monthly red X on a repo that has not set this up yet is
+noise and noise gets workflows disabled.
+
+Manually, before and after every drill:
 
 ```bash
 AWS_BUCKET_NAME=<prod-bucket> ./scripts/ops/verify-backup-config.sh

--- a/scripts/ops/verify-backup-config.sh
+++ b/scripts/ops/verify-backup-config.sh
@@ -29,15 +29,23 @@ fail() { printf '  \033[31mFAIL\033[0m  %s\n' "$1"; FAILED=1; }
 skip() { printf '  \033[33mSKIP\033[0m  %s\n' "$1"; }
 manual() { printf '  \033[33mMANUAL\033[0m %s\n' "$1"; }
 
+CHECKED_S3=0
+CHECKED_ATLAS=0
+
 echo "=== S3 ==="
 BUCKET="${AWS_BUCKET_NAME:-}"
 if [[ -z "$BUCKET" ]]; then
-  fail "AWS_BUCKET_NAME is not set — cannot verify the app bucket"
+  # SKIP, not FAIL — symmetric with the Atlas half below. A deployment may
+  # legitimately configure one and not the other, and the scheduled job (#299)
+  # would otherwise report a red month for a half it was never asked to check.
+  # "Nothing was checked at all" is still a failure; see the end of the file.
+  skip "AWS_BUCKET_NAME is not set — S3 not checked"
 elif ! command -v aws >/dev/null; then
   fail "aws CLI not found on PATH"
 elif ! aws s3api head-bucket --bucket "$BUCKET" >/dev/null 2>&1; then
   fail "bucket '$BUCKET' not reachable (credentials or permissions)"
 else
+  CHECKED_S3=1
   echo "  bucket: $BUCKET"
 
   versioning="$(aws s3api get-bucket-versioning --bucket "$BUCKET" \
@@ -91,6 +99,7 @@ if [[ -z "${ATLAS_PUBLIC_KEY:-}" || -z "${ATLAS_PRIVATE_KEY:-}" \
   skip "Atlas API credentials not set — checked by hand per runbook section 2"
   echo "       (ATLAS_PUBLIC_KEY / ATLAS_PRIVATE_KEY / ATLAS_GROUP_ID / ATLAS_CLUSTER_NAME)"
 else
+  CHECKED_ATLAS=1
   API="https://cloud.mongodb.com/api/atlas/v2"
   HDR="Accept: application/vnd.atlas.2023-02-01+json"
 
@@ -133,6 +142,16 @@ CURLCFG
 fi
 
 echo
+if [[ $CHECKED_S3 -eq 0 && $CHECKED_ATLAS -eq 0 ]]; then
+  # The one thing worse than a red check is a green one that verified nothing.
+  # Skipping an unconfigured HALF is reasonable; skipping both means this ran and
+  # told you nothing while looking like a pass.
+  echo "Nothing was verified — neither S3 nor Atlas is configured." >&2
+  echo "Set AWS_BUCKET_NAME and/or the ATLAS_* variables (see the header)." >&2
+  exit 1
+fi
+
+echo "checked: S3=$( ((CHECKED_S3)) && echo yes || echo no ), Atlas=$( ((CHECKED_ATLAS)) && echo yes || echo no )"
 if [[ $FAILED -eq 0 ]]; then
   echo "Backup posture OK. Record the run in the drill log:"
   echo "  docs/deployment/DATA_ERASURE_AND_BACKUP_RUNBOOK.md section 4"


### PR DESCRIPTION
Advances #299 — **does not close it.**

## What this covers

One item on #299's checklist does not need cloud credentials from me: *"Schedule the drills quarterly."* A quarterly check that lives only in a runbook is one nobody runs.

`.github/workflows/backup-verify.yml` runs `verify-backup-config.sh` on the 1st of each month and posts the result to the run summary — the artefact the runbook's drill log asks to have pasted into it.

**Monthly for the config check, quarterly for the drill reminder.** Verification is read-only and cheap, and noticing a disabled backup policy within a month beats noticing within a quarter. The restore drill stays quarterly because only a drill proves a restore actually *works*, and that part still needs a human.

**Secret-gated like `deploy.yml`.** Until the credentials exist it reports "not configured" and passes. That is a deliberate choice against my usual preference for failing loudly: a monthly red X on a repo that has not set this up yet is noise, and noise gets workflows disabled — at which point it protects nothing. It emits a `::warning::` and a summary explaining what to do instead. Once configured, a failure is real and fails the run.

## Three bugs I found writing it

Worth listing because none would have surfaced until the job ran for real, months from now.

**The pinned action SHA was fabricated.** I wrote `aws-actions/configure-aws-credentials@b47578312673…` from memory. It does not exist:

```
$ gh api repos/aws-actions/configure-aws-credentials/commits/b475783…
No commit found for SHA (HTTP 422)
```

Replaced with the real v4 commit (`7474bc46…`), resolved by dereferencing the tag object. Pinning by digest is worthless if the digest is invented.

**A failing verification would have lost its own output.** GitHub runs `run:` steps under `bash -e`, so the moment the verifier exited non-zero the step aborted — before the summary was written and before `exit $status`. The failure case is the entire reason this job exists, and it was the one case that produced no report. Simulated both ways:

| | summary written? |
|---|---|
| with  | yes, and step still exits 1 |
| without | no — summary lost |

**The quarterly reminder could never fire on a schedule.** It compared `github.event.schedule` against `'0 9 1 1,4,7,10 *'`, a cron string that is not in `on.schedule` — so the condition only ever matched a manual dispatch. Now checks the month directly; verified 01/04/07/10 trigger and 03/08 do not.

## Still needs you

This does not close #299. The remaining work needs credentials I neither have nor should:

- [ ] Atlas: enable Cloud Backup + PITR + snapshot/compliance policy
- [ ] S3: run `AWS_BUCKET_NAME=<prod> ./scripts/ops/configure-s3-backup.sh --dry-run`, then for real
- [ ] S3: enable MFA-delete (console-only — needs the root account's MFA token)
- [ ] Add the workflow secrets listed at the top of the file
- [ ] Run both restore drills and record RTO/RPO in the drill log

Once the secrets are in, this workflow reports the posture every month without anyone remembering to.