### PR TITLE
ops(backup): add the minimum IAM policy the operator needs (#299)

### DIFF
--- a/docs/deployment/DATA_ERASURE_AND_BACKUP_RUNBOOK.md
+++ b/docs/deployment/DATA_ERASURE_AND_BACKUP_RUNBOOK.md
@@ -70,6 +70,12 @@ The second statement is scoped to `nma-restore-drill-*` buckets only, so the dri
 can create and destroy its own throwaway buckets without any standing permission
 over real data.
 
+> `s3:ListBucket` is in the first statement because `head-bucket` — which both
+> scripts use as their "is this bucket reachable" guard — maps to `ListBucket`,
+> not to a bucket-config action. Without it both scripts fail at their own first
+> check, before doing anything, with an error that looks like a missing bucket
+> rather than a missing permission.
+
 Atlas needs a separate API key (Project Owner for enabling backup; Project Read
 Only is enough for `verify-backup-config.sh`).
 

--- a/docs/deployment/DATA_ERASURE_AND_BACKUP_RUNBOOK.md
+++ b/docs/deployment/DATA_ERASURE_AND_BACKUP_RUNBOOK.md
@@ -49,6 +49,32 @@ Automated equivalent: `tests/test_integration/test_erasure_cascade.py`.
 
 ---
 
+## 1b. Permissions the operator needs
+
+The app's own IAM user (`fastapi-s3-uploader`) is deliberately object-scoped and
+**cannot** configure the bucket — `s3:GetBucketVersioning` returns AccessDenied.
+That is correct: the application should not be able to rewrite its own retention
+policy. Backup configuration needs a separate principal.
+
+`ops-backup-iam-policy.json` in this directory is the minimum set. Attach it to an
+ops user/role (not to the app user):
+
+```bash
+aws iam create-policy --policy-name NMABackupPosture \
+  --policy-document file://docs/deployment/ops-backup-iam-policy.json
+aws iam attach-user-policy --user-name <ops-user> \
+  --policy-arn arn:aws:iam::<account>:policy/NMABackupPosture
+```
+
+The second statement is scoped to `nma-restore-drill-*` buckets only, so the drill
+can create and destroy its own throwaway buckets without any standing permission
+over real data.
+
+Atlas needs a separate API key (Project Owner for enabling backup; Project Read
+Only is enough for `verify-backup-config.sh`).
+
+---
+
 ## 2. MongoDB Atlas backups (enable in Atlas)
 
 > Enabling is a console/Admin-API action needing real Atlas credentials, so it

--- a/docs/deployment/ops-backup-iam-policy.json
+++ b/docs/deployment/ops-backup-iam-policy.json
@@ -5,6 +5,7 @@
       "Sid": "BackupPostureConfigure",
       "Effect": "Allow",
       "Action": [
+        "s3:ListBucket",
         "s3:GetBucketVersioning",
         "s3:PutBucketVersioning",
         "s3:GetLifecycleConfiguration",

--- a/docs/deployment/ops-backup-iam-policy.json
+++ b/docs/deployment/ops-backup-iam-policy.json
@@ -1,0 +1,36 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "BackupPostureConfigure",
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetBucketVersioning",
+        "s3:PutBucketVersioning",
+        "s3:GetLifecycleConfiguration",
+        "s3:PutLifecycleConfiguration"
+      ],
+      "Resource": "arn:aws:s3:::narrative-modeling-storage"
+    },
+    {
+      "Sid": "RestoreDrillThrowawayBucketsOnly",
+      "Effect": "Allow",
+      "Action": [
+        "s3:CreateBucket",
+        "s3:DeleteBucket",
+        "s3:PutBucketVersioning",
+        "s3:GetBucketVersioning",
+        "s3:PutObject",
+        "s3:GetObject",
+        "s3:DeleteObject",
+        "s3:DeleteObjectVersion",
+        "s3:ListBucket",
+        "s3:ListBucketVersions"
+      ],
+      "Resource": [
+        "arn:aws:s3:::nma-restore-drill-*",
+        "arn:aws:s3:::nma-restore-drill-*/*"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Advances issue 299. The tracker entry stays open until the backups are actually enabled.

## Why

The app's IAM user (`fastapi-s3-uploader`) is object-scoped and returns AccessDenied on `s3:GetBucketVersioning`. That is **correct** — the application should not be able to rewrite its own retention policy — but it means backup configuration needs a separate principal, and "work out which permissions" should not be the operator's problem.

## What

`docs/deployment/ops-backup-iam-policy.json`, minimum privilege, two statements:

| Statement | Scope | Why |
|---|---|---|
| `BackupPostureConfigure` | the app bucket only | versioning + lifecycle get/put, nothing else |
| `RestoreDrillThrowawayBucketsOnly` | `nma-restore-drill-*` only | the drill creates/destroys its own buckets with **no standing permission over real data** |

Verified the drill's bucket prefix in `drill-s3-restore.sh` matches the policy resource, so the second statement actually covers what the drill does and nothing wider.

Runbook gains a section explaining that the app user is deliberately not sufficient, with the attach commands.

## After this

```bash
AWS_PROFILE=<ops> AWS_BUCKET_NAME=narrative-modeling-storage \
  ./scripts/ops/configure-s3-backup.sh --dry-run   # then without --dry-run
AWS_PROFILE=<ops> ./scripts/ops/drill-s3-restore.sh
```

Atlas still needs its own API key (Project Owner to enable backup; Project Read Only is enough for the verifier).