### PR TITLE
fix(ops): the verifier reported AccessDenied as "not configured" (#299)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -382,7 +382,9 @@ jobs:
       # configure-s3-backup.sh is the destructive-if-wrong part, so it gets real
       # tests against a stubbed `aws` — no AWS account needed.
       - name: ops script behaviour tests
-        run: ./scripts/ops/test-configure-s3-backup.sh
+        run: |
+          ./scripts/ops/test-configure-s3-backup.sh
+          ./scripts/ops/test-verify-backup-config.sh
       # shellcheck's scripts/**/*.sh glob cannot see the bash inside workflow
       # `run:` blocks, and that is where three subtle bugs hid in #434 (a lost
       # summary under `bash -e`, a never-matching cron comparison). actionlint

--- a/scripts/ops/test-verify-backup-config.sh
+++ b/scripts/ops/test-verify-backup-config.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+#
+# Tests for verify-backup-config.sh, with a stub `aws` on PATH.
+#
+# WHY. This script's entire job is telling the truth about backup state, and it
+# has now got that wrong twice:
+#
+#   1. `2>/dev/null || echo "None"` reported AccessDenied as "not configured" —
+#      a confident negative about a bucket it was not allowed to read.
+#   2. The first fix special-cased AccessDenied and let every OTHER error
+#      (throttling, ExpiredToken, wrong region) fall through to "no lifecycle
+#      configuration at all", narrowing the same bug rather than removing it.
+#
+# Both were found by a human reading it. The rule the tests encode is:
+# **absence must be proven, never inferred from a failure.**
+#
+# Run: ./scripts/ops/test-verify-backup-config.sh
+
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$HERE/verify-backup-config.sh"
+FAILED=0
+
+pass() { printf '  \033[32mPASS\033[0m  %s\n' "$1"; }
+fail() { printf '  \033[31mFAIL\033[0m  %s\n' "$1"; FAILED=1; }
+
+# $1 = versioning behaviour, $2 = lifecycle behaviour (see the case blocks below)
+make_stub() {
+  local vmode="$1" lmode="$2" dir
+  dir="$(mktemp -d)"
+  cat > "$dir/aws" <<STUB
+#!/usr/bin/env bash
+case "\$*" in
+  *"head-bucket"*) exit 0 ;;
+  *"get-bucket-versioning"*)
+    case "$vmode" in
+      enabled)  echo '{"Status":"Enabled","MFADelete":"Disabled"}' ;;
+      absent)   echo '{}' ;;
+      denied)   echo "An error occurred (AccessDenied) ... not authorized to perform: s3:GetBucketVersioning" >&2; exit 254 ;;
+      throttle) echo "An error occurred (SlowDown) when calling GetBucketVersioning" >&2; exit 254 ;;
+      garbage)  echo 'not json at all' ;;
+      noisy)    echo "warning: a benign CLI notice" >&2; echo '{"Status":"Enabled","MFADelete":"Disabled"}' ;;
+    esac ;;
+  *"get-bucket-lifecycle-configuration"*)
+    case "$lmode" in
+      ok)       echo '{"Rules":[{"ID":"expire-noncurrent","Status":"Enabled","AbortIncompleteMultipartUpload":{"DaysAfterInitiation":7}}]}' ;;
+      norule)   echo '{"Rules":[{"ID":"something-else","Status":"Enabled"}]}' ;;
+      none)     echo "An error occurred (NoSuchLifecycleConfiguration) ..." >&2; exit 254 ;;
+      denied)   echo "An error occurred (AccessDenied) ... not authorized to perform: s3:GetLifecycleConfiguration" >&2; exit 254 ;;
+      expired)  echo "An error occurred (ExpiredToken) when calling GetBucketLifecycleConfiguration" >&2; exit 254 ;;
+    esac ;;
+esac
+STUB
+  chmod +x "$dir/aws"
+  echo "$dir"
+}
+
+run() {
+  local dir="$1"
+  PATH="$dir:$PATH" AWS_BUCKET_NAME=test-bucket bash "$SCRIPT" 2>&1
+}
+
+# expect_out <desc> <vmode> <lmode> <must-contain> [must-not-contain]
+expect_out() {
+  local desc="$1" v="$2" l="$3" want="$4" avoid="${5:-}" dir out
+  dir="$(make_stub "$v" "$l")"
+  out="$(run "$dir")"
+  rm -rf "$dir"
+  if ! grep -qi -- "$want" <<<"$out"; then
+    fail "$desc — expected output matching '$want'"; echo "$out" | sed 's/^/        /'; return
+  fi
+  if [[ -n "$avoid" ]] && grep -qi -- "$avoid" <<<"$out"; then
+    fail "$desc — output wrongly claimed '$avoid'"; echo "$out" | sed 's/^/        /'; return
+  fi
+  pass "$desc"
+}
+
+echo "=== the original bug: denied must never read as absent ==="
+expect_out "AccessDenied on versioning says UNKNOWN" \
+  denied ok "versioning.*UNKNOWN" "versioning is 'None'"
+expect_out "AccessDenied on lifecycle says UNKNOWN" \
+  enabled denied "lifecycle.*UNKNOWN" "no lifecycle configuration at all"
+
+echo
+echo "=== the partial fix: NON-AccessDenied errors must also be UNKNOWN ==="
+expect_out "throttling on versioning is UNKNOWN, not 'None'" \
+  throttle ok "UNKNOWN" "versioning is 'None'"
+expect_out "ExpiredToken on lifecycle is UNKNOWN, not 'no lifecycle at all'" \
+  enabled expired "UNKNOWN" "no lifecycle configuration at all"
+
+echo
+echo "=== unparseable output must be UNKNOWN, not a confident negative ==="
+expect_out "garbage JSON is UNKNOWN, not 'None'" \
+  garbage ok "UNKNOWN" "versioning is 'None'"
+expect_out "stderr noise on a SUCCESS does not corrupt the read" \
+  noisy ok "versioning enabled" "UNKNOWN"
+
+echo
+echo "=== true negatives must still be reported as negatives ==="
+expect_out "NoSuchLifecycleConfiguration really does mean absent" \
+  enabled none "no lifecycle configuration at all"
+expect_out "versioning genuinely off is reported off" \
+  absent ok "versioning is 'None'"
+expect_out "lifecycle without our rule is reported" \
+  enabled norule "no 'expire-noncurrent' rule"
+
+echo
+echo "=== the fully-configured case still passes ==="
+expect_out "versioning + lifecycle + abort = PASS" \
+  enabled ok "lifecycle rule 'expire-noncurrent' present" "UNKNOWN"
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "All verify-backup-config.sh tests passed."
+else
+  echo "verify-backup-config.sh tests FAILED." >&2
+fi
+exit $FAILED

--- a/scripts/ops/test-verify-backup-config.sh
+++ b/scripts/ops/test-verify-backup-config.sh
@@ -25,33 +25,47 @@ FAILED=0
 pass() { printf '  \033[32mPASS\033[0m  %s\n' "$1"; }
 fail() { printf '  \033[31mFAIL\033[0m  %s\n' "$1"; FAILED=1; }
 
-# $1 = versioning behaviour, $2 = lifecycle behaviour (see the case blocks below)
+# $1 = versioning behaviour, $2 = lifecycle behaviour.
+#
+# The chosen behaviour is baked into the generated stub rather than branched on at
+# stub runtime. An earlier version used an unquoted heredoc, which expanded the
+# modes at generation time anyway — producing `case "denied" in` against dead
+# branches while reading as though the stub inspected a variable. Same result,
+# but the code lied about how it worked.
+emit_versioning() {
+  case "$1" in
+    enabled)  echo "echo '{\"Status\":\"Enabled\",\"MFADelete\":\"Disabled\"}'" ;;
+    absent)   echo "echo '{}'" ;;
+    denied)   echo "echo 'An error occurred (AccessDenied) ... not authorized to perform: s3:GetBucketVersioning' >&2; exit 254" ;;
+    throttle) echo "echo 'An error occurred (SlowDown) when calling GetBucketVersioning' >&2; exit 254" ;;
+    garbage)  echo "echo 'not json at all'" ;;
+    noisy)    echo "echo 'warning: a benign CLI notice' >&2; echo '{\"Status\":\"Enabled\",\"MFADelete\":\"Disabled\"}'" ;;
+  esac
+}
+
+emit_lifecycle() {
+  case "$1" in
+    ok)      echo "echo '{\"Rules\":[{\"ID\":\"expire-noncurrent\",\"Status\":\"Enabled\",\"AbortIncompleteMultipartUpload\":{\"DaysAfterInitiation\":7}}]}'" ;;
+    norule)  echo "echo '{\"Rules\":[{\"ID\":\"something-else\",\"Status\":\"Enabled\"}]}'" ;;
+    none)    echo "echo 'An error occurred (NoSuchLifecycleConfiguration) ...' >&2; exit 254" ;;
+    denied)  echo "echo 'An error occurred (AccessDenied) ... not authorized to perform: s3:GetLifecycleConfiguration' >&2; exit 254" ;;
+    expired) echo "echo 'An error occurred (ExpiredToken) when calling GetBucketLifecycleConfiguration' >&2; exit 254" ;;
+  esac
+}
+
 make_stub() {
-  local vmode="$1" lmode="$2" dir
+  local dir
   dir="$(mktemp -d)"
-  cat > "$dir/aws" <<STUB
-#!/usr/bin/env bash
-case "\$*" in
-  *"head-bucket"*) exit 0 ;;
-  *"get-bucket-versioning"*)
-    case "$vmode" in
-      enabled)  echo '{"Status":"Enabled","MFADelete":"Disabled"}' ;;
-      absent)   echo '{}' ;;
-      denied)   echo "An error occurred (AccessDenied) ... not authorized to perform: s3:GetBucketVersioning" >&2; exit 254 ;;
-      throttle) echo "An error occurred (SlowDown) when calling GetBucketVersioning" >&2; exit 254 ;;
-      garbage)  echo 'not json at all' ;;
-      noisy)    echo "warning: a benign CLI notice" >&2; echo '{"Status":"Enabled","MFADelete":"Disabled"}' ;;
-    esac ;;
-  *"get-bucket-lifecycle-configuration"*)
-    case "$lmode" in
-      ok)       echo '{"Rules":[{"ID":"expire-noncurrent","Status":"Enabled","AbortIncompleteMultipartUpload":{"DaysAfterInitiation":7}}]}' ;;
-      norule)   echo '{"Rules":[{"ID":"something-else","Status":"Enabled"}]}' ;;
-      none)     echo "An error occurred (NoSuchLifecycleConfiguration) ..." >&2; exit 254 ;;
-      denied)   echo "An error occurred (AccessDenied) ... not authorized to perform: s3:GetLifecycleConfiguration" >&2; exit 254 ;;
-      expired)  echo "An error occurred (ExpiredToken) when calling GetBucketLifecycleConfiguration" >&2; exit 254 ;;
-    esac ;;
-esac
-STUB
+  {
+    echo '#!/usr/bin/env bash'
+    echo 'case "$*" in'
+    echo '  *"head-bucket"*) exit 0 ;;'
+    echo '  *"get-bucket-versioning"*)'
+    echo "    $(emit_versioning "$1") ;;"
+    echo '  *"get-bucket-lifecycle-configuration"*)'
+    echo "    $(emit_lifecycle "$2") ;;"
+    echo 'esac'
+  } > "$dir/aws"
   chmod +x "$dir/aws"
   echo "$dir"
 }

--- a/scripts/ops/verify-backup-config.sh
+++ b/scripts/ops/verify-backup-config.sh
@@ -48,79 +48,98 @@ else
   CHECKED_S3=1
   echo "  bucket: $BUCKET"
 
-  # Capture stderr and the exit code SEPARATELY from the value. `2>/dev/null ||
-  # echo "None"` turned an AccessDenied into "None" — reporting a bucket we are
-  # not allowed to inspect as definitively unconfigured. A verifier that cannot
-  # tell "not there" from "not allowed to look" is worse than no verifier: it
-  # produces a confident answer it has not earned, and both readings are
-  # actionable in opposite directions.
-  vraw="$(aws s3api get-bucket-versioning --bucket "$BUCKET" 2>&1)"
-  if [[ $? -ne 0 ]]; then
-    if grep -qi "AccessDenied\|not authorized" <<<"$vraw"; then
-      fail "cannot read versioning — AccessDenied. This principal lacks s3:GetBucketVersioning; the backup state is UNKNOWN, not absent"
-    else
-      fail "cannot read versioning: $(tr -d '\n' <<<"$vraw" | head -c 160)"
-    fi
-    versioning="unknown"
-    mfa="unknown"
+  # Every read below follows the same rule, and it is the whole point of this
+  # file: ABSENCE MUST BE PROVEN, never inferred from a failure.
+  #
+  # stdout and stderr are captured separately. Merging them (`2>&1`) means a
+  # benign stderr line — a CLI deprecation notice, a proxy warning — lands in the
+  # JSON, the parse fails, and the fallback reports "not configured". That is the
+  # original bug rebuilt out of its own fix.
+  s3_read() {
+    local out err rc
+    err="$(mktemp)"
+    out="$(aws s3api "$@" --bucket "$BUCKET" 2>"$err")"; rc=$?
+    S3_OUT="$out"; S3_ERR="$(cat "$err")"; rm -f "$err"
+    return $rc
+  }
+
+  if s3_read get-bucket-versioning; then
+    # One parse, both fields. A parse failure yields "unknown", NOT "None" —
+    # unparseable output means we do not know, not that nothing is configured.
+    read -r versioning mfa <<<"$(python3 -c '
+import json, sys
+try:
+    d = json.loads(sys.argv[1] or "{}")
+    print(d.get("Status", "None"), d.get("MFADelete", "None"))
+except Exception:
+    print("unknown unknown")
+' "$S3_OUT")"
   else
-    versioning="$(python3 -c "
-import json,sys
-try: print(json.loads(sys.argv[1] or '{}').get('Status','None'))
-except Exception: print('None')
-" "$vraw")"
-    mfa="$(python3 -c "
-import json,sys
-try: print(json.loads(sys.argv[1] or '{}').get('MFADelete','None'))
-except Exception: print('None')
-" "$vraw")"
-    if [[ "$versioning" == "Enabled" ]]; then
-      pass "bucket versioning enabled"
+    versioning="unknown"; mfa="unknown"
+    if grep -qi "AccessDenied\|not authorized" <<<"$S3_ERR"; then
+      fail "cannot read versioning — AccessDenied (needs s3:GetBucketVersioning). State is UNKNOWN, not absent"
     else
-      fail "bucket versioning is '$versioning' — cascade erasure destroys history immediately without it"
+      fail "cannot read versioning: $(tr -d '\n' <<<"$S3_ERR" | head -c 160). State is UNKNOWN, not absent"
     fi
-  fi
-  if [[ "$mfa" == "Enabled" ]]; then
-    pass "MFA-delete enabled"
-  elif [[ "$mfa" == "unknown" ]]; then
-    # Same trap one line down: reporting "not enabled" for something we could not
-    # read is the identical false-confidence bug.
-    manual "MFA-delete state UNKNOWN — could not read the bucket's versioning block"
-  else
-    # Not a FAIL: it needs root + an MFA token, so it is a console step by
-    # construction and a non-prod bucket may legitimately not have it.
-    manual "MFA-delete not enabled (runbook 3.4 — needs root account + MFA token)"
   fi
 
-  lraw="$(aws s3api get-bucket-lifecycle-configuration --bucket "$BUCKET" 2>&1)"
-  lrc=$?
-  if [[ $lrc -ne 0 ]] && grep -qi "AccessDenied\|not authorized" <<<"$lraw"; then
-    # Same distinction as versioning above. NoSuchLifecycleConfiguration genuinely
-    # means "no rules"; AccessDenied means we do not know.
-    fail "cannot read lifecycle — AccessDenied. This principal lacks s3:GetLifecycleConfiguration; the rules are UNKNOWN, not absent"
-  elif [[ $lrc -eq 0 ]] && lifecycle="$lraw"; then
-    if grep -q '"ID": *"expire-noncurrent"' <<<"$lifecycle" \
-       || grep -q '"ID":"expire-noncurrent"' <<<"$lifecycle"; then
-      pass "lifecycle rule 'expire-noncurrent' present"
-    else
-      fail "lifecycle exists but has no 'expire-noncurrent' rule — versioning will grow unbounded"
-    fi
-    # Scoped to OUR rule, not "appears anywhere in the document". We are the only
-    # writer today, so an unscoped grep passes either way — but the moment someone
-    # adds a second rule carrying an abort clause, an unscoped check would report
-    # our rule as healthy when it has no abort clause at all.
-    if python3 -c "
-import json,sys
-rules = json.load(sys.stdin).get('Rules', [])
-ours = next((r for r in rules if r.get('ID') == 'expire-noncurrent'), None)
-sys.exit(0 if ours and 'AbortIncompleteMultipartUpload' in ours else 1)
-" <<<"$lifecycle" 2>/dev/null; then
-      pass "incomplete multipart uploads are aborted (on the expire-noncurrent rule)"
-    else
-      fail "the expire-noncurrent rule has no AbortIncompleteMultipartUpload — failed uploads bill forever"
-    fi
-  else
+  case "$versioning" in
+    Enabled) pass "bucket versioning enabled" ;;
+    unknown) : ;;  # already reported above
+    *) fail "bucket versioning is '$versioning' — cascade erasure destroys history immediately without it" ;;
+  esac
+
+  case "$mfa" in
+    Enabled) pass "MFA-delete enabled" ;;
+    unknown) manual "MFA-delete state UNKNOWN — the versioning block could not be read" ;;
+    *) manual "MFA-delete not enabled (runbook 3.4 — needs root account + MFA token)" ;;
+  esac
+
+  if s3_read get-bucket-lifecycle-configuration; then
+    # Parsed as JSON, not grepped. A `grep '"ID"'` match is sensitive to key
+    # ordering and whitespace in the response, and would also match an ID inside
+    # some unrelated rule.
+    lifecycle_state="$(python3 -c '
+import json, sys
+try:
+    rules = json.loads(sys.argv[1] or "{}").get("Rules", [])
+except Exception:
+    print("unknown"); raise SystemExit
+ours = next((r for r in rules if r.get("ID") == "expire-noncurrent"), None)
+if ours is None:
+    print("missing")
+elif "AbortIncompleteMultipartUpload" not in ours:
+    print("no-abort")
+else:
+    print("ok")
+' "$S3_OUT")"
+    case "$lifecycle_state" in
+      ok)
+        pass "lifecycle rule 'expire-noncurrent' present"
+        pass "incomplete multipart uploads are aborted (on the expire-noncurrent rule)"
+        ;;
+      no-abort)
+        pass "lifecycle rule 'expire-noncurrent' present"
+        fail "the expire-noncurrent rule has no AbortIncompleteMultipartUpload — failed uploads bill forever"
+        ;;
+      missing)
+        fail "lifecycle exists but has no 'expire-noncurrent' rule — versioning will grow unbounded"
+        ;;
+      *)
+        fail "lifecycle response could not be parsed — state is UNKNOWN, not absent"
+        ;;
+    esac
+  elif grep -qi "NoSuchLifecycleConfiguration" <<<"$S3_ERR"; then
+    # INVERTED deliberately. This is the ONLY error that legitimately means "no
+    # rules exist". Every other failure — throttling, ExpiredToken, wrong region,
+    # AllAccessDisabled — is unknown. The previous version special-cased
+    # AccessDenied and let everything else fall through to "no lifecycle at all",
+    # which narrowed this bug rather than removing it.
     fail "no lifecycle configuration at all (run configure-s3-backup.sh)"
+  elif grep -qi "AccessDenied\|not authorized" <<<"$S3_ERR"; then
+    fail "cannot read lifecycle — AccessDenied (needs s3:GetLifecycleConfiguration). Rules are UNKNOWN, not absent"
+  else
+    fail "cannot read lifecycle: $(tr -d '\n' <<<"$S3_ERR" | head -c 160). Rules are UNKNOWN, not absent"
   fi
 fi
 

--- a/scripts/ops/verify-backup-config.sh
+++ b/scripts/ops/verify-backup-config.sh
@@ -48,25 +48,57 @@ else
   CHECKED_S3=1
   echo "  bucket: $BUCKET"
 
-  versioning="$(aws s3api get-bucket-versioning --bucket "$BUCKET" \
-    --query 'Status' --output text 2>/dev/null || echo "None")"
-  if [[ "$versioning" == "Enabled" ]]; then
-    pass "bucket versioning enabled"
+  # Capture stderr and the exit code SEPARATELY from the value. `2>/dev/null ||
+  # echo "None"` turned an AccessDenied into "None" — reporting a bucket we are
+  # not allowed to inspect as definitively unconfigured. A verifier that cannot
+  # tell "not there" from "not allowed to look" is worse than no verifier: it
+  # produces a confident answer it has not earned, and both readings are
+  # actionable in opposite directions.
+  vraw="$(aws s3api get-bucket-versioning --bucket "$BUCKET" 2>&1)"
+  if [[ $? -ne 0 ]]; then
+    if grep -qi "AccessDenied\|not authorized" <<<"$vraw"; then
+      fail "cannot read versioning — AccessDenied. This principal lacks s3:GetBucketVersioning; the backup state is UNKNOWN, not absent"
+    else
+      fail "cannot read versioning: $(tr -d '\n' <<<"$vraw" | head -c 160)"
+    fi
+    versioning="unknown"
+    mfa="unknown"
   else
-    fail "bucket versioning is '$versioning' — cascade erasure destroys history immediately without it"
+    versioning="$(python3 -c "
+import json,sys
+try: print(json.loads(sys.argv[1] or '{}').get('Status','None'))
+except Exception: print('None')
+" "$vraw")"
+    mfa="$(python3 -c "
+import json,sys
+try: print(json.loads(sys.argv[1] or '{}').get('MFADelete','None'))
+except Exception: print('None')
+" "$vraw")"
+    if [[ "$versioning" == "Enabled" ]]; then
+      pass "bucket versioning enabled"
+    else
+      fail "bucket versioning is '$versioning' — cascade erasure destroys history immediately without it"
+    fi
   fi
-
-  mfa="$(aws s3api get-bucket-versioning --bucket "$BUCKET" \
-    --query 'MFADelete' --output text 2>/dev/null || echo "None")"
   if [[ "$mfa" == "Enabled" ]]; then
     pass "MFA-delete enabled"
+  elif [[ "$mfa" == "unknown" ]]; then
+    # Same trap one line down: reporting "not enabled" for something we could not
+    # read is the identical false-confidence bug.
+    manual "MFA-delete state UNKNOWN — could not read the bucket's versioning block"
   else
     # Not a FAIL: it needs root + an MFA token, so it is a console step by
     # construction and a non-prod bucket may legitimately not have it.
     manual "MFA-delete not enabled (runbook 3.4 — needs root account + MFA token)"
   fi
 
-  if lifecycle="$(aws s3api get-bucket-lifecycle-configuration --bucket "$BUCKET" 2>/dev/null)"; then
+  lraw="$(aws s3api get-bucket-lifecycle-configuration --bucket "$BUCKET" 2>&1)"
+  lrc=$?
+  if [[ $lrc -ne 0 ]] && grep -qi "AccessDenied\|not authorized" <<<"$lraw"; then
+    # Same distinction as versioning above. NoSuchLifecycleConfiguration genuinely
+    # means "no rules"; AccessDenied means we do not know.
+    fail "cannot read lifecycle — AccessDenied. This principal lacks s3:GetLifecycleConfiguration; the rules are UNKNOWN, not absent"
+  elif [[ $lrc -eq 0 ]] && lifecycle="$lraw"; then
     if grep -q '"ID": *"expire-noncurrent"' <<<"$lifecycle" \
        || grep -q '"ID":"expire-noncurrent"' <<<"$lifecycle"; then
       pass "lifecycle rule 'expire-noncurrent' present"

--- a/scripts/ops/verify-backup-config.sh
+++ b/scripts/ops/verify-backup-config.sh
@@ -76,7 +76,7 @@ except Exception:
 ' "$S3_OUT")"
   else
     versioning="unknown"; mfa="unknown"
-    if grep -qi "AccessDenied\|not authorized" <<<"$S3_ERR"; then
+    if grep -Eqi "AccessDenied|not authorized" <<<"$S3_ERR"; then
       fail "cannot read versioning — AccessDenied (needs s3:GetBucketVersioning). State is UNKNOWN, not absent"
     else
       fail "cannot read versioning: $(tr -d '\n' <<<"$S3_ERR" | head -c 160). State is UNKNOWN, not absent"
@@ -129,14 +129,14 @@ else:
         fail "lifecycle response could not be parsed — state is UNKNOWN, not absent"
         ;;
     esac
-  elif grep -qi "NoSuchLifecycleConfiguration" <<<"$S3_ERR"; then
+  elif grep -Eqi "NoSuchLifecycleConfiguration" <<<"$S3_ERR"; then
     # INVERTED deliberately. This is the ONLY error that legitimately means "no
     # rules exist". Every other failure — throttling, ExpiredToken, wrong region,
     # AllAccessDisabled — is unknown. The previous version special-cased
     # AccessDenied and let everything else fall through to "no lifecycle at all",
     # which narrowed this bug rather than removing it.
     fail "no lifecycle configuration at all (run configure-s3-backup.sh)"
-  elif grep -qi "AccessDenied\|not authorized" <<<"$S3_ERR"; then
+  elif grep -Eqi "AccessDenied|not authorized" <<<"$S3_ERR"; then
     fail "cannot read lifecycle — AccessDenied (needs s3:GetLifecycleConfiguration). Rules are UNKNOWN, not absent"
   else
     fail "cannot read lifecycle: $(tr -d '\n' <<<"$S3_ERR" | head -c 160). Rules are UNKNOWN, not absent"


### PR DESCRIPTION
Found by running the verifier against the real bucket during issue 299 work.

## The bug

```bash
versioning="$(aws s3api get-bucket-versioning --bucket "$BUCKET" \
  --query 'Status' --output text 2>/dev/null || echo "None")"
```

An **AccessDenied** became `"None"`, which the script then reported as:

```
FAIL  bucket versioning is 'None' — cascade erasure destroys history immediately without it
FAIL  no lifecycle configuration at all (run configure-s3-backup.sh)
```

Both statements were false. The bucket's state was unknown; we simply lacked permission to look.

## Why this is the worst bug a verifier can have

It produces a confident answer it has not earned, and the two readings are **actionable in opposite directions**:

| Reported | Real | Operator does | Should do |
|---|---|---|---|
| "not configured" | AccessDenied | runs configure-s3-backup.sh, hits AccessDenied | fix the IAM policy |
| "not configured" | actually configured | re-applies a lifecycle over a working one | nothing |

It also misled this session directly: I read that output aloud as evidence that permissions had been granted and versioning was genuinely off. Neither was true, and I said so to the user before catching it.

## Fixed

Three states, distinguished explicitly:

| Condition | Result |
|---|---|
| AccessDenied | `FAIL — state is UNKNOWN, not absent` + names the missing IAM action |
| readable, unconfigured | `FAIL — versioning is 'None'` |
| readable, configured | `PASS` |

MFA-delete carried the identical bug one line down (it reads the same API response) and now reports UNKNOWN rather than asserting "not enabled".

## All three paths exercised

```
real bucket, no permission:
  FAIL  cannot read versioning — AccessDenied ... UNKNOWN, not absent
  MANUAL MFA-delete state UNKNOWN — could not read the bucket's versioning block

LocalStack bucket, no config:
  FAIL  bucket versioning is 'None' — cascade erasure destroys history immediately without it
  FAIL  no lifecycle configuration at all (run configure-s3-backup.sh)

LocalStack bucket, versioning + lifecycle applied:
  PASS  bucket versioning enabled
  PASS  lifecycle rule 'expire-noncurrent' present
  PASS  incomplete multipart uploads are aborted (on the expire-noncurrent rule)
```

shellcheck clean.