### PR TITLE
security(docs): redact live Atlas credentials from the tracked migration report (#444)

### DIFF
--- a/docs/operations/MONGODB_ATLAS_MIGRATION_STATUS.md
+++ b/docs/operations/MONGODB_ATLAS_MIGRATION_STATUS.md
@@ -14,7 +14,7 @@ The staging server (dev.briaanalytics.com) currently uses:
 - **Self-hosted MongoDB 7.0** running in Docker (container: `narrative-staging-mongodb`)
 - Port: 27018
 - Status: Healthy, running for 5+ days
-- Connection: `mongodb://narrative_user:PASSWORD@localhost:27018/narrative_staging?authSource=admin`
+- Connection: `mongodb://<USERNAME>:<PASSWORD>@localhost:27018/narrative_staging?authSource=admin`
 
 This document outlines the PLAN for migrating to MongoDB Atlas M0 Free Tier when ready.
 
@@ -43,12 +43,12 @@ This document outlines the PLAN for migrating to MongoDB Atlas M0 Free Tier when
 **Changes**:
 ```bash
 # OLD (self-hosted MongoDB)
-MONGODB_ROOT_PASSWORD=...
-MONGODB_PASSWORD=...
-MONGODB_URI=mongodb://...@localhost:27018/...
+MONGODB_ROOT_PASSWORD=<REDACTED>
+MONGODB_PASSWORD=<REDACTED>
+MONGODB_URI=mongodb://<USERNAME>:<PASSWORD>@localhost:27018/...
 
 # NEW (MongoDB Atlas)
-MONGODB_URI=mongodb+srv://USERNAME:PASSWORD@CLUSTER.mongodb.net/narrative_staging?retryWrites=true&w=majority
+MONGODB_URI=mongodb+srv://<USERNAME>:<PASSWORD>@CLUSTER.mongodb.net/narrative_staging?retryWrites=true&w=majority
 MONGODB_DB=narrative_staging
 ```
 
@@ -62,8 +62,8 @@ MONGODB_DB=narrative_staging
 **Security Issue**: MongoDB Atlas credentials were exposed in git history
 
 **Exposed Credentials**:
-- Password: `[REDACTED]` (now redacted)
-- Username: `frankbria`
+- Password: `<REDACTED — see secret store>`
+- Username: `<REDACTED — see secret store>`
 - Cluster: `<cluster>.mongodb.net`
 - Found in commits: b6935e4 and b779b25
 - File: `apps/backend/.env`
@@ -139,7 +139,7 @@ git reset --hard origin/main
 
 **Format**:
 ```
-mongodb+srv://NEW_USERNAME:NEW_PASSWORD@<cluster>.mongodb.net/narrative_staging?retryWrites=true&w=majority
+mongodb+srv://<USERNAME>:<PASSWORD>@<cluster>.mongodb.net/narrative_staging?retryWrites=true&w=majority
 ```
 
 ### 4. Verify Staging Deployment


### PR DESCRIPTION
## What this does

Redacts live MongoDB Atlas credentials from `docs/operations/MONGODB_ATLAS_MIGRATION_STATUS.md`, which is **tracked in HEAD of this public repository**.

Found while working #444's acceptance criterion 5 (*"a scan confirms no other secret is present in tracked history"*). It is not the leak #444 was opened about — it is a second, separate one, and it is in the current tree rather than only in history.

## What the scan found

`gitleaks detect` over all 791 commits returned 25 findings. Triaged:

| Finding | Count | Verdict |
|---|---|---|
| `curl-auth-header` in `documentation.py`, `PRODUCTION_API_GUIDE.md`, `README.md` | 18 | False positive — `Authorization: Bearer <placeholder>` doc examples |
| `RegEnumKey` in a committed `.venv` copy of setuptools | 2 | False positive — vendored Windows API constant |
| `SAMPLE_JWT_TOKEN` in `test_nextauth.py` | 2 | False positive — named sample fixture |
| Test fixtures in `auth-helpers.test.ts`, `test_rate_limit_integration.py` | 2 | False positive — local fixtures |
| **`MONGODB_ATLAS_MIGRATION_STATUS.md:65-66` + URIs at :51, :142** | **1** | **REAL — this PR** |

Values were classified by shape (length/charset/placeholder-pattern) rather than being read, and are not reproduced here or in the commit message.

## Why this one is bad

The file is the **incident report for the `.env` leak that #444 tracks**. In documenting the exposure it transcribed the password and username verbatim, under the heading "Exposed Credentials". So the remediation republished the secret in the current tree, where it is considerably easier to find than the git history it was cleaning.

## This PR does not fix the exposure

Merging this changes nothing about the credential's status. It remains:

- in this file's own history at `f57707b` (2025-10-28),
- in the original `apps/backend/.env` blob at `b6935e4` (2025-04-07), which **still resolves today**.

That second point contradicts the report's own remediation section, which states `git-filter-repo --replace-text` purged the credentials and force-pushed a cleaned history ending at `154c91e`. **`154c91e` does not exist in this repository**, and `git cat-file -e b6935e4:apps/backend/.env` still succeeds. The purge was reverted, overwritten by a later force-push from an un-cleaned clone, or never reached the branch that survived.

**Rotation in the Atlas console is the only action that closes this.** That is criterion 1 of #444 and needs console access, so it cannot be done from here.

## Note on disclosure

This PR is public and its diff shows a secret being removed, which draws attention to it. That is a real cost, accepted deliberately: the value is already readable in HEAD by anyone browsing the repo, so leaving it in place is strictly worse than removing it. It is another reason to rotate now rather than after review.

## Known limitations

- Does not remove the credential from history (neither this file's nor `.env`'s).
- Does not rotate anything.
- Does not add automated secret scanning to CI — a one-off scan rots immediately, and this repo has now leaked credentials twice, so a `gitleaks` CI job is worth adding. Deliberately left out of scope here; happy to open it as a follow-up.

## Testing

Docs-only change; no code path is touched, so the test suites are unaffected. Verified after the edit that no literal credential remains in the file (labels and URI structure preserved, values replaced with `<REDACTED>` / `<USERNAME>:<PASSWORD>`).

Refs #444
