### PR TITLE
fix(auth): name the NextAuth database explicitly instead of relying on the URI

### DIFF
--- a/apps/frontend/auth.ts
+++ b/apps/frontend/auth.ts
@@ -66,7 +66,13 @@ providers.push(
 )
 
 export const { handlers, signIn, signOut, auth } = NextAuth({
-  adapter: MongoDBAdapter(client),
+  // Name the database explicitly, matching the backend convention (bare
+  // MONGODB_URI + separate MONGODB_DB, see main.py's `client[db_name]`).
+  // Without this the adapter calls `client.db(undefined)`, which falls back to
+  // the URI's default database — and to `test` when the URI has no path at all.
+  // Undefined here reproduces exactly that old behaviour, so environments that
+  // still carry the database in the URI are unaffected.
+  adapter: MongoDBAdapter(client, { databaseName: process.env.MONGODB_DB }),
   providers,
   session: {
     strategy: "jwt",

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -126,6 +126,11 @@ services:
       # NextAuth's MongoDB adapter (auth.ts -> lib/db.ts) connects at runtime;
       # lib/db.ts throws on startup without this.
       MONGODB_URI: ${MONGODB_URI:?MONGODB_URI (Atlas connection string) must be set in .env.staging}
+      # Same database as the backend. MONGODB_URI is bare (no path) because the
+      # backend selects with `client[db_name]`, so without this the adapter falls
+      # back to `client.db(undefined)` — which on a pathless URI is the database
+      # literally named `test`, where staging's users and sessions have been going.
+      MONGODB_DB: ${MONGODB_DB:-narrative_modeling-staging}
       NEXTAUTH_URL: ${NEXTAUTH_URL}
       # NextAuth v5 rejects requests whose Host it doesn't trust (UntrustedHost
       # 500s on every /api/auth/* route). Behind the nginx reverse proxy the


### PR DESCRIPTION
## Problem

`auth.ts` called `MongoDBAdapter(client)` with no `databaseName`. The adapter then runs `_client.db(options.databaseName)` (`@auth/mongodb-adapter@3.11.3`, index.js:138), i.e. `client.db(undefined)`, which resolves to whatever database the connection string defaults to.

This repo's convention is a **bare** `MONGODB_URI` with the database supplied separately — the backend does `client[db_name]` at `apps/backend/app/main.py:104` and reads `MONGODB_DB` from config. A bare URI has no default database, and the driver resolves that to the database literally named **`test`**.

Compounding it, `docker-compose.staging.yml` passed `MONGODB_URI` to the frontend service but **not** `MONGODB_DB` (the backend service already received both, at :55-56). So there was no way for the frontend to know the name even if it had asked.

Net effect: on staging, NextAuth's users, accounts and sessions have been read from and written to a database called `test`.

## Change

- `auth.ts` — `MongoDBAdapter(client, { databaseName: process.env.MONGODB_DB })`
- `docker-compose.staging.yml` — frontend service now receives `MONGODB_DB`, defaulting to the same `narrative_modeling-staging` the backend uses, so both halves of the app share one database

`databaseName: undefined` reproduces the old fallback exactly, so the code change alone is a no-op anywhere that still carries the database in its URI. The behaviour only moves where `MONGODB_DB` is actually supplied.

## ⚠️ Read before deploying — this moves data

Once this lands, staging NextAuth points at `narrative_modeling-staging` instead of `test`. **Existing staging accounts and sessions live in `test` and will not follow.** To a user this looks like every staging login was deleted.

Before deploying, check Atlas for a `test` database on the cluster:

- **If `test` holds real staging users** — migrate the `users`, `accounts`, `sessions` and `verificationTokens` collections into `narrative_modeling-staging` before or with this deploy, or accept that staging users re-authenticate from scratch. Staging is pre-production, so re-authenticating may well be the cheaper answer — but it should be a decision, not a surprise.
- **If `test` is empty or only holds throwaway data** — nothing to do; deploy and delete it.

Either way the presence or absence of that database is the confirmation that this bug was real in the deployed environment. Worth recording the answer on this PR.

## Verification

- `tsc --noEmit` clean
- 9 auth tests pass
- `npm run lint` at 233/233 — no new warnings against the cap
- `docker compose -f docker-compose.staging.yml config` renders, with **both** services resolving `MONGODB_DB: narrative_modeling-staging`

**Not** verified by `npm run check:adapter`: that script builds its own adapter (`scripts/check-auth-adapter.mjs:42`) rather than importing `auth.ts`, so its 10 green checks confirm the `{ databaseName }` option works on this adapter/driver pair, not that this file is wired correctly. The wiring rests on the type check and the rendered compose output above.

## Related

Found while answering "does `MONGODB_URI` include the DB name?" during the #444 credential-rotation prep. It also sharpens the MCP issue in the launch backlog: `apps/mcp/utils/user_data.py:34` uses `client.get_default_database()`, which against a bare URI raises `ConfigurationError` outright rather than silently choosing the wrong database — that issue understates it, and I will update it.
